### PR TITLE
feat(cartoon): render ribbons from backbone topology and assign secondary structure via DSSP

### DIFF
--- a/compute-core/src/domain/biopolymer.rs
+++ b/compute-core/src/domain/biopolymer.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use super::structure::Atom;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ResidueId {
     pub chain_id: char,
@@ -27,7 +29,80 @@ pub struct ResidueRecord {
     pub residue_name: String,
     pub atom_indices: Vec<usize>,
     pub alpha_carbon: Option<usize>,
+    pub backbone_nitrogen: Option<usize>,
+    pub backbone_carbon: Option<usize>,
+    /// Optional even for a complete peptide unit: chain termini and coarse inputs
+    /// may omit the carbonyl O. Its presence is what lets the DSSP H-bond
+    /// assignment run.
+    pub backbone_oxygen: Option<usize>,
     pub is_standard_amino_acid: bool,
+}
+
+impl ResidueRecord {
+    /// Whether this residue carries a complete peptide backbone — the amide N,
+    /// the α-carbon, and the carbonyl C. This is the topological prerequisite for
+    /// drawing the residue as a cartoon ribbon: it depends only on which backbone
+    /// atoms are present, never on the residue name, so force-field-protonated,
+    /// disulfide, and otherwise renamed protein residues are recognized exactly
+    /// like their canonical forms. The carbonyl O is deliberately not required —
+    /// chain termini and some coarse inputs omit it.
+    pub fn has_peptide_backbone(&self) -> bool {
+        self.backbone_nitrogen.is_some()
+            && self.alpha_carbon.is_some()
+            && self.backbone_carbon.is_some()
+    }
+
+    /// Whether this residue can contribute one C-alpha control point to a protein
+    /// cartoon trace. A full peptide backbone is accepted independent of residue
+    /// name; a C-alpha-only trace has no topology to distinguish it from hetero atoms,
+    /// so it keeps the legacy standard-amino-acid gate.
+    pub fn has_cartoon_trace(&self) -> bool {
+        self.alpha_carbon.is_some() && (self.has_peptide_backbone() || self.is_standard_amino_acid)
+    }
+}
+
+/// Upper bound, in ångström, on the C(i)–N(i+1) peptide bond joining two
+/// consecutive residues. A real peptide bond is ~1.33 Å; the generous ceiling
+/// tolerates strained or coarse coordinates while still rejecting a chain break,
+/// where the next residue's amide nitrogen sits a missing residue's width away.
+const MAX_PEPTIDE_BOND: f32 = 2.0;
+
+/// Upper bound, in ångström, on the Cα(i)–Cα(i+1) separation, used as a fallback
+/// when carbonyl/amide atoms are absent (a terminus or a Cα-only trace). Bonded
+/// α-carbons sit ~3.8 Å apart (trans) or ~2.9 Å (cis); a one-residue gap is
+/// ~7.6 Å, well clear of this threshold.
+const MAX_ALPHA_CARBON_STEP: f32 = 4.5;
+
+/// Whether `current` is the immediate backbone successor of `previous`, judged
+/// from coordinates alone. Prefers the defining peptide bond C(i)–N(i+1); when
+/// either atom is absent it falls back to Cα–Cα proximity. It consults no residue
+/// names or sequence numbers, so it survives renumbering, insertion codes, and
+/// gaps — two residues are contiguous only when their backbones are actually
+/// bonded in space.
+///
+/// Callers may pass either full peptide residues or legacy standard-residue
+/// C-alpha traces; the latter take the C-alpha distance fallback.
+pub fn residues_backbone_bonded(
+    previous: &ResidueRecord,
+    current: &ResidueRecord,
+    atoms: &[Atom],
+) -> bool {
+    if let (Some(carbon), Some(nitrogen)) = (previous.backbone_carbon, current.backbone_nitrogen) {
+        return atoms_within(atoms, carbon, nitrogen, MAX_PEPTIDE_BOND);
+    }
+    match (previous.alpha_carbon, current.alpha_carbon) {
+        (Some(prev_ca), Some(cur_ca)) => {
+            atoms_within(atoms, prev_ca, cur_ca, MAX_ALPHA_CARBON_STEP)
+        }
+        _ => false,
+    }
+}
+
+fn atoms_within(atoms: &[Atom], a: usize, b: usize, max: f32) -> bool {
+    match (atoms.get(a), atoms.get(b)) {
+        (Some(a), Some(b)) => (a.position - b.position).norm_squared() <= max * max,
+        _ => false,
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -116,6 +191,9 @@ pub fn build_biopolymer(
                 residue_name: annotation.residue_name.clone(),
                 atom_indices: Vec::new(),
                 alpha_carbon: None,
+                backbone_nitrogen: None,
+                backbone_carbon: None,
+                backbone_oxygen: None,
                 is_standard_amino_acid: is_standard_amino_acid(&annotation.residue_name),
             });
             residue_index_by_id.insert(residue_id.clone(), index);
@@ -138,15 +216,23 @@ pub fn build_biopolymer(
 
         let residue = &mut residues[residue_index];
         residue.atom_indices.push(atom_index);
-        if annotation.atom_name == "CA" {
-            residue.alpha_carbon = Some(atom_index);
+        // The atom names "N"/"CA"/"C"/"O" are invariant across force-field
+        // protonation, disulfide, and modified-residue renaming, unlike the
+        // residue name — keying backbone identity on them lets renderability be
+        // decided from topology alone.
+        match annotation.atom_name.as_str() {
+            "CA" => residue.alpha_carbon = Some(atom_index),
+            "N" => residue.backbone_nitrogen = Some(atom_index),
+            "C" => residue.backbone_carbon = Some(atom_index),
+            "O" => residue.backbone_oxygen = Some(atom_index),
+            _ => {}
         }
         residue_for_atom[atom_index] = Some(residue_index);
     }
 
     let has_protein_residues = residues
         .iter()
-        .any(|residue| residue.is_standard_amino_acid);
+        .any(|residue| residue.is_standard_amino_acid || residue.has_peptide_backbone());
     if !has_protein_residues && secondary_structures.is_empty() {
         return None;
     }
@@ -343,6 +429,15 @@ pub fn extend_biopolymer_coverage(
 
     for appended_residue in appended {
         let residue_index = residues.len();
+        // Backbone atoms are derived, not persisted: this must match how
+        // `build_biopolymer` and the payload reload derive them, or renderability
+        // would differ in memory versus after a save/load round trip.
+        let backbone_atom = |target: &str| {
+            appended_residue
+                .atoms
+                .iter()
+                .find_map(|(atom_index, name)| (name.as_str() == target).then_some(*atom_index))
+        };
         residues.push(ResidueRecord {
             id: ResidueId::new(
                 appended_residue.chain_id,
@@ -355,7 +450,10 @@ pub fn extend_biopolymer_coverage(
                 .iter()
                 .map(|(atom_index, _)| *atom_index)
                 .collect(),
-            alpha_carbon: None,
+            alpha_carbon: backbone_atom("CA"),
+            backbone_nitrogen: backbone_atom("N"),
+            backbone_carbon: backbone_atom("C"),
+            backbone_oxygen: backbone_atom("O"),
             is_standard_amino_acid: false,
         });
 
@@ -414,4 +512,146 @@ pub fn is_standard_amino_acid(residue_name: &str) -> bool {
             | "TYR"
             | "VAL"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Point3;
+
+    fn atom_at(x: f32, y: f32, z: f32) -> Atom {
+        Atom {
+            element: "C".to_string(),
+            position: Point3::new(x, y, z),
+            charge: 0.0,
+        }
+    }
+
+    /// A residue record carrying only the backbone atom indices under test.
+    fn residue(
+        alpha_carbon: Option<usize>,
+        backbone_nitrogen: Option<usize>,
+        backbone_carbon: Option<usize>,
+    ) -> ResidueRecord {
+        ResidueRecord {
+            id: ResidueId::new('A', 1, ' '),
+            residue_name: "ALA".to_string(),
+            atom_indices: Vec::new(),
+            alpha_carbon,
+            backbone_nitrogen,
+            backbone_carbon,
+            backbone_oxygen: None,
+            is_standard_amino_acid: true,
+        }
+    }
+
+    #[test]
+    fn has_peptide_backbone_requires_n_ca_c() {
+        assert!(residue(Some(0), Some(1), Some(2)).has_peptide_backbone());
+        assert!(
+            !residue(Some(0), None, Some(2)).has_peptide_backbone(),
+            "missing N"
+        );
+        assert!(
+            !residue(Some(0), Some(1), None).has_peptide_backbone(),
+            "missing C"
+        );
+        // A calcium ion has a stray "CA" atom but no N/C — correctly not backbone.
+        assert!(
+            !residue(Some(0), None, None).has_peptide_backbone(),
+            "Cα only"
+        );
+    }
+
+    #[test]
+    fn peptide_bond_decides_contiguity_when_carbonyl_and_amide_present() {
+        // prev carbonyl C at 0; cur amide N at 1.33 Å (bonded) vs 5.0 Å (broken).
+        let atoms = vec![
+            atom_at(0.0, 0.0, 0.0),
+            atom_at(1.33, 0.0, 0.0),
+            atom_at(5.0, 0.0, 0.0),
+        ];
+        let prev = residue(None, None, Some(0));
+        let cur_bonded = residue(None, Some(1), None);
+        let cur_broken = residue(None, Some(2), None);
+        assert!(residues_backbone_bonded(&prev, &cur_bonded, &atoms));
+        assert!(!residues_backbone_bonded(&prev, &cur_broken, &atoms));
+    }
+
+    #[test]
+    fn falls_back_to_alpha_carbon_distance_when_carbonyl_or_amide_absent() {
+        // No carbonyl/amide recorded: decide by Cα–Cα. 3.8 Å bonded, 7.6 Å gap.
+        let atoms = vec![
+            atom_at(0.0, 0.0, 0.0),
+            atom_at(3.8, 0.0, 0.0),
+            atom_at(7.6, 0.0, 0.0),
+        ];
+        let prev = residue(Some(0), None, None);
+        let cur_bonded = residue(Some(1), None, None);
+        let cur_gap = residue(Some(2), None, None);
+        assert!(residues_backbone_bonded(&prev, &cur_bonded, &atoms));
+        assert!(!residues_backbone_bonded(&prev, &cur_gap, &atoms));
+    }
+
+    #[test]
+    fn peptide_bond_is_authoritative_over_alpha_carbon_proximity() {
+        // Both C and N present but far apart ⇒ a break, even though the Cα–Cα
+        // distance alone would pass the fallback threshold. The bond wins.
+        let atoms = vec![
+            atom_at(0.0, 0.0, 0.0), // prev Cα
+            atom_at(0.5, 0.0, 0.0), // prev carbonyl C — near
+            atom_at(3.8, 0.0, 0.0), // cur Cα — within 4.5 Å of prev Cα
+            atom_at(9.0, 0.0, 0.0), // cur amide N — far from prev C
+        ];
+        let prev = residue(Some(0), None, Some(1));
+        let cur = residue(Some(2), Some(3), None);
+        assert!(
+            !residues_backbone_bonded(&prev, &cur, &atoms),
+            "a long C–N distance is a break even when Cα–Cα is close"
+        );
+    }
+
+    #[test]
+    fn missing_alpha_carbons_are_not_bonded() {
+        let atoms = vec![atom_at(0.0, 0.0, 0.0)];
+        assert!(!residues_backbone_bonded(
+            &residue(None, None, None),
+            &residue(None, None, None),
+            &atoms,
+        ));
+    }
+    #[test]
+    fn full_backbone_non_standard_residues_build_biopolymer_without_secondary_records() {
+        let annotations = [
+            ("N", "HID", 1),
+            ("CA", "HID", 1),
+            ("C", "HID", 1),
+            ("N", "CYX", 2),
+            ("CA", "CYX", 2),
+            ("C", "CYX", 2),
+        ]
+        .into_iter()
+        .map(|(atom_name, residue_name, residue_seq)| PdbAtomAnnotation {
+            atom_name: atom_name.to_string(),
+            residue_name: residue_name.to_string(),
+            chain_id: 'A',
+            residue_seq,
+            insertion_code: ' ',
+        })
+        .collect::<Vec<_>>();
+
+        let biopolymer = build_biopolymer(&annotations, Vec::new()).expect("biopolymer");
+        assert!(
+            biopolymer
+                .residues
+                .iter()
+                .all(|residue| residue.has_peptide_backbone())
+        );
+        assert!(
+            biopolymer
+                .residues
+                .iter()
+                .all(|residue| !residue.is_standard_amino_acid)
+        );
+    }
 }

--- a/compute-core/src/domain/mod.rs
+++ b/compute-core/src/domain/mod.rs
@@ -10,7 +10,7 @@ pub mod trajectory;
 pub use biopolymer::{
     AppendedResidue, AtomCategory, Biopolymer, ChainRecord, PdbAtomAnnotation, ResidueId,
     ResidueRecord, SecondaryStructureKind, SecondaryStructureSpan, build_biopolymer,
-    extend_biopolymer_coverage,
+    extend_biopolymer_coverage, residues_backbone_bonded,
 };
 pub use secondary_structure::assign_secondary_structure;
 pub use structure::{Atom, Bond, BondType, Structure, UnitCell};

--- a/compute-core/src/domain/secondary_structure.rs
+++ b/compute-core/src/domain/secondary_structure.rs
@@ -1,15 +1,27 @@
-//! Cα-only secondary-structure assignment, for coordinates without HELIX/SHEET
-//! records (e.g. GRO files from an MD run) that would otherwise render as coil.
+//! Secondary-structure assignment for coordinates that arrive without HELIX/SHEET
+//! records (e.g. files from an MD run) and would otherwise render as bare coil.
 //!
-//! Uses the P-SEA criterion (Labesse & Mornon, 1997): a residue is helical or
-//! extended when the Cα(i)→Cα(i+2/i+3/i+4) distances all fall in the matching
-//! reference window. Cα-only keeps it robust to backbone atom naming and to
-//! added/removed hydrogens across an engine round-trip.
+//! Two methods, chosen per contiguous protein fragment by what its backbone
+//! carries:
+//!
+//! * **DSSP** (Kabsch & Sander, 1983) when every residue has a full N/CA/C/O
+//!   backbone: helices and strands are read from the backbone hydrogen-bond
+//!   network, so an extended loop is not mistaken for a β-strand.
+//! * **P-SEA** (Labesse & Mornon, 1997) as the Cα-only fallback: a residue is
+//!   helical or extended when the Cα(i)→Cα(i+2/i+3/i+4) distances all fall in the
+//!   matching reference window. Used when the carbonyl O is absent (a Cα-only
+//!   trace), where no hydrogen-bond network can be computed. Cα-only keeps it
+//!   robust to added/removed hydrogens across an engine round-trip.
+//!
+//! Full peptide backbones and contiguity are recognized from atoms and coordinates.
+//! Legacy C-alpha-only traces keep the standard amino-acid name gate because they
+//! have no N/C topology to distinguish them from hetero atoms.
 
 use nalgebra::Point3;
 
 use crate::domain::{
     Atom, Biopolymer, ChainRecord, ResidueId, SecondaryStructureKind, SecondaryStructureSpan,
+    residues_backbone_bonded,
 };
 
 /// Inclusive (min, max) reference window, in angstroms, for one Cα–Cα distance.
@@ -54,46 +66,55 @@ enum Label {
 }
 
 /// Derive helix/strand spans from the Cα trace of every protein chain. Each
-/// contiguous run of Cα-bearing amino acids is assigned independently; solvent,
-/// ions, and sequence gaps break a run.
+/// contiguous run of cartoon-trace residues is assigned independently; solvent,
+/// ions, ligands, and genuine backbone breaks split a run. Full peptide residues
+/// are recognized from N/CA/C topology; C-alpha-only residues keep the legacy
+/// standard-amino-acid gate.
 pub fn assign_secondary_structure(
     atoms: &[Atom],
     biopolymer: &Biopolymer,
 ) -> Vec<SecondaryStructureSpan> {
     let mut spans = Vec::new();
     for chain in &biopolymer.chains {
-        for fragment in protein_fragments(biopolymer, chain) {
+        for fragment in protein_fragments(atoms, biopolymer, chain) {
             assign_fragment(atoms, biopolymer, &fragment, &mut spans);
         }
     }
     spans
 }
 
-/// Split a chain into maximal runs of consecutive, Cα-bearing amino-acid
-/// residues. Returns residue indices into [`Biopolymer::residues`].
-fn protein_fragments(biopolymer: &Biopolymer, chain: &ChainRecord) -> Vec<Vec<usize>> {
+/// Split a chain into maximal runs of cartoon-trace residues whose backbones are
+/// actually bonded in sequence (geometric contiguity). Returns residue indices
+/// into [`Biopolymer::residues`].
+fn protein_fragments(
+    atoms: &[Atom],
+    biopolymer: &Biopolymer,
+    chain: &ChainRecord,
+) -> Vec<Vec<usize>> {
     let mut fragments = Vec::new();
     let mut current: Vec<usize> = Vec::new();
-    let mut previous_seq: Option<i32> = None;
+    let mut previous: Option<usize> = None;
 
     for &residue_index in &chain.residue_indices {
         let residue = &biopolymer.residues[residue_index];
-        let usable = residue.is_standard_amino_acid && residue.alpha_carbon.is_some();
-        if !usable {
-            // Solvent/ion/ligand, or a residue with no Cα, breaks the trace.
+        if !residue.has_cartoon_trace() {
+            // Solvent, ions, ligands, or residues without either a full peptide
+            // backbone or a legacy standard-residue C-alpha trace break the run.
             if !current.is_empty() {
                 fragments.push(std::mem::take(&mut current));
             }
-            previous_seq = None;
+            previous = None;
             continue;
         }
 
-        let contiguous = previous_seq.is_none_or(|seq| residue.id.sequence_number == seq + 1);
-        if !contiguous && !current.is_empty() {
+        let bonded = previous.is_none_or(|prev_index| {
+            residues_backbone_bonded(&biopolymer.residues[prev_index], residue, atoms)
+        });
+        if !bonded && !current.is_empty() {
             fragments.push(std::mem::take(&mut current));
         }
         current.push(residue_index);
-        previous_seq = Some(residue.id.sequence_number);
+        previous = Some(residue_index);
     }
 
     if !current.is_empty() {
@@ -102,13 +123,26 @@ fn protein_fragments(biopolymer: &Biopolymer, chain: &ChainRecord) -> Vec<Vec<us
     fragments
 }
 
-/// Assign one contiguous protein fragment and append its helix/strand spans.
+/// Assign one contiguous protein fragment and append its helix/strand spans. When
+/// the fragment carries carbonyl oxygens (a full backbone) the DSSP hydrogen-bond
+/// analysis is authoritative — it separates a genuine β-strand from a merely
+/// extended loop, which the Cα-only criterion systematically over-assigns. The
+/// P-SEA path is the fallback for backbone-incomplete inputs (a Cα-only trace).
 fn assign_fragment(
     atoms: &[Atom],
     biopolymer: &Biopolymer,
     fragment: &[usize],
     spans: &mut Vec<SecondaryStructureSpan>,
 ) {
+    let labels = dssp::assign_fragment(atoms, biopolymer, fragment)
+        .unwrap_or_else(|| psea_labels(atoms, biopolymer, fragment));
+    emit_spans(biopolymer, fragment, &labels, spans);
+}
+
+/// Cα-only P-SEA labelling: the fallback used when a fragment lacks the carbonyl
+/// oxygens the DSSP path needs. Seeds helix/strand from the Cα(i)→Cα(i+2/3/4)
+/// distance windows, then drops runs too short to be real.
+fn psea_labels(atoms: &[Atom], biopolymer: &Biopolymer, fragment: &[usize]) -> Vec<Label> {
     let ca: Vec<Point3<f32>> = fragment
         .iter()
         .map(|&residue_index| {
@@ -145,7 +179,211 @@ fn assign_fragment(
 
     enforce_min_length(&mut labels, Label::Helix, MIN_HELIX_LEN);
     enforce_min_length(&mut labels, Label::Strand, MIN_STRAND_LEN);
-    emit_spans(biopolymer, fragment, &labels, spans);
+    labels
+}
+
+/// DSSP-style assignment from the full backbone hydrogen-bond network.
+///
+/// Used when every residue of a fragment carries an N/CA/C/O backbone. Unlike the
+/// Cα-only P-SEA criterion it tells a real β-strand (cross-strand H-bonds) from a
+/// merely extended loop, so it does not over-assign strand. All geometry is read
+/// from atom coordinates — never residue names — so force-field protonation,
+/// disulfide, and modified-residue renaming leave the assignment unchanged.
+mod dssp {
+    use nalgebra::Point3;
+
+    use super::Label;
+    use crate::domain::{Atom, Biopolymer};
+
+    /// Kabsch–Sander electrostatic prefactor q1·q2·f, in kcal·Å/mol.
+    const ENERGY_PREFACTOR: f32 = 27.888;
+    /// A hydrogen bond is counted when its Kabsch–Sander energy is below this
+    /// cutoff (kcal/mol) — the standard DSSP threshold.
+    const HBOND_ENERGY_CUTOFF: f32 = -0.5;
+    /// Donor/acceptor atoms closer than this (Å) are treated as a definite bond at
+    /// a fixed strong energy, avoiding a singular 1/r term (mirrors DSSP).
+    const MIN_ATOM_DISTANCE: f32 = 0.5;
+    /// The energy assigned when two interacting atoms are implausibly close.
+    const STRONG_BOND_ENERGY: f32 = -9.9;
+    /// Minimum sequence separation for a hydrogen bond to count, in residues.
+    const MIN_HBOND_SEPARATION: usize = 2;
+    /// Minimum sequence separation between the two partners of a β-bridge.
+    const MIN_BRIDGE_SEPARATION: i64 = 3;
+
+    /// The hydrogen-bonding backbone atom positions of one residue. The α-carbon is
+    /// not needed: the H-bond network is defined entirely by N, C, and O. N and C
+    /// are always present (the fragment is pre-filtered to peptide backbones); the
+    /// carbonyl O is optional, because some force fields rename the C-terminal
+    /// carbonyl oxygen (OT1/OT2/OXT…). A residue without O simply cannot donate a
+    /// hydrogen bond and its successor cannot place an amide H — a local effect,
+    /// not a reason to abandon DSSP for the whole fragment.
+    struct Backbone {
+        nitrogen: Point3<f32>,
+        carbon: Point3<f32>,
+        oxygen: Option<Point3<f32>>,
+    }
+
+    /// Assign a Helix/Strand/Coil label to every residue of one fragment, or `None`
+    /// when the fragment is not a full backbone (a Cα/N-CA-C-only trace with no
+    /// carbonyl oxygens) — the caller then falls back to P-SEA. Indices are local
+    /// to the fragment; "adjacent" means consecutive within it.
+    pub fn assign_fragment(
+        atoms: &[Atom],
+        biopolymer: &Biopolymer,
+        fragment: &[usize],
+    ) -> Option<Vec<Label>> {
+        let backbone: Vec<Backbone> = fragment
+            .iter()
+            .map(|&residue_index| {
+                let residue = &biopolymer.residues[residue_index];
+                Some(Backbone {
+                    nitrogen: atoms[residue.backbone_nitrogen?].position,
+                    carbon: atoms[residue.backbone_carbon?].position,
+                    oxygen: residue.backbone_oxygen.map(|index| atoms[index].position),
+                })
+            })
+            .collect::<Option<Vec<_>>>()?;
+
+        let count = backbone.len();
+
+        // The DSSP path needs the carbonyl hydrogen-bond network. With oxygens on
+        // only a minority of residues this is a Cα/N-CA-C-only trace, so defer to
+        // the P-SEA fallback; a full backbone missing a renamed terminal O or two
+        // still clears the bar and is assigned by H-bonds.
+        let with_oxygen = backbone.iter().filter(|b| b.oxygen.is_some()).count();
+        if with_oxygen * 2 <= count {
+            return None;
+        }
+
+        // Amide H of residue i (i ≥ 1) sits 1 Å from N along the preceding
+        // residue's carbonyl C→O direction. The first residue has no preceding
+        // carbonyl, and a residue whose predecessor lacks O gets no virtual H; such
+        // residues can never accept a hydrogen bond.
+        let amide_hydrogen: Vec<Option<Point3<f32>>> = (0..count)
+            .map(|i| {
+                if i == 0 {
+                    return None;
+                }
+                let previous = &backbone[i - 1];
+                let oxygen = previous.oxygen?;
+                let direction = previous.carbon - oxygen;
+                let length = direction.norm();
+                (length > 1e-6).then(|| backbone[i].nitrogen + direction / length)
+            })
+            .collect();
+
+        // hbond(donor → acceptor): does the donor's C=O accept the acceptor's N–H?
+        // Indices are signed and fully bounds-checked so the β-bridge formulas can
+        // probe i±1 / j±1 without separate guards. A donor without O cannot bond.
+        let hbond = |donor: i64, acceptor: i64| -> bool {
+            if donor < 0 || acceptor < 0 {
+                return false;
+            }
+            let (donor, acceptor) = (donor as usize, acceptor as usize);
+            if donor >= count || acceptor >= count {
+                return false;
+            }
+            if donor.abs_diff(acceptor) < MIN_HBOND_SEPARATION {
+                return false;
+            }
+            let Some(oxygen) = backbone[donor].oxygen else {
+                return false;
+            };
+            let Some(hydrogen) = amide_hydrogen[acceptor] else {
+                return false;
+            };
+            kabsch_sander_energy(
+                backbone[donor].carbon,
+                oxygen,
+                backbone[acceptor].nitrogen,
+                hydrogen,
+            ) < HBOND_ENERGY_CUTOFF
+        };
+
+        let mut labels = vec![Label::Coil; count];
+
+        // α-helix: two consecutive backbone 4-turns (an i→i+4 H-bond opening at
+        // i−1 and again at i) define a helix spanning residues i..=i+3.
+        for i in 1..count {
+            let turn_at_previous = hbond((i - 1) as i64, (i + 3) as i64);
+            let turn_at_current = hbond(i as i64, (i + 4) as i64);
+            if turn_at_previous && turn_at_current {
+                let end = (i + 3).min(count - 1);
+                for label in &mut labels[i..=end] {
+                    *label = Label::Helix;
+                }
+            }
+        }
+
+        // β-bridges: two residues ≥3 apart are bridge partners when a characteristic
+        // pair of H-bonds links them, in either the antiparallel or parallel motif.
+        let mut in_bridge = vec![false; count];
+        for i in 0..count as i64 {
+            for j in (i + MIN_BRIDGE_SEPARATION)..count as i64 {
+                let antiparallel =
+                    (hbond(i, j) && hbond(j, i)) || (hbond(i - 1, j + 1) && hbond(j - 1, i + 1));
+                let parallel =
+                    (hbond(i - 1, j) && hbond(j, i + 1)) || (hbond(j - 1, i) && hbond(i, j + 1));
+                if antiparallel || parallel {
+                    in_bridge[i as usize] = true;
+                    in_bridge[j as usize] = true;
+                }
+            }
+        }
+
+        // A residue in any bridge is a strand candidate; a lone residue framed by
+        // two candidates is a β-bulge and is filled in (read from the pre-fill
+        // bridge state so the fill cannot cascade).
+        let mut candidate = in_bridge.clone();
+        for i in 1..count.saturating_sub(1) {
+            if !in_bridge[i] && in_bridge[i - 1] && in_bridge[i + 1] {
+                candidate[i] = true;
+            }
+        }
+
+        // Runs of ≥2 consecutive candidates become a strand; an isolated bridge is
+        // coil. A residue already in a helix wins on overlap and breaks the run.
+        let mut i = 0;
+        while i < count {
+            if !candidate[i] || labels[i] == Label::Helix {
+                i += 1;
+                continue;
+            }
+            let start = i;
+            while i < count && candidate[i] && labels[i] != Label::Helix {
+                i += 1;
+            }
+            if i - start >= 2 {
+                for label in &mut labels[start..i] {
+                    *label = Label::Strand;
+                }
+            }
+        }
+
+        Some(labels)
+    }
+
+    /// Kabsch–Sander electrostatic hydrogen-bond energy (kcal/mol) for the carbonyl
+    /// C=O of the donor residue interacting with the amide N–H of the acceptor.
+    fn kabsch_sander_energy(
+        carbon: Point3<f32>,
+        oxygen: Point3<f32>,
+        nitrogen: Point3<f32>,
+        hydrogen: Point3<f32>,
+    ) -> f32 {
+        let r_on = (oxygen - nitrogen).norm();
+        let r_ch = (carbon - hydrogen).norm();
+        let r_oh = (oxygen - hydrogen).norm();
+        let r_cn = (carbon - nitrogen).norm();
+        if r_on < MIN_ATOM_DISTANCE
+            || r_ch < MIN_ATOM_DISTANCE
+            || r_oh < MIN_ATOM_DISTANCE
+            || r_cn < MIN_ATOM_DISTANCE
+        {
+            return STRONG_BOND_ENERGY;
+        }
+        ENERGY_PREFACTOR * (1.0 / r_on + 1.0 / r_ch - 1.0 / r_oh - 1.0 / r_cn)
+    }
 }
 
 /// Revert any run of `target` shorter than `min_len` back to coil.
@@ -208,8 +446,52 @@ mod tests {
     use crate::domain::{PdbAtomAnnotation, build_biopolymer};
     use std::f32::consts::PI;
 
-    /// One ALA residue per Cα, single chain numbered from 1 — enough for the
-    /// Cα-only assignment.
+    /// Atoms and PDB annotations for one protein chain (chain A, numbered from 1)
+    /// carrying a single residue per Cα position. Each residue gets a minimal
+    /// N–CA–C backbone so it reads as peptide-bonded protein; the amide N and
+    /// carbonyl C are placed on the Cα–Cα midpoints so consecutive C(i)/N(i+1)
+    /// coincide — a zero-length "bond" that keeps the geometry-based fragmenter
+    /// from splitting the trace. Only the Cα carries meaningful geometry; the
+    /// P-SEA assignment reads nothing else.
+    fn protein_backbone_atoms(ca_positions: &[Point3<f32>]) -> (Vec<Atom>, Vec<PdbAtomAnnotation>) {
+        let mut atoms = Vec::new();
+        let mut annotations = Vec::new();
+        for (index, &ca) in ca_positions.iter().enumerate() {
+            let previous = if index > 0 {
+                ca_positions[index - 1]
+            } else {
+                ca
+            };
+            let next = if index + 1 < ca_positions.len() {
+                ca_positions[index + 1]
+            } else {
+                ca
+            };
+            let nitrogen = Point3::from((previous.coords + ca.coords) * 0.5);
+            let carbon = Point3::from((ca.coords + next.coords) * 0.5);
+            let sequence = index as i32 + 1;
+            for (atom_name, element, position) in
+                [("N", "N", nitrogen), ("CA", "C", ca), ("C", "C", carbon)]
+            {
+                atoms.push(Atom {
+                    element: element.to_string(),
+                    position,
+                    charge: 0.0,
+                });
+                annotations.push(PdbAtomAnnotation {
+                    atom_name: atom_name.to_string(),
+                    residue_name: "ALA".to_string(),
+                    chain_id: 'A',
+                    residue_seq: sequence,
+                    insertion_code: ' ',
+                });
+            }
+        }
+        (atoms, annotations)
+    }
+
+    /// One ALA residue per Cα with a full N/CA/C backbone, single chain numbered
+    /// from 1 — enough for the Cα-only assignment.
     fn ca_only_biopolymer(ca_positions: &[Point3<f32>]) -> (Vec<Atom>, Biopolymer) {
         let atoms: Vec<Atom> = ca_positions
             .iter()
@@ -229,6 +511,13 @@ mod tests {
             })
             .collect();
         let biopolymer = build_biopolymer(&annotations, Vec::new()).expect("protein biopolymer");
+        assert!(
+            biopolymer
+                .residues
+                .iter()
+                .all(|residue| !residue.has_peptide_backbone()),
+            "test helper must exercise the real Ca-only fallback"
+        );
         (atoms, biopolymer)
     }
 
@@ -341,24 +630,9 @@ mod tests {
 
     #[test]
     fn non_protein_residues_do_not_break_assignment() {
-        // Water after a helix must not extend the helix span.
-        let mut atoms: Vec<Atom> = ideal_helix(10)
-            .iter()
-            .map(|position| Atom {
-                element: "C".to_string(),
-                position: *position,
-                charge: 0.0,
-            })
-            .collect();
-        let mut annotations: Vec<PdbAtomAnnotation> = (0..10)
-            .map(|index| PdbAtomAnnotation {
-                atom_name: "CA".to_string(),
-                residue_name: "ALA".to_string(),
-                chain_id: 'A',
-                residue_seq: index + 1,
-                insertion_code: ' ',
-            })
-            .collect();
+        // Water after a helix must not extend the helix span. The water residue
+        // has no peptide backbone, so topology alone keeps it out of the trace.
+        let (mut atoms, mut annotations) = protein_backbone_atoms(&ideal_helix(10));
         atoms.push(Atom {
             element: "O".to_string(),
             position: Point3::new(50.0, 50.0, 50.0),
@@ -379,6 +653,265 @@ mod tests {
         assert!(
             spans[0].end.sequence_number <= 10,
             "helix must not run into the water"
+        );
+    }
+
+    #[test]
+    fn non_standard_residue_names_do_not_fragment_assignment() {
+        // A helix interleaving canonical and force-field/variant residue names
+        // must stay one contiguous protein run: fragmentation depends on backbone
+        // topology, never on whether each name is a standard amino acid. The old
+        // name-gated fragmenter would split at every variant, dropping the helix
+        // below its minimum length.
+        let (atoms, mut annotations) = protein_backbone_atoms(&ideal_helix(12));
+        let variants = ["HID", "HSE", "CYX", "GLH", "LYN", "ASH"];
+        for annotation in annotations.iter_mut().filter(|a| a.residue_seq % 2 == 0) {
+            let pick = (annotation.residue_seq as usize / 2) % variants.len();
+            annotation.residue_name = variants[pick].to_string();
+        }
+        let biopolymer = build_biopolymer(&annotations, Vec::new()).expect("biopolymer");
+        assert!(
+            biopolymer
+                .residues
+                .iter()
+                .any(|residue| !residue.is_standard_amino_acid),
+            "test must include non-standard residue names"
+        );
+
+        let spans = assign_secondary_structure(&atoms, &biopolymer);
+        assert_eq!(spans.len(), 1, "one contiguous helix expected: {spans:?}");
+        assert_eq!(spans[0].kind, SecondaryStructureKind::Helix);
+        assert!(spans[0].start.sequence_number <= 2);
+        assert!(spans[0].end.sequence_number >= 11);
+    }
+
+    #[test]
+    fn renumbering_and_insertion_codes_do_not_fragment_assignment() {
+        // The Cα geometry is one continuous helix, but the residues are renumbered
+        // with large gaps and insertion codes. Contiguity is geometric, so the run
+        // stays whole — the old `sequence_number == prev + 1` test would have split
+        // it into length-1 runs and assigned nothing.
+        let (atoms, mut annotations) = protein_backbone_atoms(&ideal_helix(12));
+        for annotation in annotations.iter_mut() {
+            let original = annotation.residue_seq - 1; // 0-based original index
+            annotation.residue_seq = 10 + original * 5; // 10, 15, 20, … big gaps
+            annotation.insertion_code = if original % 2 == 0 { 'A' } else { ' ' };
+        }
+        let biopolymer = build_biopolymer(&annotations, Vec::new()).expect("biopolymer");
+
+        let spans = assign_secondary_structure(&atoms, &biopolymer);
+        assert_eq!(
+            spans.len(),
+            1,
+            "one contiguous helix despite renumbering: {spans:?}"
+        );
+        assert_eq!(spans[0].kind, SecondaryStructureKind::Helix);
+    }
+
+    // --- Full N/CA/C/O backbones for the DSSP path -------------------------------
+
+    /// Place the fourth atom D of a chain A–B–C–D from the C–D bond length, the
+    /// bond angle ∠B-C-D, and the dihedral A-B-C-D (NeRF, Parsons et al. 2005).
+    fn place_atom(
+        a: Point3<f32>,
+        b: Point3<f32>,
+        c: Point3<f32>,
+        length: f32,
+        angle_deg: f32,
+        dihedral_deg: f32,
+    ) -> Point3<f32> {
+        let theta = angle_deg.to_radians();
+        let chi = dihedral_deg.to_radians();
+        let bc = (c - b).normalize();
+        let n = (b - a).cross(&bc).normalize();
+        let m = n.cross(&bc);
+        let displacement = bc * (-length * theta.cos())
+            + m * (length * theta.sin() * chi.cos())
+            + n * (length * theta.sin() * chi.sin());
+        c + displacement
+    }
+
+    /// Synthesize one protein chain (chain A, residues numbered from 1) from a
+    /// per-residue (φ, ψ) list, emitting a full N/CA/C/O backbone so the DSSP
+    /// hydrogen-bond path runs. ω is held trans (180°); the carbonyl O is placed in
+    /// the sp² plane along the external bisector of the CA(i)–C(i)–N(i+1) angle.
+    /// Standard Engh–Huber bond lengths (Å) and angles (degrees).
+    fn build_protein_backbone(phi_psi: &[(f32, f32)]) -> (Vec<Atom>, Vec<PdbAtomAnnotation>) {
+        const N_CA: f32 = 1.458;
+        const CA_C: f32 = 1.525;
+        const C_N: f32 = 1.329;
+        const C_O: f32 = 1.231;
+        const ANGLE_N_CA_C: f32 = 111.0;
+        const ANGLE_CA_C_N: f32 = 116.6;
+        const ANGLE_C_N_CA: f32 = 121.7;
+        const OMEGA: f32 = 180.0;
+
+        let count = phi_psi.len();
+        assert!(count >= 1, "need at least one residue");
+
+        let mut nitrogen = Vec::with_capacity(count);
+        let mut alpha = Vec::with_capacity(count);
+        let mut carbon = Vec::with_capacity(count);
+
+        // Seed the first three backbone atoms in the xy-plane. CA→N points along
+        // −x; CA→C makes ∠N-CA-C with it, opening into the +y half-plane.
+        nitrogen.push(Point3::new(0.0, 0.0, 0.0));
+        alpha.push(Point3::new(N_CA, 0.0, 0.0));
+        let seed_angle = (180.0 - ANGLE_N_CA_C).to_radians();
+        carbon.push(
+            alpha[0]
+                + nalgebra::Vector3::new(CA_C * seed_angle.cos(), CA_C * seed_angle.sin(), 0.0),
+        );
+
+        for i in 0..count - 1 {
+            let psi_i = phi_psi[i].1;
+            let phi_next = phi_psi[i + 1].0;
+            let n_next = place_atom(nitrogen[i], alpha[i], carbon[i], C_N, ANGLE_CA_C_N, psi_i);
+            let ca_next = place_atom(alpha[i], carbon[i], n_next, N_CA, ANGLE_C_N_CA, OMEGA);
+            let c_next = place_atom(carbon[i], n_next, ca_next, CA_C, ANGLE_N_CA_C, phi_next);
+            nitrogen.push(n_next);
+            alpha.push(ca_next);
+            carbon.push(c_next);
+        }
+
+        let oxygen: Vec<Point3<f32>> = (0..count)
+            .map(|i| {
+                let to_ca = (alpha[i] - carbon[i]).normalize();
+                let direction = if i + 1 < count {
+                    let to_n = (nitrogen[i + 1] - carbon[i]).normalize();
+                    -(to_ca + to_n)
+                } else {
+                    // Terminal residue: no next N; point the O away from its CA.
+                    -to_ca
+                };
+                carbon[i] + direction.normalize() * C_O
+            })
+            .collect();
+
+        let mut atoms = Vec::with_capacity(count * 4);
+        let mut annotations = Vec::with_capacity(count * 4);
+        for i in 0..count {
+            for (name, element, position) in [
+                ("N", "N", nitrogen[i]),
+                ("CA", "C", alpha[i]),
+                ("C", "C", carbon[i]),
+                ("O", "O", oxygen[i]),
+            ] {
+                atoms.push(Atom {
+                    element: element.to_string(),
+                    position,
+                    charge: 0.0,
+                });
+                annotations.push(PdbAtomAnnotation {
+                    atom_name: name.to_string(),
+                    residue_name: "ALA".to_string(),
+                    chain_id: 'A',
+                    residue_seq: i as i32 + 1,
+                    insertion_code: ' ',
+                });
+            }
+        }
+        (atoms, annotations)
+    }
+
+    fn full_backbone_biopolymer(phi_psi: &[(f32, f32)]) -> (Vec<Atom>, Biopolymer) {
+        let (atoms, annotations) = build_protein_backbone(phi_psi);
+        let biopolymer = build_biopolymer(&annotations, Vec::new()).expect("protein biopolymer");
+        (atoms, biopolymer)
+    }
+
+    #[test]
+    fn ideal_alpha_helix_with_full_backbone_is_helix() {
+        // φ/ψ ≈ (−57°, −47°) is the canonical right-handed α-helix; its i→i+4
+        // backbone H-bonds drive the DSSP helix assignment.
+        let phi_psi = vec![(-57.0, -47.0); 14];
+        let (atoms, biopolymer) = full_backbone_biopolymer(&phi_psi);
+        let spans = assign_secondary_structure(&atoms, &biopolymer);
+
+        assert!(
+            spans
+                .iter()
+                .any(|s| s.kind == SecondaryStructureKind::Helix),
+            "expected a helix span: {spans:?}"
+        );
+        assert!(
+            spans
+                .iter()
+                .all(|s| s.kind == SecondaryStructureKind::Helix),
+            "an ideal helix must never be labelled sheet: {spans:?}"
+        );
+        let helix_residues: i32 = spans
+            .iter()
+            .map(|s| s.end.sequence_number - s.start.sequence_number + 1)
+            .sum();
+        assert!(
+            helix_residues >= 8,
+            "helix should cover most of the chain: {spans:?}"
+        );
+    }
+
+    #[test]
+    fn antiparallel_beta_hairpin_is_sheet() {
+        // Two extended strands joined by a two-residue type-II′ turn fold into an
+        // antiparallel hairpin whose reciprocal cross-strand H-bonds define a
+        // β-sheet (one strand span per arm).
+        let strand = (-139.0, 135.0);
+        let mut phi_psi = vec![strand; 6];
+        phi_psi.push((60.0, -120.0));
+        phi_psi.push((-80.0, 0.0));
+        phi_psi.extend(std::iter::repeat_n(strand, 6));
+        let (atoms, biopolymer) = full_backbone_biopolymer(&phi_psi);
+        let spans = assign_secondary_structure(&atoms, &biopolymer);
+
+        assert!(
+            spans
+                .iter()
+                .any(|s| s.kind == SecondaryStructureKind::Sheet),
+            "expected a sheet span: {spans:?}"
+        );
+        assert!(
+            spans
+                .iter()
+                .all(|s| s.kind == SecondaryStructureKind::Sheet),
+            "a β-hairpin must never be labelled helix: {spans:?}"
+        );
+    }
+
+    #[test]
+    fn extended_strand_without_partner_is_coil() {
+        // A lone fully extended strand carries β backbone dihedrals but has no
+        // partner strand to hydrogen-bond with, so DSSP must leave it coil. The
+        // Cα-only P-SEA criterion mislabels the whole thing β — this is the key
+        // over-assignment regression the H-bond path fixes.
+        let phi_psi = vec![(-139.0, 135.0); 12];
+        let (atoms, biopolymer) = full_backbone_biopolymer(&phi_psi);
+        let spans = assign_secondary_structure(&atoms, &biopolymer);
+        assert!(
+            spans.is_empty(),
+            "an isolated extended strand must be coil, got: {spans:?}"
+        );
+    }
+
+    #[test]
+    fn one_renamed_terminal_oxygen_keeps_the_dssp_path() {
+        // A full-backbone extended strand must stay on the DSSP path (→ coil) even
+        // when a single terminal carbonyl oxygen is renamed, as force fields do at
+        // the C terminus. The majority-oxygen gate must not drop the whole fragment
+        // back to the Cα-only criterion, which would over-assign it as β-strand.
+        let phi_psi = vec![(-139.0, 135.0); 12];
+        let (atoms, mut annotations) = build_protein_backbone(&phi_psi);
+        let terminal_oxygen = annotations
+            .iter_mut()
+            .rev()
+            .find(|annotation| annotation.atom_name == "O")
+            .expect("a carbonyl oxygen to rename");
+        terminal_oxygen.atom_name = "OXT".to_string();
+        let biopolymer = build_biopolymer(&annotations, Vec::new()).expect("protein biopolymer");
+
+        let spans = assign_secondary_structure(&atoms, &biopolymer);
+        assert!(
+            spans.is_empty(),
+            "DSSP must still run (→ coil) with one renamed terminal O: {spans:?}"
         );
     }
 }

--- a/compute-core/src/domain/structure.rs
+++ b/compute-core/src/domain/structure.rs
@@ -369,6 +369,24 @@ impl Structure {
         }
     }
 
+    /// Whether the atom's residue carries a complete peptide backbone (N/CA/C) —
+    /// the topological test for ribbon-drawability. Decided from atoms alone, so
+    /// it holds for force-field-protonated, disulfide, and otherwise renamed
+    /// protein residues exactly as for their canonical forms. Lets the cartoon
+    /// overlay default on for protein backbone without consulting residue names
+    /// (kept separate from [`Self::atom_category`], which stays name-based for
+    /// classification, selection, and MD).
+    pub fn atom_has_peptide_backbone(&self, atom_index: usize) -> bool {
+        self.biopolymer
+            .as_ref()
+            .filter(|biopolymer| biopolymer.is_compatible_with_atom_count(self.atoms.len()))
+            .and_then(|biopolymer| {
+                let residue_index = (*biopolymer.residue_for_atom.get(atom_index)?)?;
+                biopolymer.residues.get(residue_index)
+            })
+            .is_some_and(|residue| residue.has_peptide_backbone())
+    }
+
     pub fn center(&self) -> Point3<f32> {
         if let Some(cell) = &self.cell {
             let corners = cell.corners();

--- a/compute-core/src/payload.rs
+++ b/compute-core/src/payload.rs
@@ -288,21 +288,41 @@ pub fn payload_to_structure(payload: StructurePayload) -> anyhow::Result<Structu
     })
 }
 
+/// The atom index within `atoms` whose recorded name equals `target` (e.g. "N"
+/// or "C"). Lets a deserialized residue recover its backbone atoms — which are
+/// derived, not persisted — from the atom names the payload already carries.
+fn backbone_atom_index(atoms: &[usize], names: &[Option<String>], target: &str) -> Option<usize> {
+    atoms
+        .iter()
+        .copied()
+        .find(|&index| names.get(index).and_then(|name| name.as_deref()) == Some(target))
+}
+
 fn payload_to_biopolymer(payload: BiopolymerPayload) -> Biopolymer {
+    let atom_name_for_atom = payload.atom_name_for_atom;
     Biopolymer {
         residues: payload
             .residues
             .into_iter()
-            .map(|residue| ResidueRecord {
-                id: ResidueId::new(
-                    residue.chain_id,
-                    residue.sequence_number,
-                    residue.insertion_code,
-                ),
-                residue_name: residue.name,
-                atom_indices: residue.atoms,
-                alpha_carbon: residue.alpha_carbon,
-                is_standard_amino_acid: residue.is_standard,
+            .map(|residue| {
+                let backbone_nitrogen =
+                    backbone_atom_index(&residue.atoms, &atom_name_for_atom, "N");
+                let backbone_carbon = backbone_atom_index(&residue.atoms, &atom_name_for_atom, "C");
+                let backbone_oxygen = backbone_atom_index(&residue.atoms, &atom_name_for_atom, "O");
+                ResidueRecord {
+                    id: ResidueId::new(
+                        residue.chain_id,
+                        residue.sequence_number,
+                        residue.insertion_code,
+                    ),
+                    residue_name: residue.name,
+                    atom_indices: residue.atoms,
+                    alpha_carbon: residue.alpha_carbon,
+                    backbone_nitrogen,
+                    backbone_carbon,
+                    backbone_oxygen,
+                    is_standard_amino_acid: residue.is_standard,
+                }
             })
             .collect(),
         chains: payload
@@ -331,7 +351,7 @@ fn payload_to_biopolymer(payload: BiopolymerPayload) -> Biopolymer {
             })
             .collect(),
         residue_for_atom: payload.residue_for_atom,
-        atom_name_for_atom: payload.atom_name_for_atom,
+        atom_name_for_atom,
     }
 }
 

--- a/src/frontend/console/editing.rs
+++ b/src/frontend/console/editing.rs
@@ -144,15 +144,22 @@ fn biopolymer_after_atom_retain(
         if atom_indices.is_empty() {
             continue;
         }
-        let alpha_carbon = residue
-            .alpha_carbon
-            .and_then(|atom_index| atom_remap.get(atom_index).copied().flatten());
+        let remap_atom = |atom_index: Option<usize>| {
+            atom_index.and_then(|i| atom_remap.get(i).copied().flatten())
+        };
+        let alpha_carbon = remap_atom(residue.alpha_carbon);
+        let backbone_nitrogen = remap_atom(residue.backbone_nitrogen);
+        let backbone_carbon = remap_atom(residue.backbone_carbon);
+        let backbone_oxygen = remap_atom(residue.backbone_oxygen);
         residue_remap[old_residue_index] = Some(residues.len());
         residues.push(ResidueRecord {
             id: residue.id.clone(),
             residue_name: residue.residue_name.clone(),
             atom_indices,
             alpha_carbon,
+            backbone_nitrogen,
+            backbone_carbon,
+            backbone_oxygen,
             is_standard_amino_acid: residue.is_standard_amino_acid,
         });
     }

--- a/src/frontend/viewport/composer.rs
+++ b/src/frontend/viewport/composer.rs
@@ -1,13 +1,14 @@
 use crate::{domain::Structure, frontend::AtomSelection};
 
 use super::{
-    SurfaceCache, SurfaceCacheKey, ViewportVisualState,
+    SecondaryStructureCache, SecondaryStructureCacheKey, SurfaceCache, SurfaceCacheKey,
+    ViewportVisualState,
     camera::Projector,
     render::{
         PickTarget, RenderScene, ScreenDepthBuffer, ViewportGeometry, any_atoms_drawn_as_cartoon,
         any_atoms_drawn_as_surface, build_ball_and_stick_scene, build_biopolymer_cartoon_scene,
-        build_cached_surface_scene, build_cell_scene, build_opaque_depth_buffer,
-        build_surface_scene,
+        build_cached_biopolymer_cartoon_scene, build_cached_surface_scene, build_cell_scene,
+        build_opaque_depth_buffer, build_surface_scene,
     },
 };
 
@@ -23,11 +24,30 @@ pub(super) struct RepresentationComposer<'a> {
     selection: &'a AtomSelection,
     visual_state: &'a ViewportVisualState,
     surface_cache: SurfaceCacheMode<'a>,
+    secondary_cache: SecondaryStructureCacheMode<'a>,
 }
 
+enum SecondaryStructureCacheMode<'a> {
+    Cached(SecondaryStructureCacheContext<'a>),
+    Uncached,
+}
 enum SurfaceCacheMode<'a> {
     Cached(SurfaceCacheContext<'a>),
     Uncached,
+}
+
+pub(super) struct SecondaryStructureCacheContext<'a> {
+    cache: &'a mut SecondaryStructureCache,
+    key: SecondaryStructureCacheKey,
+}
+
+impl<'a> SecondaryStructureCacheContext<'a> {
+    pub(super) fn new(
+        cache: &'a mut SecondaryStructureCache,
+        key: SecondaryStructureCacheKey,
+    ) -> Self {
+        Self { cache, key }
+    }
 }
 
 pub(super) struct SurfaceCacheContext<'a> {
@@ -58,6 +78,7 @@ impl<'a> RepresentationComposer<'a> {
         selection: &'a AtomSelection,
         visual_state: &'a ViewportVisualState,
         cache_context: SurfaceCacheContext<'a>,
+        secondary_context: SecondaryStructureCacheContext<'a>,
     ) -> Self {
         Self {
             structure,
@@ -66,6 +87,7 @@ impl<'a> RepresentationComposer<'a> {
             selection,
             visual_state,
             surface_cache: SurfaceCacheMode::Cached(cache_context),
+            secondary_cache: SecondaryStructureCacheMode::Cached(secondary_context),
         }
     }
 
@@ -83,6 +105,7 @@ impl<'a> RepresentationComposer<'a> {
             selection,
             visual_state,
             surface_cache: SurfaceCacheMode::Uncached,
+            secondary_cache: SecondaryStructureCacheMode::Uncached,
         }
     }
 
@@ -94,6 +117,7 @@ impl<'a> RepresentationComposer<'a> {
             selection,
             visual_state,
             mut surface_cache,
+            secondary_cache,
         } = self;
         let mut scene = RenderScene::default();
 
@@ -116,8 +140,18 @@ impl<'a> RepresentationComposer<'a> {
         // other and the translucent surface by the compositor, and — for the
         // wireframe surface — seed the depth buffer its line runs are clipped
         // against. Nothing here depends on append order any more.
-        let cartoon_scene =
-            draw_cartoon.then(|| build_biopolymer_cartoon_scene(structure, viewport, visual_state));
+        let cartoon_scene = draw_cartoon.then(|| match secondary_cache {
+            SecondaryStructureCacheMode::Cached(context) => build_cached_biopolymer_cartoon_scene(
+                structure,
+                viewport,
+                visual_state,
+                context.cache,
+                context.key,
+            ),
+            SecondaryStructureCacheMode::Uncached => {
+                build_biopolymer_cartoon_scene(structure, viewport, visual_state)
+            }
+        });
         let ball_stick_scene =
             build_ball_and_stick_scene(structure, geometry, viewport, selection, visual_state);
 

--- a/src/frontend/viewport/gpu.rs
+++ b/src/frontend/viewport/gpu.rs
@@ -895,46 +895,60 @@ mod tests {
     /// extended β-strand, so the cartoon renders a helix ribbon, a coil turn, and
     /// a sheet arrow.
     fn helix_sheet_protein() -> Structure {
-        let mut atoms = Vec::new();
-        let mut annotations = Vec::new();
-        let mut push_residue = |atoms: &mut Vec<Atom>, position: Point3<f32>, seq: i32| {
-            atoms.push(Atom {
-                element: "C".to_string(),
-                position,
-                charge: 0.0,
-            });
-            annotations.push(PdbAtomAnnotation {
-                atom_name: "CA".to_string(),
-                residue_name: "ALA".to_string(),
-                chain_id: 'A',
-                residue_seq: seq,
-                insertion_code: ' ',
-            });
-        };
-
-        // Helix: 11 residues on an idealized α-helix (100°/residue, 1.5 Å rise).
+        // Cα trace: an idealized α-helix (100°/residue, 1.5 Å rise) followed by an
+        // extended β-strand continuing from the helix end, so the chain is one
+        // continuous backbone.
+        let mut ca = Vec::new();
         for i in 0..11usize {
             let angle = i as f32 * 1.745;
-            push_residue(
-                &mut atoms,
-                Point3::new(2.3 * angle.cos(), 2.3 * angle.sin(), 1.5 * i as f32),
-                i as i32 + 1,
-            );
+            ca.push(Point3::new(
+                2.3 * angle.cos(),
+                2.3 * angle.sin(),
+                1.5 * i as f32,
+            ));
         }
-        // Sheet: 9 residues extended along +x with a slight pleat, starting from
-        // the helix end so the chain is continuous.
-        let base = atoms.last().unwrap().position;
+        let base = *ca.last().unwrap();
         for i in 0..9usize {
             let step = i as f32 + 1.0;
-            push_residue(
-                &mut atoms,
-                Point3::new(
-                    base.x + 3.3 * step,
-                    base.y + if i % 2 == 0 { 0.5 } else { -0.5 },
-                    base.z,
-                ),
-                12 + i as i32,
-            );
+            ca.push(Point3::new(
+                base.x + 3.3 * step,
+                base.y + if i % 2 == 0 { 0.5 } else { -0.5 },
+                base.z,
+            ));
+        }
+
+        // Give each residue a full N/CA/C backbone; N and C sit on the Cα–Cα
+        // midpoints so consecutive C(i)/N(i+1) coincide (a zero-length peptide
+        // bond), keeping the chain a single contiguous ribbon.
+        let mut atoms = Vec::with_capacity(ca.len() * 3);
+        let mut annotations = Vec::with_capacity(ca.len() * 3);
+        for (index, &position) in ca.iter().enumerate() {
+            let previous = if index > 0 { ca[index - 1] } else { position };
+            let next = if index + 1 < ca.len() {
+                ca[index + 1]
+            } else {
+                position
+            };
+            let nitrogen = Point3::from((previous.coords + position.coords) * 0.5);
+            let carbon = Point3::from((position.coords + next.coords) * 0.5);
+            for (atom_name, element, atom_position) in [
+                ("N", "N", nitrogen),
+                ("CA", "C", position),
+                ("C", "C", carbon),
+            ] {
+                atoms.push(Atom {
+                    element: element.to_string(),
+                    position: atom_position,
+                    charge: 0.0,
+                });
+                annotations.push(PdbAtomAnnotation {
+                    atom_name: atom_name.to_string(),
+                    residue_name: "ALA".to_string(),
+                    chain_id: 'A',
+                    residue_seq: index as i32 + 1,
+                    insertion_code: ' ',
+                });
+            }
         }
 
         let spans = vec![

--- a/src/frontend/viewport/mod.rs
+++ b/src/frontend/viewport/mod.rs
@@ -2,7 +2,10 @@ use std::time::Duration;
 
 use eframe::egui::{self, Align2, FontId, Pos2, Sense, Vec2};
 
-use crate::{domain::Structure, frontend::AtomSelection};
+use crate::{
+    domain::{SecondaryStructureSpan, Structure},
+    frontend::AtomSelection,
+};
 
 mod camera;
 mod composer;
@@ -22,7 +25,7 @@ pub use visual_state::{
 };
 
 use camera::Projector;
-use composer::{RepresentationComposer, SurfaceCacheContext};
+use composer::{RepresentationComposer, SecondaryStructureCacheContext, SurfaceCacheContext};
 use interaction::{InteractionSystem, ViewportInteraction};
 use render::*;
 
@@ -37,6 +40,7 @@ pub const HOVER_FRAME: Duration = Duration::from_millis(100);
 pub struct ViewportCache {
     geometry: GeometryCache,
     surface: SurfaceCache,
+    secondary: SecondaryStructureCache,
     gpu: GpuViewCache,
 }
 
@@ -50,6 +54,27 @@ pub(super) struct GeometryCache {
 pub(super) struct SurfaceCache {
     key: Option<SurfaceCacheKey>,
     geometry: Option<SurfaceSceneGeometry>,
+}
+
+#[derive(Default)]
+pub(super) struct SecondaryStructureCache {
+    key: Option<SecondaryStructureCacheKey>,
+    spans: Vec<SecondaryStructureSpan>,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub(super) struct SecondaryStructureCacheKey {
+    structure_id: u64,
+    structure_revision: u64,
+}
+
+impl SecondaryStructureCacheKey {
+    fn new(structure_id: u64, structure_revision: u64) -> Self {
+        Self {
+            structure_id,
+            structure_revision,
+        }
+    }
 }
 
 /// State for the GPU ball-and-stick path. The instance set is camera-independent
@@ -66,6 +91,7 @@ impl ViewportCache {
     pub fn clear(&mut self) {
         self.geometry = GeometryCache::default();
         self.surface = SurfaceCache::default();
+        self.secondary = SecondaryStructureCache::default();
         self.gpu = GpuViewCache::default();
     }
 }
@@ -411,6 +437,10 @@ fn render_molecules_cpu(
         selection,
         visual_state,
         SurfaceCacheContext::new(&mut cache.surface, structure_id, structure_revision),
+        SecondaryStructureCacheContext::new(
+            &mut cache.secondary,
+            SecondaryStructureCacheKey::new(structure_id, structure_revision),
+        ),
     )
     .build();
     let rendered_in_full =
@@ -464,7 +494,13 @@ fn render_molecules_gpu(
         None
     } else {
         cache.gpu.instance_key = Some(instance_key);
-        let mut scene = build_molecule_instances(structure, selection, visual_state);
+        let mut scene = build_cached_molecule_instances(
+            structure,
+            selection,
+            visual_state,
+            &mut cache.secondary,
+            SecondaryStructureCacheKey::new(structure_id, structure_revision),
+        );
         let surface_key =
             SurfaceCacheKey::new(structure_id, structure_revision, structure, visual_state);
         scene.surface =

--- a/src/frontend/viewport/render.rs
+++ b/src/frontend/viewport/render.rs
@@ -25,9 +25,12 @@ pub(super) use backend::{
 pub(super) use ball_stick::build_ball_and_stick_scene;
 pub(super) use canvas::HeadlessCanvas;
 pub(super) use cartoon::{
-    ScreenDepthBuffer, build_biopolymer_cartoon_scene, build_opaque_depth_buffer,
+    ScreenDepthBuffer, build_biopolymer_cartoon_scene, build_cached_biopolymer_cartoon_scene,
+    build_opaque_depth_buffer,
 };
 pub(super) use cell::{build_cell_scene, draw_cell_labels};
+pub(super) use instances::build_cached_molecule_instances;
+#[cfg(test)]
 pub(super) use instances::build_molecule_instances;
 pub(super) use scene::{
     PickTarget, ViewportGeometry, build_viewport_geometry, cached_geometry, pick_atom,
@@ -250,7 +253,7 @@ pub(super) fn any_atoms_drawn_as_cartoon(
     biopolymer
         .residues
         .iter()
-        .filter(|residue| residue.is_standard_amino_acid)
+        .filter(|residue| residue.has_cartoon_trace())
         .filter_map(|residue| residue.alpha_carbon)
         .any(|atom_index| visual_state.cartoon_enabled(structure, atom_index))
 }

--- a/src/frontend/viewport/render/cartoon/mesh_cpu.rs
+++ b/src/frontend/viewport/render/cartoon/mesh_cpu.rs
@@ -4,7 +4,9 @@ use eframe::egui::Color32;
 use nalgebra::Vector3;
 
 use crate::domain::{Biopolymer, Structure};
-use crate::frontend::ViewportVisualState;
+use crate::frontend::viewport::{
+    SecondaryStructureCache, SecondaryStructureCacheKey, ViewportVisualState,
+};
 
 use super::super::super::camera::Projector;
 use super::super::backend::{LineSegmentPrimitive, RenderScene};
@@ -25,10 +27,45 @@ pub(crate) fn build_biopolymer_cartoon_scene(
     let Some(biopolymer) = usable_biopolymer(structure) else {
         return RenderScene::default();
     };
+    build_cartoon_scene_from_fragments(
+        cartoon_fragments(structure, biopolymer, viewport, visual_state),
+        viewport,
+        visual_state,
+    )
+}
 
+pub(crate) fn build_cached_biopolymer_cartoon_scene(
+    structure: &Structure,
+    viewport: &Projector,
+    visual_state: &ViewportVisualState,
+    secondary_cache: &mut SecondaryStructureCache,
+    secondary_key: SecondaryStructureCacheKey,
+) -> RenderScene {
+    let Some(biopolymer) = usable_biopolymer(structure) else {
+        return RenderScene::default();
+    };
+    build_cartoon_scene_from_fragments(
+        cached_cartoon_fragments(
+            structure,
+            biopolymer,
+            viewport,
+            visual_state,
+            secondary_cache,
+            secondary_key,
+        ),
+        viewport,
+        visual_state,
+    )
+}
+
+fn build_cartoon_scene_from_fragments(
+    fragments: Vec<CartoonFragment>,
+    viewport: &Projector,
+    visual_state: &ViewportVisualState,
+) -> RenderScene {
     let mut opaque_meshes = Vec::new();
     let mut lines = Vec::new();
-    for fragment in cartoon_fragments(structure, biopolymer, viewport, visual_state) {
+    for fragment in fragments {
         if visual_state.lighting.silhouettes && visual_state.lighting.silhouette_width > 0.0 {
             append_cartoon_silhouette(
                 &mut lines,
@@ -58,6 +95,29 @@ fn cartoon_fragments(
             samples,
         })
         .collect()
+}
+
+fn cached_cartoon_fragments(
+    structure: &Structure,
+    biopolymer: &Biopolymer,
+    viewport: &Projector,
+    visual_state: &ViewportVisualState,
+    secondary_cache: &mut SecondaryStructureCache,
+    secondary_key: SecondaryStructureCacheKey,
+) -> Vec<CartoonFragment> {
+    cached_cartoon_chain_sweeps(
+        structure,
+        biopolymer,
+        visual_state,
+        secondary_cache,
+        secondary_key,
+    )
+    .into_iter()
+    .map(|samples| CartoonFragment {
+        triangles: build_cartoon_triangles(viewport, &samples, visual_state),
+        samples,
+    })
+    .collect()
 }
 
 pub(crate) fn build_cartoon_triangles(

--- a/src/frontend/viewport/render/cartoon/mesh_gpu.rs
+++ b/src/frontend/viewport/render/cartoon/mesh_gpu.rs
@@ -3,13 +3,16 @@ use super::*;
 use nalgebra::{Point3, Vector3};
 
 use crate::domain::Structure;
-use crate::frontend::ViewportVisualState;
+use crate::frontend::viewport::{
+    SecondaryStructureCache, SecondaryStructureCacheKey, ViewportVisualState,
+};
 
 use super::super::super::gpu::MeshVertex;
 use super::super::usable_biopolymer;
 
 /// Build the world-space cartoon mesh (position, normal, color triangle soup)
 /// for the GPU mesh pipeline. Camera-independent.
+#[cfg(test)]
 pub(crate) fn build_biopolymer_cartoon_world_mesh(
     structure: &Structure,
     visual_state: &ViewportVisualState,
@@ -17,9 +20,40 @@ pub(crate) fn build_biopolymer_cartoon_world_mesh(
     let Some(biopolymer) = usable_biopolymer(structure) else {
         return Vec::new();
     };
+    build_cartoon_world_mesh_from_sweeps(
+        cartoon_chain_sweeps(structure, biopolymer, visual_state),
+        visual_state,
+    )
+}
+
+pub(crate) fn build_cached_biopolymer_cartoon_world_mesh(
+    structure: &Structure,
+    visual_state: &ViewportVisualState,
+    secondary_cache: &mut SecondaryStructureCache,
+    secondary_key: SecondaryStructureCacheKey,
+) -> Vec<MeshVertex> {
+    let Some(biopolymer) = usable_biopolymer(structure) else {
+        return Vec::new();
+    };
+    build_cartoon_world_mesh_from_sweeps(
+        cached_cartoon_chain_sweeps(
+            structure,
+            biopolymer,
+            visual_state,
+            secondary_cache,
+            secondary_key,
+        ),
+        visual_state,
+    )
+}
+
+fn build_cartoon_world_mesh_from_sweeps(
+    sweeps: Vec<Vec<CartoonSweepSample>>,
+    visual_state: &ViewportVisualState,
+) -> Vec<MeshVertex> {
     let segments = visual_state.cartoon.profile_segments.clamp(6, 48);
     let mut mesh = Vec::new();
-    for samples in cartoon_chain_sweeps(structure, biopolymer, visual_state) {
+    for samples in sweeps {
         append_cartoon_world_fragment(&mut mesh, &samples, segments);
     }
     mesh

--- a/src/frontend/viewport/render/cartoon/path.rs
+++ b/src/frontend/viewport/render/cartoon/path.rs
@@ -7,10 +7,12 @@ use nalgebra::{Point3, Rotation3, Unit, Vector3};
 
 use crate::{
     domain::{
-        Biopolymer, ChainRecord, ResidueRecord, SecondaryStructureKind, SecondaryStructureSpan,
-        Structure, assign_secondary_structure,
+        Atom, Biopolymer, ChainRecord, ResidueRecord, SecondaryStructureKind,
+        SecondaryStructureSpan, Structure, assign_secondary_structure, residues_backbone_bonded,
     },
-    frontend::ViewportVisualState,
+    frontend::viewport::{
+        SecondaryStructureCache, SecondaryStructureCacheKey, ViewportVisualState,
+    },
 };
 
 use super::super::{
@@ -66,8 +68,27 @@ pub(crate) fn cartoon_chain_sweeps(
     visual_state: &ViewportVisualState,
 ) -> Vec<Vec<CartoonSweepSample>> {
     let secondary = resolve_secondary_structures(structure, biopolymer);
-    let secondary = secondary.as_ref();
+    cartoon_chain_sweeps_with_secondary(structure, biopolymer, visual_state, secondary.as_ref())
+}
 
+pub(crate) fn cached_cartoon_chain_sweeps(
+    structure: &Structure,
+    biopolymer: &Biopolymer,
+    visual_state: &ViewportVisualState,
+    secondary_cache: &mut SecondaryStructureCache,
+    secondary_key: SecondaryStructureCacheKey,
+) -> Vec<Vec<CartoonSweepSample>> {
+    let secondary =
+        resolve_secondary_structures_cached(structure, biopolymer, secondary_cache, secondary_key);
+    cartoon_chain_sweeps_with_secondary(structure, biopolymer, visual_state, secondary.as_ref())
+}
+
+fn cartoon_chain_sweeps_with_secondary(
+    structure: &Structure,
+    biopolymer: &Biopolymer,
+    visual_state: &ViewportVisualState,
+    secondary: &[SecondaryStructureSpan],
+) -> Vec<Vec<CartoonSweepSample>> {
     let mut sweeps = Vec::new();
     for (chain_index, chain) in biopolymer.chains.iter().enumerate() {
         let chain_color = visual_state
@@ -80,7 +101,8 @@ pub(crate) fn cartoon_chain_sweeps(
             continue;
         }
 
-        for (start, end) in chain_contiguous_fragments(biopolymer, &residue_trace) {
+        for (start, end) in chain_contiguous_fragments(biopolymer, &structure.atoms, &residue_trace)
+        {
             let fragment = &residue_trace[start..end];
             if fragment.len() < 2 {
                 continue;
@@ -154,11 +176,11 @@ fn chain_residue_trace(
         .filter_map(|&residue_index| {
             let residue = biopolymer.residues.get(residue_index)?;
             let atom_index = residue.alpha_carbon?;
-            // Only residues whose alpha carbon has the cartoon overlay enabled
-            // are drawn as ribbon, so the user can toggle cartoon on a protein
-            // selection independently of its base style.
-            let is_cartoon = residue.is_standard_amino_acid
-                && visual_state.cartoon_enabled(structure, atom_index);
+            // Full peptide residues are renderable from N/CA/C topology alone.
+            // Standard C-alpha-only residues keep the legacy trace fallback; the
+            // overlay toggle then gates whether the user wants the ribbon here.
+            let is_cartoon =
+                residue.has_cartoon_trace() && visual_state.cartoon_enabled(structure, atom_index);
             is_cartoon.then_some(ChainResiduePoint {
                 residue_index,
                 position: structure.atoms[atom_index].position,
@@ -169,6 +191,7 @@ fn chain_residue_trace(
 
 fn chain_contiguous_fragments(
     biopolymer: &Biopolymer,
+    atoms: &[Atom],
     residue_trace: &[ChainResiduePoint],
 ) -> Vec<(usize, usize)> {
     let mut fragments = Vec::new();
@@ -178,9 +201,13 @@ fn chain_contiguous_fragments(
 
     let mut fragment_start = 0;
     for index in 1..residue_trace.len() {
-        let is_contiguous = residues_are_contiguous(
+        // A fragment break is a genuine backbone discontinuity in space, not a
+        // jump in residue numbering — so renumbering, insertion codes, and gaps
+        // never split a ribbon that is physically one continuous chain.
+        let is_contiguous = residues_backbone_bonded(
             &biopolymer.residues[residue_trace[index - 1].residue_index],
             &biopolymer.residues[residue_trace[index].residue_index],
+            atoms,
         );
 
         if !is_contiguous {
@@ -236,6 +263,22 @@ pub(crate) fn resolve_secondary_structures<'a>(
     }
 }
 
+pub(crate) fn resolve_secondary_structures_cached<'a>(
+    structure: &Structure,
+    biopolymer: &'a Biopolymer,
+    cache: &'a mut SecondaryStructureCache,
+    key: SecondaryStructureCacheKey,
+) -> Cow<'a, [SecondaryStructureSpan]> {
+    if !biopolymer.secondary_structures.is_empty() {
+        return Cow::Borrowed(&biopolymer.secondary_structures);
+    }
+    if cache.key != Some(key) {
+        cache.spans = assign_secondary_structure(&structure.atoms, biopolymer);
+        cache.key = Some(key);
+    }
+    Cow::Borrowed(&cache.spans)
+}
+
 pub(crate) fn residue_cartoon_kind(
     residue: &ResidueRecord,
     secondary_structures: &[SecondaryStructureSpan],
@@ -270,12 +313,6 @@ fn residue_in_span(residue: &ResidueRecord, span: &SecondaryStructureSpan) -> bo
     residue.id.chain_id == span.start.chain_id
         && residue.id.ordering_key() >= span.start.ordering_key()
         && residue.id.ordering_key() <= span.end.ordering_key()
-}
-
-fn residues_are_contiguous(previous: &ResidueRecord, current: &ResidueRecord) -> bool {
-    previous.id.chain_id == current.id.chain_id
-        && current.id.sequence_number - previous.id.sequence_number <= 1
-        && current.id.sequence_number >= previous.id.sequence_number
 }
 
 fn smooth_cartoon_controls(
@@ -439,4 +476,288 @@ fn transport_frame_vector(
     }
 
     Rotation3::from_axis_angle(&Unit::new_normalize(axis), angle) * vector
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{PdbAtomAnnotation, ResidueId, build_biopolymer};
+
+    const CA_STEP: f32 = 3.8;
+
+    /// Atoms + annotations for a straight protein backbone laid along +x: one
+    /// residue per `(residue_name, sequence_number, insertion_code)` at `CA_STEP`
+    /// Cα spacing, each carrying N/CA/C atoms placed so the C(i)–N(i+1) peptide
+    /// bond is short — the residues are physically bonded in file order regardless
+    /// of how they are numbered. Returned separately so a test can perturb
+    /// coordinates before the structure is assembled.
+    fn straight_backbone(residues: &[(&str, i32, char)]) -> (Vec<Atom>, Vec<PdbAtomAnnotation>) {
+        let mut atoms = Vec::new();
+        let mut annotations = Vec::new();
+        for (index, &(name, sequence_number, insertion_code)) in residues.iter().enumerate() {
+            let x = index as f32 * CA_STEP;
+            for (atom_name, element, offset) in
+                [("N", "N", -1.2_f32), ("CA", "C", 0.0), ("C", "C", 1.2)]
+            {
+                atoms.push(Atom {
+                    element: element.to_string(),
+                    position: Point3::new(x + offset, 0.0, 0.0),
+                    charge: 0.0,
+                });
+                annotations.push(PdbAtomAnnotation {
+                    atom_name: atom_name.to_string(),
+                    residue_name: name.to_string(),
+                    chain_id: 'A',
+                    residue_seq: sequence_number,
+                    insertion_code,
+                });
+            }
+        }
+        (atoms, annotations)
+    }
+
+    /// `straight_backbone` with default consecutive numbering from 1.
+    fn backbone_atoms(residue_names: &[&str]) -> (Vec<Atom>, Vec<PdbAtomAnnotation>) {
+        let residues: Vec<(&str, i32, char)> = residue_names
+            .iter()
+            .enumerate()
+            .map(|(index, &name)| (name, index as i32 + 1, ' '))
+            .collect();
+        straight_backbone(&residues)
+    }
+
+    /// Wrap atoms + annotations into a `Structure`. A dummy secondary-structure
+    /// span is passed so `build_biopolymer` accepts the input as a biopolymer even
+    /// when no residue name is a standard amino acid — the parse-level "is this a
+    /// protein" gate is out of scope here; these tests exercise the renderer.
+    fn structure_from(atoms: Vec<Atom>, annotations: Vec<PdbAtomAnnotation>) -> Structure {
+        let span = SecondaryStructureSpan {
+            kind: SecondaryStructureKind::Helix,
+            start: ResidueId::new('A', 1, ' '),
+            end: ResidueId::new('A', 1, ' '),
+        };
+        let biopolymer = build_biopolymer(&annotations, vec![span]).expect("biopolymer");
+        Structure {
+            title: "test".to_string(),
+            atoms,
+            bonds: Vec::new(),
+            cell: None,
+            biopolymer: Some(biopolymer),
+        }
+    }
+
+    /// A visual state with the cartoon overlay explicitly on for every atom, i.e.
+    /// "cartoon is active" — the precondition the renderer is fixed under.
+    fn cartoon_on_all(atom_count: usize) -> ViewportVisualState {
+        let mut visual_state = ViewportVisualState::default();
+        for atom_index in 0..atom_count {
+            visual_state.cartoon_overlay.atoms.insert(atom_index, true);
+        }
+        visual_state
+    }
+
+    #[test]
+    fn non_standard_residue_names_form_one_continuous_ribbon() {
+        // Force-field protonation states, disulfide variants, selenomethionine,
+        // phosphoserine — none recognized by is_standard_amino_acid — must ribbon
+        // as one unbroken fragment. This is the regression: the old name gate
+        // dropped every one of these residues, shredding the ribbon.
+        let residue_names = [
+            "HID", "CYX", "HSE", "GLH", "HSD", "LYN", "ASH", "HIP", "HIE", "CYM", "MSE", "SEP",
+        ];
+        let (atoms, annotations) = backbone_atoms(&residue_names);
+        let structure = structure_from(atoms, annotations);
+        let biopolymer = structure.biopolymer.as_ref().expect("biopolymer");
+        assert!(
+            biopolymer
+                .residues
+                .iter()
+                .all(|residue| !residue.is_standard_amino_acid),
+            "every residue must use a non-standard name for this regression to bite"
+        );
+
+        let visual_state = cartoon_on_all(structure.atoms.len());
+        let chain = &biopolymer.chains[0];
+        let trace = chain_residue_trace(&structure, biopolymer, chain, &visual_state);
+        assert_eq!(
+            trace.len(),
+            residue_names.len(),
+            "every backbone residue enters the ribbon trace regardless of name"
+        );
+
+        let fragments = chain_contiguous_fragments(biopolymer, &structure.atoms, &trace);
+        assert_eq!(
+            fragments,
+            vec![(0, residue_names.len())],
+            "the chain renders as a single continuous ribbon fragment"
+        );
+    }
+
+    #[test]
+    fn non_standard_protein_ribbons_by_default_without_explicit_enabling() {
+        // With the *default* visual state (no overlay overrides), a protein whose
+        // residues use non-standard names must still default to a cartoon ribbon:
+        // enablement is driven by backbone topology, not the residue name nor its
+        // name-based atom category (which would classify these as a ligand and,
+        // before the fix, default cartoon off — dropping them from the ribbon).
+        let residue_names = ["HID", "CYX", "HSE", "GLH", "HSD", "LYN"];
+        let (atoms, annotations) = backbone_atoms(&residue_names);
+        let structure = structure_from(atoms, annotations);
+        let biopolymer = structure.biopolymer.as_ref().expect("biopolymer");
+
+        let visual_state = ViewportVisualState::default(); // nothing enabled by hand
+        let chain = &biopolymer.chains[0];
+        let trace = chain_residue_trace(&structure, biopolymer, chain, &visual_state);
+        assert_eq!(
+            trace.len(),
+            residue_names.len(),
+            "non-standard protein defaults to cartoon and enters the trace"
+        );
+        let fragments = chain_contiguous_fragments(biopolymer, &structure.atoms, &trace);
+        assert_eq!(fragments, vec![(0, residue_names.len())]);
+    }
+
+    #[test]
+    fn standard_ca_only_trace_ribbons_by_default() {
+        let atoms = (0..6)
+            .map(|index| Atom {
+                element: "C".to_string(),
+                position: Point3::new(index as f32 * CA_STEP, 0.0, 0.0),
+                charge: 0.0,
+            })
+            .collect::<Vec<_>>();
+        let annotations = (0..6)
+            .map(|index| PdbAtomAnnotation {
+                atom_name: "CA".to_string(),
+                residue_name: "ALA".to_string(),
+                chain_id: 'A',
+                residue_seq: index + 1,
+                insertion_code: ' ',
+            })
+            .collect::<Vec<_>>();
+        let biopolymer = build_biopolymer(&annotations, Vec::new()).expect("biopolymer");
+        assert!(
+            biopolymer
+                .residues
+                .iter()
+                .all(|residue| !residue.has_peptide_backbone())
+        );
+        let structure = Structure {
+            title: "ca-only".to_string(),
+            atoms,
+            bonds: Vec::new(),
+            cell: None,
+            biopolymer: Some(biopolymer),
+        };
+        let biopolymer = structure.biopolymer.as_ref().expect("biopolymer");
+
+        let visual_state = ViewportVisualState::default();
+        let trace =
+            chain_residue_trace(&structure, biopolymer, &biopolymer.chains[0], &visual_state);
+        assert_eq!(trace.len(), 6, "standard C-alpha traces still draw ribbons");
+        let fragments = chain_contiguous_fragments(biopolymer, &structure.atoms, &trace);
+        assert_eq!(fragments, vec![(0, 6)]);
+    }
+    #[test]
+    fn renumbering_and_insertion_codes_keep_one_continuous_ribbon() {
+        // Physically one continuous backbone, but with a sequence-number jump and
+        // insertion codes — exactly what the old `sequence_number diff <= 1`
+        // contiguity test wrongly split. Geometry says one fragment; the numbering
+        // must not override it.
+        let residues = [
+            ("HID", 5, ' '),
+            ("CYX", 6, ' '),
+            ("HSE", 6, 'A'), // insertion code, same sequence number
+            ("GLH", 6, 'B'),
+            ("ALA", 41, ' '), // large jump in numbering, still bonded in space
+            ("LYN", 42, ' '),
+        ];
+        let (atoms, annotations) = straight_backbone(&residues);
+        let structure = structure_from(atoms, annotations);
+        let biopolymer = structure.biopolymer.as_ref().expect("biopolymer");
+
+        let visual_state = cartoon_on_all(structure.atoms.len());
+        let chain = &biopolymer.chains[0];
+        let trace = chain_residue_trace(&structure, biopolymer, chain, &visual_state);
+        assert_eq!(trace.len(), residues.len());
+
+        let fragments = chain_contiguous_fragments(biopolymer, &structure.atoms, &trace);
+        assert_eq!(
+            fragments,
+            vec![(0, residues.len())],
+            "bonded backbone stays one fragment despite renumbering and insertion codes"
+        );
+    }
+
+    #[test]
+    fn a_real_backbone_break_splits_the_ribbon_despite_consecutive_numbering() {
+        // Contiguity is geometric: a true spatial gap must split the ribbon even
+        // though the residue numbers stay 1,2,3,4 with no insertion codes.
+        let (mut atoms, annotations) = backbone_atoms(&["HID", "CYX", "HSE", "GLH"]);
+        // Push residues 3 and 4 (their nine atoms start at index 6) far away, so
+        // the C(2)–N(3) peptide bond is long while everything else stays bonded.
+        for atom in atoms.iter_mut().skip(6) {
+            atom.position.x += 50.0;
+        }
+        let structure = structure_from(atoms, annotations);
+        let biopolymer = structure.biopolymer.as_ref().expect("biopolymer");
+
+        let visual_state = cartoon_on_all(structure.atoms.len());
+        let chain = &biopolymer.chains[0];
+        let trace = chain_residue_trace(&structure, biopolymer, chain, &visual_state);
+        assert_eq!(trace.len(), 4, "all four residues are renderable");
+
+        let fragments = chain_contiguous_fragments(biopolymer, &structure.atoms, &trace);
+        assert_eq!(
+            fragments,
+            vec![(0, 2), (2, 4)],
+            "the spatial break splits the trace into two fragments"
+        );
+    }
+
+    #[test]
+    fn hetero_groups_without_backbone_are_excluded() {
+        // A calcium ion (residue and atom both named "CA", so it carries a stray
+        // alpha_carbon) and a water are not protein backbone — they lack the
+        // N/CA/C triad — so topology keeps them out of the ribbon entirely.
+        let (mut atoms, mut annotations) = backbone_atoms(&["HID", "CYX", "HSE"]);
+        atoms.push(Atom {
+            element: "Ca".to_string(),
+            position: Point3::new(100.0, 0.0, 0.0),
+            charge: 2.0,
+        });
+        annotations.push(PdbAtomAnnotation {
+            atom_name: "CA".to_string(),
+            residue_name: "CA".to_string(),
+            chain_id: 'A',
+            residue_seq: 100,
+            insertion_code: ' ',
+        });
+        atoms.push(Atom {
+            element: "O".to_string(),
+            position: Point3::new(110.0, 0.0, 0.0),
+            charge: 0.0,
+        });
+        annotations.push(PdbAtomAnnotation {
+            atom_name: "OW".to_string(),
+            residue_name: "SOL".to_string(),
+            chain_id: 'A',
+            residue_seq: 101,
+            insertion_code: ' ',
+        });
+        let structure = structure_from(atoms, annotations);
+        let biopolymer = structure.biopolymer.as_ref().expect("biopolymer");
+
+        let visual_state = cartoon_on_all(structure.atoms.len());
+        let chain = &biopolymer.chains[0];
+        let trace = chain_residue_trace(&structure, biopolymer, chain, &visual_state);
+        assert_eq!(
+            trace.len(),
+            3,
+            "only the three backbone residues enter the trace; Ca and water are excluded"
+        );
+
+        let fragments = chain_contiguous_fragments(biopolymer, &structure.atoms, &trace);
+        assert_eq!(fragments, vec![(0, 3)]);
+    }
 }

--- a/src/frontend/viewport/render/cartoon/tests.rs
+++ b/src/frontend/viewport/render/cartoon/tests.rs
@@ -14,25 +14,43 @@ use crate::frontend::ViewportVisualState;
 
 use super::super::super::camera::Projector;
 
-/// Single-chain structure with one ALA Cα per residue along an ideal α-helix
-/// trace (1.5 Å rise, 100° turn, 2.3 Å radius) and no HELIX/SHEET records.
+/// Single-chain structure with one ALA residue per residue along an ideal
+/// α-helix Cα trace (1.5 Å rise, 100° turn, 2.3 Å radius) and no HELIX/SHEET
+/// records. Each residue carries a full N/CA/C backbone: the amide N and
+/// carbonyl C sit on the Cα–Cα midpoints, so consecutive C(i)/N(i+1) coincide —
+/// a zero-length peptide "bond" that keeps the ribbon one continuous fragment.
+/// Only the Cα positions carry the helix geometry the ribbon sweep reads.
 fn helix_structure(residues: usize) -> Structure {
-    let mut atoms = Vec::with_capacity(residues);
-    let mut annotations = Vec::with_capacity(residues);
+    let ca: Vec<Point3<f32>> = (0..residues)
+        .map(|i| {
+            let angle = 100.0 * PI / 180.0 * i as f32;
+            Point3::new(2.3 * angle.cos(), 2.3 * angle.sin(), 1.5 * i as f32)
+        })
+        .collect();
+
+    let mut atoms = Vec::with_capacity(residues * 3);
+    let mut annotations = Vec::with_capacity(residues * 3);
     for i in 0..residues {
-        let angle = 100.0 * PI / 180.0 * i as f32;
-        atoms.push(Atom {
-            element: "C".to_string(),
-            position: Point3::new(2.3 * angle.cos(), 2.3 * angle.sin(), 1.5 * i as f32),
-            charge: 0.0,
-        });
-        annotations.push(PdbAtomAnnotation {
-            atom_name: "CA".to_string(),
-            residue_name: "ALA".to_string(),
-            chain_id: 'A',
-            residue_seq: i as i32 + 1,
-            insertion_code: ' ',
-        });
+        let previous = if i > 0 { ca[i - 1] } else { ca[i] };
+        let next = if i + 1 < residues { ca[i + 1] } else { ca[i] };
+        let nitrogen = Point3::from((previous.coords + ca[i].coords) * 0.5);
+        let carbon = Point3::from((ca[i].coords + next.coords) * 0.5);
+        for (atom_name, element, position) in
+            [("N", "N", nitrogen), ("CA", "C", ca[i]), ("C", "C", carbon)]
+        {
+            atoms.push(Atom {
+                element: element.to_string(),
+                position,
+                charge: 0.0,
+            });
+            annotations.push(PdbAtomAnnotation {
+                atom_name: atom_name.to_string(),
+                residue_name: "ALA".to_string(),
+                chain_id: 'A',
+                residue_seq: i as i32 + 1,
+                insertion_code: ' ',
+            });
+        }
     }
     let mut structure = Structure::with_bonds("helix", atoms, Vec::new());
     structure.biopolymer = build_biopolymer(&annotations, Vec::new());

--- a/src/frontend/viewport/render/instances.rs
+++ b/src/frontend/viewport/render/instances.rs
@@ -8,12 +8,18 @@ use nalgebra::{Point3, Vector3};
 
 use crate::{
     domain::{BondType, Structure},
-    frontend::{AtomSelection, ViewportVisualState, state::AtomStyle},
+    frontend::{
+        AtomSelection,
+        state::AtomStyle,
+        viewport::{SecondaryStructureCache, SecondaryStructureCacheKey, ViewportVisualState},
+    },
 };
 
-use super::super::gpu::{CylinderInstance, MoleculeInstances, SphereInstance};
+use super::super::gpu::{CylinderInstance, MeshVertex, MoleculeInstances, SphereInstance};
 use super::ball_stick::build_atom_draw_table;
+#[cfg(test)]
 use super::cartoon::build_biopolymer_cartoon_world_mesh;
+use super::cartoon::build_cached_biopolymer_cartoon_world_mesh;
 use super::scene::{BondWorldSegment, bond_world_segments};
 use super::{
     AROMATIC_DASH_LENGTH, AROMATIC_DASH_OFFSET, AROMATIC_DASH_RADIUS, AROMATIC_GAP_LENGTH,
@@ -26,10 +32,37 @@ use super::{
 /// become small shaded spheres rather than flat screen-space discs.
 const POINT_SPHERE_SCALE: f32 = 0.5;
 
+#[cfg(test)]
 pub(crate) fn build_molecule_instances(
     structure: &Structure,
     selection: &AtomSelection,
     visual_state: &ViewportVisualState,
+) -> MoleculeInstances {
+    let cartoon = build_biopolymer_cartoon_world_mesh(structure, visual_state);
+    build_molecule_instances_with_cartoon(structure, selection, visual_state, cartoon)
+}
+
+pub(crate) fn build_cached_molecule_instances(
+    structure: &Structure,
+    selection: &AtomSelection,
+    visual_state: &ViewportVisualState,
+    secondary_cache: &mut SecondaryStructureCache,
+    secondary_key: SecondaryStructureCacheKey,
+) -> MoleculeInstances {
+    let cartoon = build_cached_biopolymer_cartoon_world_mesh(
+        structure,
+        visual_state,
+        secondary_cache,
+        secondary_key,
+    );
+    build_molecule_instances_with_cartoon(structure, selection, visual_state, cartoon)
+}
+
+fn build_molecule_instances_with_cartoon(
+    structure: &Structure,
+    selection: &AtomSelection,
+    visual_state: &ViewportVisualState,
+    cartoon: Vec<MeshVertex>,
 ) -> MoleculeInstances {
     let atom_draw = build_atom_draw_table(structure, selection, visual_state);
 
@@ -72,7 +105,7 @@ pub(crate) fn build_molecule_instances(
     MoleculeInstances {
         spheres,
         cylinders,
-        cartoon: build_biopolymer_cartoon_world_mesh(structure, visual_state),
+        cartoon,
         ..Default::default()
     }
 }

--- a/src/frontend/viewport/visual_state.rs
+++ b/src/frontend/viewport/visual_state.rs
@@ -278,13 +278,18 @@ impl ViewportVisualState {
     }
 
     /// Whether the cartoon ribbon overlay applies to an atom. Independent of the
-    /// base style: polymers (whose software default is `Cartoon`) show a ribbon
-    /// unless explicitly turned off, so a protein can be ball-and-stick *and*
-    /// cartoon at once. Only standard amino-acid residues actually draw a ribbon
-    /// (enforced by the cartoon renderer).
+    /// base style: polymers show a ribbon unless explicitly turned off, so a
+    /// protein can be ball-and-stick *and* cartoon at once.
+    ///
+    /// Cartoon defaults on for anything the renderer can actually draw as a
+    /// ribbon — a peptide backbone (decided from atoms via
+    /// [`Structure::atom_has_peptide_backbone`], so force-field-protonated,
+    /// disulfide, and modified residues count too) or a category whose software
+    /// default is cartoon (e.g. nucleic acids). The residue name never gates this.
     pub fn cartoon_enabled(&self, structure: &Structure, atom_index: usize) -> bool {
         let category = structure.atom_category(atom_index);
-        let default_on = software_default_style(category) == AtomStyle::Cartoon;
+        let default_on = structure.atom_has_peptide_backbone(atom_index)
+            || software_default_style(category) == AtomStyle::Cartoon;
         self.cartoon_overlay
             .enabled(category, atom_index, default_on)
     }


### PR DESCRIPTION
Decide cartoon renderability, contiguity, and secondary structure from atoms and coordinates instead of residue names and sequence numbers.

- **Renderability from topology** — a residue ribbons when it carries an N/CA/C backbone, read from invariant atom names. Force-field-protonated, disulfide, and modified residues (HID, CYX, MSE, SEP, …) no longer drop out of the ribbon.
- **Geometric contiguity** — fragments split on a real C(i)–N(i+1) / Cα–Cα spatial break, not on numbering jumps, so renumbering and insertion codes don't shred a continuous ribbon.
- **DSSP assignment** (Kabsch–Sander H-bond network) for full N/CA/C/O backbones, with the Cα-only P-SEA criterion as fallback — fixes β-strand over-assignment on extended loops.
- **Secondary-structure cache** keyed by structure id + revision, so DSSP isn't recomputed every frame (CPU and GPU paths).

`cargo fmt --check`, `clippy --workspace --all-targets --all-features`, and `test --workspace --all-features` pass locally with `-D warnings`.