### PR TITLE
chore(deps): update hartree to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2609,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "hartree"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf9e98ac8d12fc156224bb4c74d868d13a911d7622e7a4afe101cfe7699214"
+checksum = "a2f7600d91c169a260fd3275a7a7c221eab7ea96a589ed76096899b116912977"
 dependencies = [
  "faer",
  "integral",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ egui_commonmark = { version = "0.23", default-features = false, features = [
     "pulldown_cmark",
 ] }
 flate2 = "1"
-hartree = "0.2.0"
+hartree = "0.2.1"
 image = { version = "0.25", default-features = false, features = ["png"] }
 nalgebra = "0.35.0"
 rfd = "0.17"

--- a/compute-core/Cargo.toml
+++ b/compute-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = "1.0"
 docking = "0.1.0"
-hartree = "0.2.0"
+hartree = "0.2.1"
 nalgebra = "0.35.0"
 rayon = "1"
 sdfrust = "0.6"


### PR DESCRIPTION
## What

Bump `hartree` from `0.2.0` to `0.2.1` (workspace root + `compute-core`, plus `Cargo.lock`).

## Why

0.2.1 is a performance release. It speeds up **r2scan-3c SCF by ~3.7-5.4x** via a point-efficient default integration grid and a superposition-of-atomic-densities (SAD) initial guess. Since `r2scan-3c` is our default/recommended DFT method, this directly cuts QM job runtimes with no API changes on our side.

Upstream: https://github.com/nmrtist/hartree

## Verification

Simulated CI locally — all green:
- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets --all-features` (`-D warnings`) ✓
- worker pure-Rust dependency check ✓
- `cargo test --workspace --all-features` ✓ (937 passed, 0 failed)