### PR TITLE
fix(io): bond deposited biomolecules non-periodically to stop the open freeze

### DIFF
--- a/compute-core/src/domain/structure.rs
+++ b/compute-core/src/domain/structure.rs
@@ -163,7 +163,12 @@ impl Structure {
     }
 
     pub fn recompute_bonds(&mut self) {
-        self.bonds = chemistry::infer_bonds_with_cell(&self.atoms, self.cell.as_ref());
+        // A deposited biomolecule is bonded non-periodically (see the PDB/mmCIF
+        // readers); only genuine periodic materials bond through the cell. Honor
+        // the same invariant here so the GUI "recompute bonds" action can't
+        // re-introduce the periodic path's freeze and spurious cross-cell bonds.
+        let bonding_cell = self.cell.as_ref().filter(|_| self.biopolymer.is_none());
+        self.bonds = chemistry::infer_bonds_with_cell(&self.atoms, bonding_cell);
     }
 
     pub fn add_bond(&mut self, a: usize, b: usize, bond_type: BondType) {

--- a/compute-core/src/io/formats/cif.rs
+++ b/compute-core/src/io/formats/cif.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, anyhow, bail};
 
 use crate::{
-    domain::chemistry::normalized_symbol,
+    domain::chemistry::{infer_bonds_with_cell, normalized_symbol},
     domain::{Atom, PdbAtomAnnotation, Structure, UnitCell, build_biopolymer},
 };
 
@@ -101,6 +101,13 @@ fn parse_mmcif(input: &str) -> Result<Structure> {
         .and_then(|annotations| build_biopolymer(&annotations, Vec::new()));
 
     let mut structure = match cell {
+        // See the PDB reader: a deposited biomolecule is bonded non-periodically
+        // even when it carries a crystallographic cell, which is kept for display
+        // and PBC.
+        Some(cell) if biopolymer.is_some() => {
+            let bonds = infer_bonds_with_cell(&atoms, None);
+            Structure::with_cell_and_bonds(title, atoms, bonds, cell)
+        }
         Some(cell) => Structure::with_cell(title, atoms, cell),
         None => Structure::new(title, atoms),
     };
@@ -534,6 +541,52 @@ HETATM 5 C  C1  MAN B 2 8.000 0.800 0.000
         assert_eq!(structure.atom_category(0), AtomCategory::Protein);
         assert_eq!(structure.atom_category(2), AtomCategory::Carbohydrate);
         assert_eq!(structure.atom_category(4), AtomCategory::Carbohydrate);
+    }
+
+    #[test]
+    fn deposited_protein_mmcif_with_real_cell_is_bonded_nonperiodically() {
+        // Same 1HKN regression as the PDB reader, for the mmCIF path: a protein that
+        // carries a real cell is bonded non-periodically (the two backbone nitrogens
+        // are 9.8 A apart in Cartesian but 0.2 A under minimum image), while the cell
+        // is preserved for display/PBC.
+        let structure = parse_cif(
+            "\
+data_peptide
+_cell.length_a 10.000
+_cell.length_b 10.000
+_cell.length_c 10.000
+_cell.angle_alpha 90
+_cell.angle_beta 90
+_cell.angle_gamma 90
+loop_
+_atom_site.group_PDB
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_comp_id
+_atom_site.label_asym_id
+_atom_site.auth_seq_id
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+ATOM 1 N N ALA A 1 0.100 0.000 0.000
+ATOM 2 N N ALA A 2 9.900 0.000 0.000
+",
+        )
+        .expect("valid mmcif");
+
+        assert!(
+            structure.biopolymer.is_some(),
+            "ALA residues form a biopolymer"
+        );
+        assert!(
+            structure.cell.is_some(),
+            "the cell is preserved for display/PBC"
+        );
+        assert!(
+            structure.bonds.is_empty(),
+            "minimum-image must not fabricate a cross-cell bond for a deposited biomolecule"
+        );
     }
 
     #[test]

--- a/compute-core/src/io/formats/pdb/read.rs
+++ b/compute-core/src/io/formats/pdb/read.rs
@@ -152,16 +152,25 @@ fn build_model_structure(
         other => other.cloned(),
     };
 
+    let biopolymer = build_biopolymer(&annotations, secondary_structures.to_vec());
+
+    // A deposited biomolecule's covalent graph is intramolecular (plus the
+    // explicit CONECT/LINK records). Its crystallographic cell tiles space by
+    // symmetry operators, not the pure translation that minimum-image bonding
+    // assumes, so periodic inference across that cell discovers no real bonds and
+    // only fabricates false ones — and on a large structure its O(n^2) form
+    // stalls the load. Bond such structures non-periodically; the cell is still
+    // stored below for display and PBC.
+    let bonding_cell = effective_cell.as_ref().filter(|_| biopolymer.is_none());
+
     let bonds = resolve_bonds(
         &atoms,
-        effective_cell.as_ref(),
+        bonding_cell,
         &serial_to_index,
         &identity_to_index,
         conect_pairs,
         link_pairs,
     );
-
-    let biopolymer = build_biopolymer(&annotations, secondary_structures.to_vec());
 
     let mut structure = match effective_cell {
         Some(cell) => Structure::with_cell_and_bonds(title, atoms, bonds, cell),

--- a/compute-core/src/io/formats/pdb/tests.rs
+++ b/compute-core/src/io/formats/pdb/tests.rs
@@ -297,3 +297,88 @@ END
         "the cross-residue bond must survive a to_pdb / parse round trip"
     );
 }
