### PR TITLE
docs: keep each fact in one owning document

### DIFF
--- a/.rules
+++ b/.rules
@@ -57,3 +57,4 @@ The GUI uses an Elm-style flow.
 
 These rules are read by every agent session. Add new rules only for non-obvious, repeated traps. Prefer keeping this file small.
 Remove obsolete rules when architecture changes; stale rules are worse than missing rules.
+Each fact has one owning document; reference it from elsewhere, never restate its value (a copied threshold or command drifts the moment the owner changes).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,5 +66,5 @@ Set `RUSTFLAGS=-D warnings` so clippy and test fail on warnings exactly as CI do
 ## Code conventions
 
 - **Single-responsibility files.** Split into modules rather than letting a file
-  accumulate — keep source files under 600 *code* lines (soft target ~400), per
-  [`.rules`](.rules). This is a modular Cargo workspace; lean on the module system.
+  accumulate; see [`.rules`](.rules) for the current size budget. This is a
+  modular Cargo workspace; lean on the module system.


### PR DESCRIPTION
## What

Make `.rules` the single owner of the file-size budget, and record the underlying principle: keep each fact in one document and reference it from elsewhere rather than restating its value.

## Why

PR #6 moved the size rule to **800 physical lines** (enforced by CI), but `CONTRIBUTING.md` still restated it as "600 *code* lines (soft ~400), per `.rules`" — disagreeing with both `.rules` and CI in the harmful direction, telling contributors to over-split files against a budget CI doesn't enforce.

The root cause isn't a topic-boundary problem; it's a single-source-of-truth violation — a copied threshold drifts the moment its owner changes.

## Changes

- **`CONTRIBUTING.md`** — drop the duplicated number/metric, keep only the pointer to `.rules`.
- **`.rules`** (Rules hygiene) — add: each fact has one owning document; reference it from elsewhere, never restate its value.
