### PR TITLE
fix(gromacs): make built glycan MD systems solvate and run end-to-end

### DIFF
--- a/compute-core/src/engines/gromacs/carb_topology.rs
+++ b/compute-core/src/engines/gromacs/carb_topology.rs
@@ -413,6 +413,9 @@ mod tests {
         assert!(!top.contains("forcefield.itp"));
         assert!(top.contains("[ defaults ]"));
         assert!(top.contains("1         2"));
+        // Solvent/ion molecule types, so a later solvate/genion can resolve them.
+        assert!(top.contains("tip3p.itp"));
+        assert!(top.contains("ions.itp"));
     }
 
     #[test]

--- a/compute-core/src/engines/gromacs/forcefield_assets.rs
+++ b/compute-core/src/engines/gromacs/forcefield_assets.rs
@@ -49,6 +49,11 @@ const CHARMM36_FILES: &[(&str, &str)] = &[
 pub const GLYCAN_FORCE_FIELD_INCLUDES: &[&str] =
     &["ffnonbonded.itp", "ffbonded.itp", "cmap.itp", "nbfix.itp"];
 
+/// Water (`SOL`) and ion (`NA`/`CL`) molecule-type files the self-contained
+/// glycan topology must `#include`, so a later `solvate`/`genion` step can
+/// resolve what it appends to `[ molecules ]` — as a pdb2gmx topology would.
+const GLYCAN_SOLVENT_INCLUDES: &[&str] = &["tip3p.itp", "ions.itp"];
+
 pub struct ForceFieldBundle {
     pub token: &'static str,
     files: &'static [(&'static str, &'static str)],
@@ -100,7 +105,10 @@ pub fn glycan_force_field_includes(token: &str) -> Result<String> {
         .ok_or_else(|| anyhow::anyhow!("no bundled force field for token `{token}`"))?;
     let dir = bundle.dir_name();
     let mut text = String::new();
-    for name in GLYCAN_FORCE_FIELD_INCLUDES {
+    for name in GLYCAN_FORCE_FIELD_INCLUDES
+        .iter()
+        .chain(GLYCAN_SOLVENT_INCLUDES)
+    {
         text.push_str(&format!("#include \"{dir}/{name}\"\n"));
     }
     Ok(text)
@@ -408,6 +416,9 @@ mod tests {
         assert!(includes.contains(&format!("{CHARMM36_TOKEN}.ff/ffnonbonded.itp")));
         assert!(includes.contains("cmap.itp"));
         assert!(!includes.contains("forcefield.itp"));
+        // Water and ions, so a later solvate/genion's `SOL`/`NA`/`CL` resolve.
+        assert!(includes.contains(&format!("{CHARMM36_TOKEN}.ff/tip3p.itp")));
+        assert!(includes.contains(&format!("{CHARMM36_TOKEN}.ff/ions.itp")));
     }
 
     #[test]

--- a/compute-core/src/engines/gromacs/runner.rs
+++ b/compute-core/src/engines/gromacs/runner.rs
@@ -252,10 +252,11 @@ pub fn prepare_system(request: PrepareSystemRequest) -> Result<PreparedSystem> {
     })
 }
 
-/// Copy the `.itp` files sitting beside a file topology into the run directory,
-/// so `#include` directives (such as `posre.itp` for position restraints) resolve
-/// when the run directory differs from the topology's source directory. A no-op
-/// when they are the same directory; best-effort if the source dir can't be read.
+/// Copy what a file topology `#include`s — sibling `.itp` files (e.g. pdb2gmx's
+/// `posre.itp`) and any staged force-field directory (`charmm36.ff/…`) — from the
+/// topology's source directory into the run directory, so the relative includes
+/// resolve when the two directories differ. No-op when they are the same;
+/// best-effort if the source dir can't be read.
 fn copy_topology_includes(topology_source: &Path, target_dir: &Path) -> Result<()> {
     let Some(source_dir) = topology_source.parent() else {
         return Ok(());
@@ -268,10 +269,39 @@ fn copy_topology_includes(topology_source: &Path, target_dir: &Path) -> Result<(
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().and_then(|ext| ext.to_str()) == Some("itp")
-            && let Some(name) = path.file_name()
-        {
+        let Some(name) = path.file_name() else {
+            continue;
+        };
+        if path.is_dir() {
+            // A staged force-field bundle is a `<name>.ff` directory included by
+            // relative path; carry the whole tree over.
+            if path.extension().and_then(|ext| ext.to_str()) == Some("ff") {
+                copy_dir_recursive(&path, &target_dir.join(name))?;
+            }
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("itp") {
             fs::copy(&path, target_dir.join(name))
+                .with_context(|| format!("copying topology include {}", path.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn copy_dir_recursive(source: &Path, target: &Path) -> Result<()> {
+    fs::create_dir_all(target)
+        .with_context(|| format!("creating include directory {}", target.display()))?;
+    for entry in fs::read_dir(source)
+        .with_context(|| format!("reading include directory {}", source.display()))?
+        .flatten()
+    {
+        let path = entry.path();
+        let Some(name) = path.file_name() else {
+            continue;
+        };
+        let dest = target.join(name);
+        if path.is_dir() {
+            copy_dir_recursive(&path, &dest)?;
+        } else {
+            fs::copy(&path, &dest)
                 .with_context(|| format!("copying topology include {}", path.display()))?;
         }
     }
@@ -1079,6 +1109,28 @@ AR  8
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn copy_topology_includes_carries_itp_files_and_staged_force_field() {
+        let root = std::env::temp_dir().join("silicolab_copy_includes_test");
+        let _ = fs::remove_dir_all(&root);
+        let build = root.join("build");
+        let run = root.join("run");
+        fs::create_dir_all(build.join("charmm36.ff")).unwrap();
+        fs::create_dir_all(&run).unwrap();
+
+        fs::write(build.join("topol.top"), "; top\n").unwrap();
+        fs::write(build.join("posre.itp"), "; restraints\n").unwrap();
+        fs::write(build.join("charmm36.ff/ffnonbonded.itp"), "; nb\n").unwrap();
+
+        copy_topology_includes(&build.join("topol.top"), &run).unwrap();
+
+        // Both the sibling .itp and the whole staged force-field tree carry over.
+        assert!(run.join("posre.itp").exists());
+        assert!(run.join("charmm36.ff/ffnonbonded.itp").exists());
+
+        let _ = fs::remove_dir_all(&root);
     }
 
     /// Real end-to-end energy minimization through the WSL GROMACS launch.


### PR DESCRIPTION
## Problem

The `glycan` → MD System Builder → Run MD pipeline failed in two places when
using the vendored CHARMM36 force field:

1. **Build (`solvate`/`genion`):** `gmx grompp` failed with
   `No such moleculetype SOL`. The self-contained glycan topology included only
   the force field's atom/bonded parameter files, so when `gmx solvate`/`genion`
   appended `SOL`/`NA`/`CL` to `[ molecules ]`, grompp had no definition for them.

2. **Run MD (EM):** `gmx grompp` failed with
   `Topology include file "charmm36.ff/ffnonbonded.itp" not found`. Reusing the
   built `topol.top` from a fresh run directory copied only sibling `.itp` files,
   not the staged `charmm36.ff/` directory the topology `#include`s by relative path.

## Fix

- **`forcefield_assets.rs`** — append the water (`tip3p.itp`) and ion (`ions.itp`)
  molecule-type includes to the glycan topology, mirroring what a pdb2gmx-written
  `topol.top` provides.
- **`runner.rs`** — when reusing a file topology, copy sibling `*.ff` force-field
  trees into the run directory alongside the `.itp` files, so relative `#include`s
  resolve.

## Verification

- New/updated unit tests; full gromacs suite passes (90), clippy clean.
- Verified end-to-end against GROMACS 2026.2: solvate/genion build completes and
  EM `grompp` produces a valid `.tpr`. Confirmed working in the real app.