### PR TITLE
ci: add Claude code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,45 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: '--allowedTools "Bash(gh:*)"'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+


### PR DESCRIPTION
Adds a `Claude Code Review` workflow that auto-reviews PRs (on open / synchronize / ready_for_review / reopened) with the `code-review@claude-code-plugins` plugin.

## Empty-result workaround

The plugin generates the review but its final turn is a `TodoWrite` call, so `claude-code-action` captures an empty `result` and posts no comment (anthropics/claude-code-action#1087). To sidestep that, the plugin posts findings itself during the run rather than relying on the captured result:

- `--comment` on the `/code-review:code-review` invocation, so it posts inline as it goes
- `--allowedTools "Bash(gh:*)"` to give it the `gh` CLI to post with
- `pull-requests: write` so `gh` has permission to comment

This is a workaround, not a confirmed fix — once #1087 is resolved upstream the extra flags can be dropped. Worth a throwaway-PR smoke test after merge to confirm comments actually land.