+
+#[test]
+fn deposited_protein_with_real_cell_is_bonded_nonperiodically() {
+    // 1HKN regression: a deposited biomolecule that carries a real crystallographic
+    // cell must be bonded from its single Cartesian frame, never by minimum-image
+    // across the cell — which fabricates bonds and, on a large structure, stalls the
+    // load on the O(n^2) periodic path. The cell is still kept for display/PBC.
+    //
+    // The two backbone nitrogens sit at x=0.1 and x=9.9 in a 10 A cell: 9.8 A apart
+    // in raw Cartesian (no bond), but 0.2 A apart under minimum image (would bond).
+    let structure = parse_pdb(
+        "\
+TITLE     two-residue peptide in a real cell
+CRYST1   10.000   10.000   10.000  90.00  90.00  90.00 P 1
+ATOM      1  N   ALA A   1       0.100   0.000   0.000  1.00  0.00           N
+ATOM      2  N   ALA A   2       9.900   0.000   0.000  1.00  0.00           N
+END
+",
+    )
+    .expect("valid pdb");
+
+    assert!(
+        structure.biopolymer.is_some(),
+        "standard amino acids must be recognized as a biopolymer"
+    );
+    assert!(
+        structure.cell.is_some(),
+        "the crystallographic cell is preserved for display/PBC"
+    );
+    assert!(
+        structure.bonds.is_empty(),
+        "minimum-image must not fabricate a cross-cell bond for a deposited biomolecule"
+    );
+}
+
+#[test]
+fn non_biopolymer_with_real_cell_still_bonds_periodically() {
+    // The contrast that pins the discriminator: the same cross-cell pair, but as a
+    // material / small-molecule crystal (no biopolymer overlay), keeps periodic
+    // bonding, so the minimum-image bond across the 10 A cell is still found.
+    let structure = parse_pdb(
+        "\
+TITLE     two atoms in a real cell
+CRYST1   10.000   10.000   10.000  90.00  90.00  90.00 P 1
+ATOM      1  C1  LIG A   1       0.100   0.000   0.000  1.00  0.00           C
+ATOM      2  C2  LIG A   1       9.900   0.000   0.000  1.00  0.00           C
+END
+",
+    )
+    .expect("valid pdb");
+
+    assert!(
+        structure.biopolymer.is_none(),
+        "a non-standard ligand residue is not a biopolymer"
+    );
+    assert_eq!(
+        structure.bonds.len(),
+        1,
+        "a material/small-molecule crystal keeps minimum-image periodic bonding"
+    );
+}
+
+#[test]
+fn recompute_bonds_keeps_deposited_biomolecules_nonperiodic() {
+    // The non-periodic invariant must also survive a bond recomputation (the GUI
+    // "recompute bonds" action), or that path would re-freeze and re-fabricate the
+    // cross-cell bond the loader avoids.
+    let mut structure = parse_pdb(
+        "\
+TITLE     two-residue peptide in a real cell
+CRYST1   10.000   10.000   10.000  90.00  90.00  90.00 P 1
+ATOM      1  N   ALA A   1       0.100   0.000   0.000  1.00  0.00           N
+ATOM      2  N   ALA A   2       9.900   0.000   0.000  1.00  0.00           N
+END
+",
+    )
+    .expect("valid pdb");
+
+    structure.recompute_bonds();
+
+    assert!(
+        structure.bonds.is_empty(),
+        "recompute must not periodically re-bond a deposited biomolecule"
+    );
+}


### PR DESCRIPTION
## Problem

Opening a deposited protein with a real crystallographic cell froze the app. `1HKN` (an FGF complex — 6 chains, ~6.3k atoms, monoclinic `CRYST1`) hung the UI for ~2.8 s in release, and tens of seconds in a debug build.

Root cause: the PDB/mmCIF readers fed the crystallographic cell straight into `infer_bonds_with_cell`, which switches to an **O(n²)** minimum-image path when a real cell is present — and each atom pair recomputes a 3×3 matrix inverse twice via `cartesian_to_fractional`. For 6.3k atoms that's ~20M pairs and ~40M inversions, run **synchronously on the UI thread**.

It was also a correctness bug, not just a perf one: a deposited biomolecule is one un-wrapped Cartesian frame whose lattice tiles space by symmetry operators, not pure translation. Minimum-image bonding across that cell discovers no real bonds and can only fabricate false cross-cell / cross-chain ones.

## Fix

Gate periodic bond inference on **biopolymer absence** at every entry point that infers bonds:

- PDB reader (`pdb/read.rs`)
- mmCIF reader (`cif.rs`) — the bug was format-agnostic
- `Structure::recompute_bonds` (the GUI "recompute bonds" action) — so the invariant holds through a structure's whole lifecycle, not just at load

Deposited biomolecules (proteins / nucleic acids / carbohydrates) take the existing O(n) spatial-bucket path; the crystallographic cell is still stored for display and PBC. Genuine periodic materials (no biopolymer overlay) are unchanged.

## Verification

- `1HKN` parse: **2.78 s → 20 ms** (release); the real cell is still preserved.
- 4 new regression tests: PDB + mmCIF protein → non-periodic; non-biopolymer crystal → still periodic (pins the discriminator); recompute path → stays non-periodic.
- Full `compute-core` suite: **612 passed, 0 failed**. `cargo fmt --check` clean; `cargo clippy --workspace -D warnings` clean.

## Out of scope (noted follow-ups)

- The periodic path itself is still O(n²) with a per-call matrix inverse. Only materials reach it now, so it is no longer a freeze, but a very large supercell could be slow; hardening it (spatial buckets + cached cell inverse) is a separate change.
- A malformed (empty) `CONECT` line currently aborts the whole parse (e.g. 2RCU) — an unrelated, pre-existing robustness issue.
