### PR TITLE
feat(agent): risk-tiered command approval with modes, memory, and batch cards

### DIFF
--- a/src/backend/assistant_config.rs
+++ b/src/backend/assistant_config.rs
@@ -1,0 +1,105 @@
+//! Persisted settings for the in-app LLM assistant: provider/model selection and
+//! the command-approval policy. Re-exported from [`super::config`].
+
+use serde::{Deserialize, Serialize};
+
+/// How aggressively assistant-issued commands auto-run. Combined with each
+/// command's `RiskLevel` (declared in the console grammar) to decide whether a
+/// call runs immediately or waits for the user. Destructive commands always
+/// prompt, in every mode — the non-bypassable floor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum ApprovalMode {
+    /// Confirm every structure-editing, file-writing, compute, or destructive
+    /// command.
+    Manual,
+    /// Auto-run read-only and in-memory structure edits; confirm file writes,
+    /// compute, and destructive ones. The default.
+    #[default]
+    AutoSafe,
+    /// Auto-run everything except destructive commands.
+    Auto,
+    /// Never execute — the assistant only proposes commands for the user to run.
+    Plan,
+}
+
+impl ApprovalMode {
+    pub fn all() -> [ApprovalMode; 4] {
+        [
+            ApprovalMode::Manual,
+            ApprovalMode::AutoSafe,
+            ApprovalMode::Auto,
+            ApprovalMode::Plan,
+        ]
+    }
+
+    /// Full description for a menu row.
+    pub fn label(self) -> &'static str {
+        match self {
+            ApprovalMode::Manual => "Manual — confirm edits, writes, compute & destructive",
+            ApprovalMode::AutoSafe => "Auto (safe) — confirm writes, compute & destructive",
+            ApprovalMode::Auto => "Auto — confirm destructive only",
+            ApprovalMode::Plan => "Plan — propose only, never run",
+        }
+    }
+
+    /// Compact label for the collapsed picker.
+    pub fn short_label(self) -> &'static str {
+        match self {
+            ApprovalMode::Manual => "Manual",
+            ApprovalMode::AutoSafe => "Auto (safe)",
+            ApprovalMode::Auto => "Auto",
+            ApprovalMode::Plan => "Plan",
+        }
+    }
+}
+
+/// Settings for the in-app LLM assistant. Holds only non-secret selection: the
+/// provider id, model, effort, an optional `base_url` override for
+/// OpenAI-compatible providers, and the command-approval policy. **The API key is
+/// never stored here** — it is read from the provider's environment variable at
+/// call time (see `frontend::agent::registry`), preserving the
+/// no-secrets-in-config invariant SSH already follows.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantConfig {
+    /// Whether the assistant is usable (the Assistant tab still renders a hint when a
+    /// key is missing). On by default.
+    pub enabled: bool,
+    /// Active provider id, keyed into `frontend::agent::registry::PROVIDERS`.
+    pub provider: String,
+    /// Active model id within the selected provider.
+    pub model: String,
+    /// Reasoning effort; adapters map or drop it per model capability.
+    pub effort: crate::io::llm::types::Effort,
+    /// Base-URL override for OpenAI-compatible providers. `None` uses
+    /// the provider's registry default. Non-secret.
+    #[serde(default)]
+    pub base_url: Option<String>,
+    /// Per-model override for whether the active OpenAI-compatible model accepts
+    /// a reasoning-effort knob. `None` uses the registry heuristic (known model
+    /// → its declared capability; unknown / free-typed id → assume yes); `Some`
+    /// pins it. Lets users point a custom endpoint at a reasoning model the
+    /// built-in table can't know about — or silence the picker for one that
+    /// rejects the knob. Reset when the model or provider changes. Non-secret.
+    #[serde(default)]
+    pub effort_override: Option<bool>,
+    /// How much of what the assistant proposes auto-runs. `#[serde(default)]` so
+    /// an older `settings.json` parses to the default (AutoSafe).
+    #[serde(default)]
+    pub approval_mode: ApprovalMode,
+}
+
+impl Default for AssistantConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            provider: "anthropic".to_string(),
+            // Sonnet 4.6: cheaper/faster than Opus, very strong tool use — the
+            // recommended default driver (Opus 4.8 remains selectable).
+            model: "claude-sonnet-4-6".to_string(),
+            effort: crate::io::llm::types::Effort::High,
+            base_url: None,
+            effort_override: None,
+            approval_mode: ApprovalMode::default(),
+        }
+    }
+}

--- a/src/backend/config.rs
+++ b/src/backend/config.rs
@@ -15,6 +15,8 @@ use crate::engines::registry::EngineLaunch;
 use compute_core::hosts::home_dir;
 pub use compute_core::hosts::{RemoteHost, ResourceSpec, config_dir};
 
+pub use crate::backend::assistant_config::{ApprovalMode, AssistantConfig};
+
 /// How the interface picks its light/dark appearance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum ThemeMode {
@@ -131,52 +133,6 @@ pub enum ComputeTarget {
     Local,
     /// Run on the remote host with this [`RemoteHost::id`].
     Remote(String),
-}
-
-/// Settings for the in-app LLM assistant. Holds only non-secret selection: the
-/// provider id, model, effort, and an optional `base_url` override for
-/// OpenAI-compatible providers. **The API key is never stored here** — it is read
-/// from the provider's environment variable at call time (see
-/// `frontend::agent::registry`), preserving the no-secrets-in-config invariant
-/// SSH already follows.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AssistantConfig {
-    /// Whether the assistant is usable (the Assistant tab still renders a hint when a
-    /// key is missing). On by default.
-    pub enabled: bool,
-    /// Active provider id, keyed into `frontend::agent::registry::PROVIDERS`.
-    pub provider: String,
-    /// Active model id within the selected provider.
-    pub model: String,
-    /// Reasoning effort; adapters map or drop it per model capability.
-    pub effort: crate::io::llm::types::Effort,
-    /// Base-URL override for OpenAI-compatible providers. `None` uses
-    /// the provider's registry default. Non-secret.
-    #[serde(default)]
-    pub base_url: Option<String>,
-    /// Per-model override for whether the active OpenAI-compatible model accepts
-    /// a reasoning-effort knob. `None` uses the registry heuristic (known model
-    /// → its declared capability; unknown / free-typed id → assume yes); `Some`
-    /// pins it. Lets users point a custom endpoint at a reasoning model the
-    /// built-in table can't know about — or silence the picker for one that
-    /// rejects the knob. Reset when the model or provider changes. Non-secret.
-    #[serde(default)]
-    pub effort_override: Option<bool>,
-}
-
-impl Default for AssistantConfig {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            provider: "anthropic".to_string(),
-            // Sonnet 4.6: cheaper/faster than Opus, very strong tool use — the
-            // recommended default driver (Opus 4.8 remains selectable).
-            model: "claude-sonnet-4-6".to_string(),
-            effort: crate::io::llm::types::Effort::High,
-            base_url: None,
-            effort_override: None,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,3 +1,4 @@
+pub mod assistant_config;
 pub mod config;
 pub mod entries;
 pub mod force_fields;

--- a/src/frontend/actions.rs
+++ b/src/frontend/actions.rs
@@ -294,10 +294,16 @@ pub enum AppAction {
     DeleteAssistantConversation(crate::frontend::agent::AssistantConversationId),
     /// Cancel the in-flight assistant turn and any pending tool batch.
     CancelAgent,
-    /// Approve the gated (destructive/expensive) tool call with this id.
+    /// Approve the gated (compute/destructive) tool call with this id.
     ApproveToolCall(String),
     /// Reject the gated tool call with this id (the model gets an error result).
     RejectToolCall(String),
+    /// Approve this id and auto-allow its command verb for the rest of the chat.
+    AlwaysAllowCommand(String),
+    /// Approve this id and auto-allow its whole risk level for the rest of the chat.
+    AlwaysAllowRisk(String),
+    /// Set the assistant's command-approval mode and persist.
+    SetApprovalMode(crate::backend::config::ApprovalMode),
     /// Drop the queued (type-ahead) assistant follow-up message at this index.
     RemoveQueuedAgentInput(usize),
     /// Cancel the running background (qm/md/dock) agent job with this id.

--- a/src/frontend/agent/loop_driver.rs
+++ b/src/frontend/agent/loop_driver.rs
@@ -56,9 +56,12 @@ Working style:
 what is loaded.
 - Take one concrete step at a time and keep your prose short; the user sees both your \
 text and the commands you run.
-- Destructive or expensive commands (delete, save, md, qm, running a script) are gated: \
-when you call one, the user is asked to approve it first. Call them anyway when they are \
-the right step; explain why briefly.
+- Commands are risk-classified (read-only, structure edit, file write, compute, destructive). \
+Whether one needs the user's approval depends on their approval mode; destructive commands \
+(delete, running a script) always ask. When approval is pending the user sees a card and \
+decides. Call the right command regardless and explain briefly. In Plan mode your console \
+commands are recorded as proposals, not run — but you can still `inspect` and read state to \
+ground the plan.
 - Heavy computations (qm energy/optimize/freq, md run/simulate, dock) run in the BACKGROUND. \
 The tool returns immediately with a job id and you get control back right away — do NOT wait \
 for the result inline. Tell the user it started, then help with something else or stop. When \

--- a/src/frontend/agent/loop_driver/heavy.rs
+++ b/src/frontend/agent/loop_driver/heavy.rs
@@ -59,6 +59,21 @@ pub fn heavy_kind_of(call: &ToolCall) -> Option<HeavyKind> {
     }
 }
 
+/// A short cost/impact hint for an approval card, or `None` when the call has no
+/// special cost (only heavy commands, which run off-thread one at a time, have one).
+pub fn impact_hint(call: &ToolCall) -> Option<String> {
+    let kind = heavy_kind_of(call)?;
+    let command = call
+        .input
+        .get("command")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    Some(format!(
+        "{} — heavy compute; runs in the background, one job at a time",
+        heavy_label(kind, command)
+    ))
+}
+
 /// A short human label for a heavy command, e.g. `qm optimize`, `md run`, `dock`.
 fn heavy_label(kind: HeavyKind, command: &str) -> String {
     let sub = command.split_whitespace().nth(1).unwrap_or("");

--- a/src/frontend/agent/loop_driver/settings.rs
+++ b/src/frontend/agent/loop_driver/settings.rs
@@ -2,6 +2,7 @@ use super::*;
 
 use eframe::egui;
 
+use crate::backend::config::ApprovalMode;
 use crate::frontend::agent::registry;
 use crate::frontend::agent::session::{AssistantConversationId, ModelFetchStatus};
 use crate::frontend::jobs::spawn_model_fetch;
@@ -75,6 +76,12 @@ pub fn set_assistant_enabled(state: &mut AppState, enabled: bool) {
 /// Set the reasoning effort and persist.
 pub fn set_assistant_effort(state: &mut AppState, effort: Effort) {
     state.config.assistant.effort = effort;
+    persist(state);
+}
+
+/// Set the command-approval mode and persist.
+pub fn set_approval_mode(state: &mut AppState, mode: ApprovalMode) {
+    state.config.assistant.approval_mode = mode;
     persist(state);
 }
 

--- a/src/frontend/agent/loop_driver/tests/jobs.rs
+++ b/src/frontend/agent/loop_driver/tests/jobs.rs
@@ -1,0 +1,319 @@
+use super::super::*;
+use super::{enabled_state, fake_qm_job};
+
+use crate::engines::qm::QmOutcome;
+use crate::frontend::agent::session::{AgentPhase, ModelFetchStatus, PendingTurn, TranscriptEntry};
+use crate::frontend::jobs::QmWorkerMessage;
+use crate::frontend::state::AppState;
+use crate::io::llm::types::{ChatMessage, ContentBlock, LlmError, ReasoningBlob, Role, ToolCall};
+
+use eframe::egui;
+use serde_json::json;
+
+#[test]
+fn job_done_is_consumed_when_idle() {
+    let mut state = enabled_state();
+    let ctx = egui::Context::default();
+    state.ui.agent.queued.push_back(PendingTurn::JobDone {
+        label: "qm optimize".into(),
+        summary: "E = -1.0 Ha".into(),
+        is_error: false,
+    });
+    state.ui.agent.phase = AgentPhase::Done;
+
+    pump_queue(&mut state, &ctx);
+
+    assert!(
+        state.ui.agent.queued.is_empty(),
+        "an idle pump consumes a queued JobDone to wake the model"
+    );
+}
+
+#[test]
+fn heavy_launch_is_refused_while_one_is_running() {
+    let mut state = enabled_state();
+    let ctx = egui::Context::default();
+    let conversation = state.ui.agent.active_conversation;
+    let (_tx, rx) = std::sync::mpsc::channel();
+    state.jobs.agent_jobs.push(fake_qm_job(1, conversation, rx));
+
+    let call = ToolCall {
+        id: "c1".into(),
+        name: "run_command".into(),
+        input: json!({ "command": "qm energy --basis sto-3g" }),
+    };
+    dispatch_call(&mut state, &call, &ctx);
+
+    // No second job spawned â€” serialized to one.
+    assert_eq!(state.jobs.agent_jobs.len(), 1);
+    // The model is told to wait, not handed an error.
+    let told_to_wait = state.ui.agent.transcript.iter().any(|entry| {
+        matches!(
+            entry,
+            TranscriptEntry::Tool { result: Some(text), is_error: false, .. }
+            if text.contains("already running")
+        )
+    });
+    assert!(told_to_wait);
+}
+
+#[test]
+fn finished_job_posts_notice_and_clears_the_registry() {
+    let mut state = enabled_state();
+    let ctx = egui::Context::default();
+    let conversation = state.ui.agent.active_conversation;
+    let (tx, rx) = std::sync::mpsc::channel();
+    tx.send(QmWorkerMessage::Finished(Box::new(QmOutcome {
+        energy_hartree: -1.0,
+        converged: true,
+        optimized_structure: None,
+        summary: "E = -1.0 Ha".into(),
+    })))
+    .unwrap();
+    drop(tx);
+    state.jobs.agent_jobs.push(fake_qm_job(7, conversation, rx));
+
+    poll_agent_jobs(&mut state, &ctx);
+
+    // The completed job leaves the registry...
+    assert!(state.jobs.agent_jobs.is_empty());
+    // ...and the originating conversation gets a "finished" notice. (The JobDone it
+    // enqueued is then pumped; with no API key in tests it is consumed, so the
+    // notice is the durable evidence the completion was routed.)
+    let finished =
+        state.ui.agent.transcript.iter().any(
+            |entry| matches!(entry, TranscriptEntry::Notice(text) if text.contains("finished")),
+        );
+    assert!(finished);
+}
+
+#[test]
+fn cancel_keeps_jobdone_but_drops_typed_messages() {
+    let mut state = enabled_state();
+    let ctx = egui::Context::default();
+    state
+        .ui
+        .agent
+        .queued
+        .push_back(PendingTurn::UserMessage("typed".into()));
+    state.ui.agent.queued.push_back(PendingTurn::JobDone {
+        label: "qm optimize".into(),
+        summary: "done".into(),
+        is_error: false,
+    });
+    state.ui.agent.phase = AgentPhase::AwaitingModel;
+
+    cancel_agent(&mut state, &ctx);
+
+    // The typed follow-up is dropped, but the completed job's result survives.
+    assert_eq!(state.ui.agent.queued.len(), 1);
+    assert!(matches!(
+        state.ui.agent.queued.front(),
+        Some(PendingTurn::JobDone { .. })
+    ));
+}
+
+#[test]
+fn idle_send_drains_queued_jobdone_first() {
+    let mut state = enabled_state();
+    let ctx = egui::Context::default();
+    state.ui.agent.queued.push_back(PendingTurn::JobDone {
+        label: "qm optimize".into(),
+        summary: "done".into(),
+        is_error: false,
+    });
+    state.ui.agent.phase = AgentPhase::Idle;
+
+    send_agent_message(&mut state, "and now this", &ctx);
+
+    // FIFO: the JobDone pumps first (consumed), the new message waits behind it â€”
+    // not jumping ahead and not stranding the JobDone.
+    assert_eq!(state.ui.agent.queued.len(), 1);
+    assert!(matches!(
+        state.ui.agent.queued.front(),
+        Some(PendingTurn::UserMessage(t)) if t == "and now this"
+    ));
+}
+
+#[test]
+fn stop_cancels_active_conversation_background_jobs() {
+    let mut state = enabled_state();
+    let ctx = egui::Context::default();
+    let conv = state.ui.agent.active_conversation;
+    let (_tx, rx) = std::sync::mpsc::channel();
+    state.jobs.agent_jobs.push(fake_qm_job(1, conv, rx));
+    state.ui.agent.phase = AgentPhase::AwaitingModel;
+
+    cancel_agent(&mut state, &ctx);
+
+    assert!(
+        state.jobs.agent_jobs.is_empty(),
+        "Stop cancels the active conversation's background jobs"
+    );
+}
+
+#[test]
+fn deleting_a_conversation_cancels_its_background_jobs() {
+    let mut state = enabled_state();
+    let ctx = egui::Context::default();
+    let first = state.ui.agent.active_conversation;
+    state.ui.agent.start_new_conversation(); // a 2nd chat, so delete removes `first`
+    let (_tx, rx) = std::sync::mpsc::channel();
+    state.jobs.agent_jobs.push(fake_qm_job(1, first, rx));
+
+    delete_assistant_conversation(&mut state, first);
+
+    assert!(
+        state.jobs.agent_jobs.is_empty(),
+        "deleting a chat cancels the jobs it launched"
+    );
+    let _ = ctx;
+}
+
+#[test]
+fn job_finishing_in_inactive_conversation_routes_to_its_origin() {
+    let mut state = enabled_state();
+    let ctx = egui::Context::default();
+    let origin = state.ui.agent.active_conversation;
+    let (tx, rx) = std::sync::mpsc::channel();
+    tx.send(QmWorkerMessage::Finished(Box::new(QmOutcome {
+        energy_hartree: -1.0,
+        converged: true,
+        optimized_structure: None,
+        summary: "E = -1.0 Ha".into(),
+    })))
+    .unwrap();
+    drop(tx);
+    state.jobs.agent_jobs.push(fake_qm_job(5, origin, rx));
+    // Make a different conversation active before the job completes.
+    state.ui.agent.start_new_conversation();
+    let active = state.ui.agent.active_conversation;
+    assert_ne!(origin, active);
+
+    poll_agent_jobs(&mut state, &ctx);
+
+    // The active conversation gets nothing; the follow-up lands in the origin.
+    assert!(state.ui.agent.queued.is_empty());
+    let origin_conv = state
+        .ui
+        .agent
+        .conversation_mut(origin)
+        .expect("origin exists");
+    assert_eq!(origin_conv.queued.len(), 1);
+    assert!(matches!(
+        origin_conv.queued.front(),
+        Some(PendingTurn::JobDone { .. })
+    ));
+}
+
+#[test]
+fn switching_back_pumps_a_pending_jobdone() {
+    let mut state = enabled_state();
+    let ctx = egui::Context::default();
+    let origin = state.ui.agent.active_conversation;
+    state.ui.agent.start_new_conversation(); // switch away from `origin`
+    state
+        .ui
+        .agent
+        .conversation_mut(origin)
+        .expect("origin exists")
+        .queued
+        .push_back(PendingTurn::JobDone {
+            label: "qm optimize".into(),
+            summary: "done".into(),
+            is_error: false,
+        });
+
+    switch_assistant_conversation(&mut state, origin, &ctx);
+
+    // Returning to the conversation pumps its stranded follow-up (consumed; no key
+    // in tests, so the turn itself doesn't spawn â€” the point is it no longer sticks).
+    assert!(state.ui.agent.queued.is_empty());
+}
+
+#[test]
+fn switching_provider_strips_reasoning() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    state.ui.agent.history.push(ChatMessage {
+        role: Role::Assistant,
+        content: vec![
+            ContentBlock::OpaqueReasoning(ReasoningBlob::Anthropic(vec![json!({})])),
+            ContentBlock::Text("hi".to_string()),
+        ],
+    });
+    switch_provider_model(&mut state, "anthropic", "claude-opus-4-8");
+    let still_has_reasoning = state.ui.agent.history.iter().any(|message| {
+        message
+            .content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::OpaqueReasoning(_)))
+    });
+    assert!(!still_has_reasoning);
+    assert_eq!(state.config.assistant.model, "claude-opus-4-8");
+}
+
+#[test]
+fn changing_base_url_clears_stale_model_fetch_error() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    state.ui.agent.model_fetch = ModelFetchStatus::Error("io: No route to host".to_string());
+
+    set_assistant_base_url(&mut state, "https://api.example.com/v1");
+
+    assert_eq!(
+        state.config.assistant.base_url.as_deref(),
+        Some("https://api.example.com/v1")
+    );
+    assert_eq!(state.ui.agent.model_fetch, ModelFetchStatus::Idle);
+}
+
+#[test]
+fn pump_marks_dequeued_follow_up_as_running_backlog() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    let ctx = egui::Context::default();
+    state
+        .ui
+        .agent
+        .queued
+        .push_back(PendingTurn::UserMessage("do this next".into()));
+
+    pump_queue(&mut state, &ctx);
+
+    assert!(state.ui.agent.queued.is_empty());
+    assert_eq!(
+        state.ui.agent.current_backlog.as_deref(),
+        Some("do this next")
+    );
+}
+
+#[test]
+fn flush_on_next_pump_clears_backlog() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    let ctx = egui::Context::default();
+    state
+        .ui
+        .agent
+        .note_backlog_start("earlier follow-up".into(), 0);
+    state
+        .ui
+        .agent
+        .transcript
+        .push(TranscriptEntry::Assistant("Here is the answer.".into()));
+
+    pump_queue(&mut state, &ctx);
+
+    assert!(state.ui.agent.current_backlog.is_none());
+}
+
+#[test]
+fn errored_backlog_turn_clears_backlog() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    let ctx = egui::Context::default();
+    state
+        .ui
+        .agent
+        .note_backlog_start("risky follow-up".into(), 0);
+
+    handle_turn_result(&mut state, Err(LlmError::BadRequest("nope".into())), &ctx);
+
+    assert!(state.ui.agent.current_backlog.is_none());
+}

--- a/src/frontend/agent/loop_driver/tests/mod.rs
+++ b/src/frontend/agent/loop_driver/tests/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::frontend::agent::session::{AgentPhase, ModelFetchStatus, PendingTurn, TranscriptEntry};
+use crate::frontend::agent::session::{AgentPhase, PendingTurn, TranscriptEntry};
 use crate::frontend::state::AppState;
 use crate::io::llm::types::{
     AssistantTurn, ChatMessage, ContentBlock, LlmError, ReasoningBlob, Role, StopReason, ToolCall,
@@ -12,7 +12,6 @@ use serde_json::json;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-use crate::engines::qm::QmOutcome;
 use crate::frontend::jobs::{AgentHeavyJob, QmWorkerMessage, RunningQmJob, TrackedAgentJob};
 
 /// A background QM job whose channel the test controls, so completion/back-pressure
@@ -52,6 +51,28 @@ fn turn_with_tool(command: &str) -> AssistantTurn {
     }
 }
 
+fn turn_with_tools(commands: &[&str]) -> AssistantTurn {
+    AssistantTurn {
+        text: "Working on it.".to_string(),
+        tool_calls: commands
+            .iter()
+            .enumerate()
+            .map(|(index, command)| ToolCall {
+                id: format!("call_{}", index + 1),
+                name: "run_command".to_string(),
+                input: json!({ "command": command }),
+            })
+            .collect(),
+        reasoning: ReasoningBlob::None,
+        stop: StopReason::ToolUse,
+        usage: Usage {
+            input: 10,
+            output: 4,
+            ..Usage::default()
+        },
+    }
+}
+
 fn end_turn(text: &str) -> AssistantTurn {
     AssistantTurn {
         text: text.to_string(),
@@ -69,7 +90,7 @@ fn read_only_tool_runs_inline_and_records_result() {
     // No API key in tests, so the follow-up turn fails to spawn gracefully;
     // the tool itself still executes and is recorded.
     handle_turn_result(&mut state, Ok(turn_with_tool("inspect")), &ctx);
-    // (the model asked for run_command "inspect" — a console command — which
+    // (the model asked for run_command "inspect" â€” a console command â€” which
     // is unknown to the console and returns an error result; the point is the
     // tool dispatched and produced a tool_result.)
     assert!(
@@ -91,6 +112,139 @@ fn gated_command_pauses_for_approval() {
     assert_eq!(state.ui.agent.phase, AgentPhase::AwaitingApproval);
     let pending = state.ui.agent.pending_approval().expect("a pending call");
     assert_eq!(pending.id, "call_1");
+}
+
+#[test]
+fn batch_gates_only_consequential_calls_and_resolves_in_any_order() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    let ctx = egui::Context::default();
+    // Default mode is AutoSafe: the read-only call auto-runs (an unknown command
+    // here, so it errors gracefully without touching the empty workspace); the
+    // compute and destructive calls wait â€” together, as one batch. They are
+    // resolved by reject so nothing executes against the entry-less scratch state.
+    handle_turn_result(
+        &mut state,
+        Ok(turn_with_tools(&[
+            "inspect-noop",            // read-only â†’ auto-runs, errors gracefully
+            "score --receptor active", // compute â†’ gated in AutoSafe
+            "delete chain A",          // destructive â†’ always gated
+        ])),
+        &ctx,
+    );
+    assert_eq!(state.ui.agent.phase, AgentPhase::AwaitingApproval);
+    let ids: Vec<String> = gated_pending(&state)
+        .iter()
+        .map(|call| call.id.clone())
+        .collect();
+    assert_eq!(
+        ids,
+        vec!["call_2", "call_3"],
+        "only the two gated calls wait"
+    );
+
+    // Resolve out of order: rejecting the destructive one leaves the batch paused
+    // on the still-undecided compute call.
+    reject_tool_call(&mut state, "call_3", &ctx);
+    assert_eq!(state.ui.agent.phase, AgentPhase::AwaitingApproval);
+    let remaining: Vec<String> = gated_pending(&state)
+        .iter()
+        .map(|call| call.id.clone())
+        .collect();
+    assert_eq!(remaining, vec!["call_2"]);
+
+    // Resolving the last one drains the batch.
+    reject_tool_call(&mut state, "call_2", &ctx);
+    assert!(state.ui.agent.pending_approval().is_none());
+    assert!(state.ui.agent.pending_calls.is_empty());
+}
+
+#[test]
+fn plan_mode_proposes_without_executing() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    state.config.assistant.approval_mode = crate::backend::config::ApprovalMode::Plan;
+    let ctx = egui::Context::default();
+    handle_turn_result(&mut state, Ok(turn_with_tool("delete chain A")), &ctx);
+    // Nothing waits and nothing destructive ran; the call became a proposal.
+    assert!(state.ui.agent.pending_approval().is_none());
+    assert!(state.ui.agent.pending_calls.is_empty());
+    assert!(
+        !state
+            .output_log
+            .iter()
+            .any(|line| line.starts_with("agent>")),
+        "plan mode must not execute the command"
+    );
+}
+
+#[test]
+fn plan_mode_runs_perception_but_only_proposes_doers() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    state.config.assistant.approval_mode = crate::backend::config::ApprovalMode::Plan;
+    let ctx = egui::Context::default();
+    // One perception call (inspect) and one doer (run_command): the perception
+    // must execute so the model can ground its plan; the doer must not run.
+    let turn = AssistantTurn {
+        text: "Planning.".to_string(),
+        tool_calls: vec![
+            ToolCall {
+                id: "call_1".to_string(),
+                name: "inspect".to_string(),
+                input: json!({}),
+            },
+            ToolCall {
+                id: "call_2".to_string(),
+                name: "run_command".to_string(),
+                input: json!({ "command": "delete chain A" }),
+            },
+        ],
+        reasoning: ReasoningBlob::None,
+        stop: StopReason::ToolUse,
+        usage: Usage {
+            input: 10,
+            output: 4,
+            ..Usage::default()
+        },
+    };
+    handle_turn_result(&mut state, Ok(turn), &ctx);
+
+    let results = last_tool_results(&state);
+    let inspect = results.get("call_1").expect("inspect produced a result");
+    let doer = results.get("call_2").expect("the doer produced a result");
+    assert!(
+        !inspect.starts_with("Plan mode: not executed"),
+        "perception runs in Plan mode, got: {inspect}"
+    );
+    assert!(
+        doer.starts_with("Plan mode: not executed"),
+        "doers are proposed, not run, got: {doer}"
+    );
+}
+
+/// The `tool_use_id` â†’ content map of the last flushed `Tool` message, for
+/// asserting what each call in a finished batch returned.
+fn last_tool_results(state: &AppState) -> std::collections::HashMap<String, String> {
+    state
+        .ui
+        .agent
+        .history
+        .iter()
+        .rev()
+        .find(|message| message.role == Role::Tool)
+        .map(|message| {
+            message
+                .content
+                .iter()
+                .filter_map(|block| match block {
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        ..
+                    } => Some((tool_use_id.clone(), content.clone())),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 #[test]
@@ -401,310 +555,4 @@ fn remove_queued_drops_the_indexed_item() {
     ));
 }
 
-#[test]
-fn job_done_is_consumed_when_idle() {
-    let mut state = enabled_state();
-    let ctx = egui::Context::default();
-    state.ui.agent.queued.push_back(PendingTurn::JobDone {
-        label: "qm optimize".into(),
-        summary: "E = -1.0 Ha".into(),
-        is_error: false,
-    });
-    state.ui.agent.phase = AgentPhase::Done;
-
-    pump_queue(&mut state, &ctx);
-
-    assert!(
-        state.ui.agent.queued.is_empty(),
-        "an idle pump consumes a queued JobDone to wake the model"
-    );
-}
-
-#[test]
-fn heavy_launch_is_refused_while_one_is_running() {
-    let mut state = enabled_state();
-    let ctx = egui::Context::default();
-    let conversation = state.ui.agent.active_conversation;
-    let (_tx, rx) = std::sync::mpsc::channel();
-    state.jobs.agent_jobs.push(fake_qm_job(1, conversation, rx));
-
-    let call = ToolCall {
-        id: "c1".into(),
-        name: "run_command".into(),
-        input: json!({ "command": "qm energy --basis sto-3g" }),
-    };
-    dispatch_call(&mut state, &call, &ctx);
-
-    // No second job spawned — serialized to one.
-    assert_eq!(state.jobs.agent_jobs.len(), 1);
-    // The model is told to wait, not handed an error.
-    let told_to_wait = state.ui.agent.transcript.iter().any(|entry| {
-        matches!(
-            entry,
-            TranscriptEntry::Tool { result: Some(text), is_error: false, .. }
-            if text.contains("already running")
-        )
-    });
-    assert!(told_to_wait);
-}
-
-#[test]
-fn finished_job_posts_notice_and_clears_the_registry() {
-    let mut state = enabled_state();
-    let ctx = egui::Context::default();
-    let conversation = state.ui.agent.active_conversation;
-    let (tx, rx) = std::sync::mpsc::channel();
-    tx.send(QmWorkerMessage::Finished(Box::new(QmOutcome {
-        energy_hartree: -1.0,
-        converged: true,
-        optimized_structure: None,
-        summary: "E = -1.0 Ha".into(),
-    })))
-    .unwrap();
-    drop(tx);
-    state.jobs.agent_jobs.push(fake_qm_job(7, conversation, rx));
-
-    poll_agent_jobs(&mut state, &ctx);
-
-    // The completed job leaves the registry...
-    assert!(state.jobs.agent_jobs.is_empty());
-    // ...and the originating conversation gets a "finished" notice. (The JobDone it
-    // enqueued is then pumped; with no API key in tests it is consumed, so the
-    // notice is the durable evidence the completion was routed.)
-    let finished =
-        state.ui.agent.transcript.iter().any(
-            |entry| matches!(entry, TranscriptEntry::Notice(text) if text.contains("finished")),
-        );
-    assert!(finished);
-}
-
-#[test]
-fn cancel_keeps_jobdone_but_drops_typed_messages() {
-    let mut state = enabled_state();
-    let ctx = egui::Context::default();
-    state
-        .ui
-        .agent
-        .queued
-        .push_back(PendingTurn::UserMessage("typed".into()));
-    state.ui.agent.queued.push_back(PendingTurn::JobDone {
-        label: "qm optimize".into(),
-        summary: "done".into(),
-        is_error: false,
-    });
-    state.ui.agent.phase = AgentPhase::AwaitingModel;
-
-    cancel_agent(&mut state, &ctx);
-
-    // The typed follow-up is dropped, but the completed job's result survives.
-    assert_eq!(state.ui.agent.queued.len(), 1);
-    assert!(matches!(
-        state.ui.agent.queued.front(),
-        Some(PendingTurn::JobDone { .. })
-    ));
-}
-
-#[test]
-fn idle_send_drains_queued_jobdone_first() {
-    let mut state = enabled_state();
-    let ctx = egui::Context::default();
-    state.ui.agent.queued.push_back(PendingTurn::JobDone {
-        label: "qm optimize".into(),
-        summary: "done".into(),
-        is_error: false,
-    });
-    state.ui.agent.phase = AgentPhase::Idle;
-
-    send_agent_message(&mut state, "and now this", &ctx);
-
-    // FIFO: the JobDone pumps first (consumed), the new message waits behind it —
-    // not jumping ahead and not stranding the JobDone.
-    assert_eq!(state.ui.agent.queued.len(), 1);
-    assert!(matches!(
-        state.ui.agent.queued.front(),
-        Some(PendingTurn::UserMessage(t)) if t == "and now this"
-    ));
-}
-
-#[test]
-fn stop_cancels_active_conversation_background_jobs() {
-    let mut state = enabled_state();
-    let ctx = egui::Context::default();
-    let conv = state.ui.agent.active_conversation;
-    let (_tx, rx) = std::sync::mpsc::channel();
-    state.jobs.agent_jobs.push(fake_qm_job(1, conv, rx));
-    state.ui.agent.phase = AgentPhase::AwaitingModel;
-
-    cancel_agent(&mut state, &ctx);
-
-    assert!(
-        state.jobs.agent_jobs.is_empty(),
-        "Stop cancels the active conversation's background jobs"
-    );
-}
-
-#[test]
-fn deleting_a_conversation_cancels_its_background_jobs() {
-    let mut state = enabled_state();
-    let ctx = egui::Context::default();
-    let first = state.ui.agent.active_conversation;
-    state.ui.agent.start_new_conversation(); // a 2nd chat, so delete removes `first`
-    let (_tx, rx) = std::sync::mpsc::channel();
-    state.jobs.agent_jobs.push(fake_qm_job(1, first, rx));
-
-    delete_assistant_conversation(&mut state, first);
-
-    assert!(
-        state.jobs.agent_jobs.is_empty(),
-        "deleting a chat cancels the jobs it launched"
-    );
-    let _ = ctx;
-}
-
-#[test]
-fn job_finishing_in_inactive_conversation_routes_to_its_origin() {
-    let mut state = enabled_state();
-    let ctx = egui::Context::default();
-    let origin = state.ui.agent.active_conversation;
-    let (tx, rx) = std::sync::mpsc::channel();
-    tx.send(QmWorkerMessage::Finished(Box::new(QmOutcome {
-        energy_hartree: -1.0,
-        converged: true,
-        optimized_structure: None,
-        summary: "E = -1.0 Ha".into(),
-    })))
-    .unwrap();
-    drop(tx);
-    state.jobs.agent_jobs.push(fake_qm_job(5, origin, rx));
-    // Make a different conversation active before the job completes.
-    state.ui.agent.start_new_conversation();
-    let active = state.ui.agent.active_conversation;
-    assert_ne!(origin, active);
-
-    poll_agent_jobs(&mut state, &ctx);
-
-    // The active conversation gets nothing; the follow-up lands in the origin.
-    assert!(state.ui.agent.queued.is_empty());
-    let origin_conv = state
-        .ui
-        .agent
-        .conversation_mut(origin)
-        .expect("origin exists");
-    assert_eq!(origin_conv.queued.len(), 1);
-    assert!(matches!(
-        origin_conv.queued.front(),
-        Some(PendingTurn::JobDone { .. })
-    ));
-}
-
-#[test]
-fn switching_back_pumps_a_pending_jobdone() {
-    let mut state = enabled_state();
-    let ctx = egui::Context::default();
-    let origin = state.ui.agent.active_conversation;
-    state.ui.agent.start_new_conversation(); // switch away from `origin`
-    state
-        .ui
-        .agent
-        .conversation_mut(origin)
-        .expect("origin exists")
-        .queued
-        .push_back(PendingTurn::JobDone {
-            label: "qm optimize".into(),
-            summary: "done".into(),
-            is_error: false,
-        });
-
-    switch_assistant_conversation(&mut state, origin, &ctx);
-
-    // Returning to the conversation pumps its stranded follow-up (consumed; no key
-    // in tests, so the turn itself doesn't spawn — the point is it no longer sticks).
-    assert!(state.ui.agent.queued.is_empty());
-}
-
-#[test]
-fn switching_provider_strips_reasoning() {
-    let mut state = AppState::scratch(Default::default(), Vec::new());
-    state.ui.agent.history.push(ChatMessage {
-        role: Role::Assistant,
-        content: vec![
-            ContentBlock::OpaqueReasoning(ReasoningBlob::Anthropic(vec![json!({})])),
-            ContentBlock::Text("hi".to_string()),
-        ],
-    });
-    switch_provider_model(&mut state, "anthropic", "claude-opus-4-8");
-    let still_has_reasoning = state.ui.agent.history.iter().any(|message| {
-        message
-            .content
-            .iter()
-            .any(|block| matches!(block, ContentBlock::OpaqueReasoning(_)))
-    });
-    assert!(!still_has_reasoning);
-    assert_eq!(state.config.assistant.model, "claude-opus-4-8");
-}
-
-#[test]
-fn changing_base_url_clears_stale_model_fetch_error() {
-    let mut state = AppState::scratch(Default::default(), Vec::new());
-    state.ui.agent.model_fetch = ModelFetchStatus::Error("io: No route to host".to_string());
-
-    set_assistant_base_url(&mut state, "https://api.example.com/v1");
-
-    assert_eq!(
-        state.config.assistant.base_url.as_deref(),
-        Some("https://api.example.com/v1")
-    );
-    assert_eq!(state.ui.agent.model_fetch, ModelFetchStatus::Idle);
-}
-
-#[test]
-fn pump_marks_dequeued_follow_up_as_running_backlog() {
-    let mut state = AppState::scratch(Default::default(), Vec::new());
-    let ctx = egui::Context::default();
-    state
-        .ui
-        .agent
-        .queued
-        .push_back(PendingTurn::UserMessage("do this next".into()));
-
-    pump_queue(&mut state, &ctx);
-
-    assert!(state.ui.agent.queued.is_empty());
-    assert_eq!(
-        state.ui.agent.current_backlog.as_deref(),
-        Some("do this next")
-    );
-}
-
-#[test]
-fn flush_on_next_pump_clears_backlog() {
-    let mut state = AppState::scratch(Default::default(), Vec::new());
-    let ctx = egui::Context::default();
-    state
-        .ui
-        .agent
-        .note_backlog_start("earlier follow-up".into(), 0);
-    state
-        .ui
-        .agent
-        .transcript
-        .push(TranscriptEntry::Assistant("Here is the answer.".into()));
-
-    pump_queue(&mut state, &ctx);
-
-    assert!(state.ui.agent.current_backlog.is_none());
-}
-
-#[test]
-fn errored_backlog_turn_clears_backlog() {
-    let mut state = AppState::scratch(Default::default(), Vec::new());
-    let ctx = egui::Context::default();
-    state
-        .ui
-        .agent
-        .note_backlog_start("risky follow-up".into(), 0);
-
-    handle_turn_result(&mut state, Err(LlmError::BadRequest("nope".into())), &ctx);
-
-    assert!(state.ui.agent.current_backlog.is_none());
-}
+mod jobs;

--- a/src/frontend/agent/loop_driver/tool_batch.rs
+++ b/src/frontend/agent/loop_driver/tool_batch.rs
@@ -2,29 +2,88 @@ use super::*;
 
 use eframe::egui;
 
+use crate::backend::config::ApprovalMode;
 use crate::frontend::agent::session::{AgentPhase, TranscriptEntry};
 use crate::frontend::agent::tools;
+use crate::frontend::console::RiskLevel;
 use crate::frontend::state::AppState;
 use crate::io::llm::types::{ChatMessage, ContentBlock, Role, ToolCall};
 
-/// Run queued tool calls in order until the batch empties or one hits a
-/// confirmation gate. A failing call still yields an `is_error` result; the
-/// batch is not aborted (the model recovers from the error).
+/// Run queued tool calls in order until the batch empties or one hits the
+/// approval gate. A failing call still yields an `is_error` result; the batch is
+/// not aborted (the model recovers from the error). `Plan` mode diverts to
+/// [`propose_in_plan_mode`].
 pub fn run_tool_batch(state: &mut AppState, ctx: &egui::Context) {
+    if state.config.assistant.approval_mode == ApprovalMode::Plan {
+        propose_in_plan_mode(state, ctx);
+        return;
+    }
     loop {
         let Some(call) = state.ui.agent.pending_calls.front().cloned() else {
             finish_tool_batch(state, ctx);
             return;
         };
-        if tools::needs_confirmation(&call) {
+        if gate_blocks(state, &call) {
             state.ui.agent.phase = AgentPhase::AwaitingApproval;
-            notice(state, &format!("Approve to run: {}", describe_call(&call)));
             ctx.request_repaint();
             return;
         }
+        state.ui.agent.approved_ids.remove(&call.id);
         dispatch_call(state, &call, ctx);
         state.ui.agent.pending_calls.pop_front();
     }
+}
+
+/// Whether `call` should pause the batch for approval: gated by the policy and
+/// not already pre-approved by the user in this batch.
+fn gate_blocks(state: &AppState, call: &ToolCall) -> bool {
+    if state.ui.agent.approved_ids.contains(&call.id) {
+        return false;
+    }
+    let mode = state.config.assistant.approval_mode;
+    let conversation = state.ui.agent.active();
+    tools::needs_confirmation(
+        call,
+        mode,
+        &conversation.allowed_verbs,
+        &conversation.allowed_risks,
+    )
+}
+
+/// The pending calls awaiting a user decision (gated, not yet approved). Drives
+/// the approval-card list; empty unless `AwaitingApproval`.
+pub fn gated_pending(state: &AppState) -> Vec<ToolCall> {
+    if state.ui.agent.phase != AgentPhase::AwaitingApproval {
+        return Vec::new();
+    }
+    state
+        .ui
+        .agent
+        .pending_calls
+        .iter()
+        .filter(|call| gate_blocks(state, call))
+        .cloned()
+        .collect()
+}
+
+/// In `Plan` mode the doer tools (`run_command`, `save_script`) never execute —
+/// each is recorded as a not-run proposal. Read-only perception (`inspect`,
+/// `recommend_method`) still runs, since it changes nothing and the model needs
+/// to see the workspace to propose a grounded plan.
+fn propose_in_plan_mode(state: &mut AppState, ctx: &egui::Context) {
+    while let Some(call) = state.ui.agent.pending_calls.pop_front() {
+        if matches!(call.name.as_str(), "run_command" | "save_script") {
+            push_tool_call_entry(state, &call);
+            let summary = format!(
+                "Plan mode: not executed. Proposed {}.",
+                describe_call(&call)
+            );
+            record_result(state, &call, summary, false);
+        } else {
+            dispatch_call(state, &call, ctx);
+        }
+    }
+    finish_tool_batch(state, ctx);
 }
 
 /// Execute a call inline, or launch it as a detached background job. Heavy jobs
@@ -82,6 +141,7 @@ pub fn fill_pending_tool_entry(state: &mut AppState, content: &str, is_error: bo
 /// Flush the batch's tool results into one neutral `Tool` message and spawn the
 /// next model turn.
 fn finish_tool_batch(state: &mut AppState, ctx: &egui::Context) {
+    state.ui.agent.approved_ids.clear();
     let results = std::mem::take(&mut state.ui.agent.collected_results);
     state.ui.agent.history.push(ChatMessage {
         role: Role::Tool,
@@ -90,38 +150,83 @@ fn finish_tool_batch(state: &mut AppState, ctx: &egui::Context) {
     spawn_next_turn(state, ctx);
 }
 
-/// Approve the gated tool call with `id` (the front of the batch); run it and
-/// continue the batch.
+/// A pending call by id, cloned, regardless of position in the batch.
+fn pending_call(state: &AppState, id: &str) -> Option<ToolCall> {
+    state
+        .ui
+        .agent
+        .pending_calls
+        .iter()
+        .find(|call| call.id == id)
+        .cloned()
+}
+
+/// Approve the gated call `id`: mark it approved and resume the batch. It runs
+/// when the loop reaches it, so execution stays in queue order; if other gated
+/// calls remain undecided the loop pauses again on the next one.
 pub fn approve_tool_call(state: &mut AppState, id: &str, ctx: &egui::Context) {
-    let Some(front) = state.ui.agent.pending_approval().cloned() else {
-        return;
-    };
-    if front.id != id {
+    if state.ui.agent.phase != AgentPhase::AwaitingApproval {
         return;
     }
+    state.ui.agent.approved_ids.insert(id.to_string());
     state.ui.agent.phase = AgentPhase::ExecutingTools;
-    dispatch_call(state, &front, ctx);
-    state.ui.agent.pending_calls.pop_front();
     run_tool_batch(state, ctx);
 }
 
-/// Reject the gated tool call with `id`: record an `is_error` result so the
-/// model learns it was declined, then continue the batch.
+/// Approve `id` and auto-allow its command verb for the rest of the conversation,
+/// so repeats of the same command stop prompting.
+pub fn always_allow_command(state: &mut AppState, id: &str, ctx: &egui::Context) {
+    if let Some(call) = pending_call(state, id) {
+        state
+            .ui
+            .agent
+            .allowed_verbs
+            .insert(tools::call_allow_key(&call));
+    }
+    approve_tool_call(state, id, ctx);
+}
+
+/// Approve `id` and auto-allow every command of its risk level (never
+/// `Destructive`) for the rest of the conversation.
+pub fn always_allow_risk(state: &mut AppState, id: &str, ctx: &egui::Context) {
+    if let Some(call) = pending_call(state, id) {
+        let risk = tools::risk_of_call(&call);
+        if risk != RiskLevel::Destructive {
+            state.ui.agent.allowed_risks.insert(risk);
+        }
+    }
+    approve_tool_call(state, id, ctx);
+}
+
+/// Reject the gated call `id`: drop it from the queue and record an `is_error`
+/// result so the model learns it was declined, then resume the batch.
 pub fn reject_tool_call(state: &mut AppState, id: &str, ctx: &egui::Context) {
-    let Some(front) = state.ui.agent.pending_approval().cloned() else {
-        return;
-    };
-    if front.id != id {
+    if state.ui.agent.phase != AgentPhase::AwaitingApproval {
         return;
     }
-    push_tool_call_entry(state, &front);
+    let Some(position) = state
+        .ui
+        .agent
+        .pending_calls
+        .iter()
+        .position(|call| call.id == id)
+    else {
+        return;
+    };
+    let call = state
+        .ui
+        .agent
+        .pending_calls
+        .remove(position)
+        .expect("position just found");
+    state.ui.agent.approved_ids.remove(id);
+    push_tool_call_entry(state, &call);
     record_result(
         state,
-        &front,
+        &call,
         "The user declined to run this command.".to_string(),
         true,
     );
-    state.ui.agent.pending_calls.pop_front();
     state.ui.agent.phase = AgentPhase::ExecutingTools;
     run_tool_batch(state, ctx);
 }

--- a/src/frontend/agent/loop_driver/turn.rs
+++ b/src/frontend/agent/loop_driver/turn.rs
@@ -344,6 +344,7 @@ pub fn cancel_agent(state: &mut AppState, ctx: &egui::Context) {
     let cancelled_jobs = cancel_conversation_jobs(state, active);
     fill_pending_tool_entry(state, "Cancelled.", true);
     state.ui.agent.pending_calls.clear();
+    state.ui.agent.approved_ids.clear();
     state.ui.agent.collected_results.clear();
     discard_queued(state, "the turn was cancelled");
     state.ui.agent.current_backlog = None;

--- a/src/frontend/agent/mod.rs
+++ b/src/frontend/agent/mod.rs
@@ -12,12 +12,12 @@ pub mod tools;
 mod mock;
 
 pub use loop_driver::{
-    approve_tool_call, cancel_agent, cancel_agent_job, clear_stored_key,
-    delete_assistant_conversation, fetch_models, new_assistant_conversation, poll_agent_jobs,
-    poll_agent_turn, poll_model_fetch, refresh_key_status, reject_tool_call,
-    remove_queued_agent_input, rename_assistant_conversation, send_agent_message,
-    set_assistant_api_key, set_assistant_base_url, set_assistant_effort,
-    set_assistant_effort_supported, set_assistant_enabled, switch_assistant_conversation,
-    switch_provider_model,
+    always_allow_command, always_allow_risk, approve_tool_call, cancel_agent, cancel_agent_job,
+    clear_stored_key, delete_assistant_conversation, fetch_models, gated_pending, impact_hint,
+    new_assistant_conversation, poll_agent_jobs, poll_agent_turn, poll_model_fetch,
+    refresh_key_status, reject_tool_call, remove_queued_agent_input, rename_assistant_conversation,
+    send_agent_message, set_approval_mode, set_assistant_api_key, set_assistant_base_url,
+    set_assistant_effort, set_assistant_effort_supported, set_assistant_enabled,
+    switch_assistant_conversation, switch_provider_model,
 };
 pub use session::{AgentSession, AssistantConversationId, ModelFetchStatus, TranscriptEntry};

--- a/src/frontend/agent/session.rs
+++ b/src/frontend/agent/session.rs
@@ -3,9 +3,10 @@
 //! Assistant tab. Held as `UiState::agent`; mutated only through the dispatcher and
 //! the poll-driven [`loop_driver`](super::loop_driver).
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ops::{Deref, DerefMut};
 
+use crate::frontend::console::RiskLevel;
 use crate::io::llm::types::{ChatMessage, ContentBlock, ToolCall, Usage};
 
 /// Where the session is in the turn cycle.
@@ -121,6 +122,17 @@ pub struct AssistantConversation {
     /// `tool_result` blocks gathered so far in the current batch; flushed into a
     /// single neutral `Tool` message when the batch completes.
     pub collected_results: Vec<ContentBlock>,
+    /// Command verbs (the top-level name, or `save_script`) the user chose to
+    /// auto-allow for the rest of this conversation. Checked before the approval
+    /// gate; never overrides the `Destructive` floor.
+    pub allowed_verbs: HashSet<String>,
+    /// Whole risk levels the user chose to auto-allow this conversation. Never
+    /// holds `Destructive` (that always prompts).
+    pub allowed_risks: HashSet<RiskLevel>,
+    /// Ids of gated calls the user approved in the current batch but which have
+    /// not run yet (an earlier call is still awaiting a decision). Lets the batch
+    /// be resolved in any order while executing in queue order.
+    pub approved_ids: HashSet<String>,
     /// Live preview of the assistant text streaming in this turn. Shown beneath
     /// the transcript while `AwaitingModel`, then cleared and replaced by the
     /// authoritative final text when the turn completes.
@@ -152,6 +164,9 @@ impl AssistantConversation {
             last_usage: None,
             pending_calls: VecDeque::new(),
             collected_results: Vec::new(),
+            allowed_verbs: HashSet::new(),
+            allowed_risks: HashSet::new(),
+            approved_ids: HashSet::new(),
             streaming_text: String::new(),
             queued: VecDeque::new(),
             current_backlog: None,

--- a/src/frontend/agent/tools.rs
+++ b/src/frontend/agent/tools.rs
@@ -7,11 +7,14 @@
 //! not act blind). Confirmation gating classifies destructive/expensive commands
 //! that need a one-click approval before they run.
 
+use std::collections::HashSet;
 use std::fmt::Write;
 
 use serde_json::{Value, json};
 
+use crate::backend::config::ApprovalMode;
 use crate::engines::registry::{EngineId, EngineRegistry};
+use crate::frontend::console::{RiskLevel, command_risk};
 use crate::frontend::state::AppState;
 use crate::io::llm::types::{ToolCall, ToolDef};
 
@@ -28,9 +31,11 @@ pub fn tool_defs() -> Vec<ToolDef> {
                 `fetch 4hhb`, `sketch CCO`, `view background white`, `color chain A red`, \
                 `representation cartoon`, `hydrogen add`, `md build`, `qm energy`, \
                 `dock --receptor active --ligand 2`). One command per call; this is the same \
-                command line a user types in the console. Destructive or expensive commands \
-                (delete, save, md, qm, dock, score, running a script) require the user to \
-                confirm before they run."
+                command line a user types in the console. Commands are risk-classified \
+                (read-only, structure edit, file write, compute, destructive); whether one \
+                needs the user's approval depends on their approval mode, and destructive \
+                commands (`delete`, running a script) always ask. Call the right command \
+                regardless and explain briefly."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
@@ -88,7 +93,8 @@ pub fn tool_defs() -> Vec<ToolDef> {
             name: "save_script".to_string(),
             description: "Save a reusable SilicoLab `.sls` script of console commands to the \
                 project so a workflow can be replayed with `run <file>`. Use this to capture a \
-                sequence of steps you ran. Writing a file requires the user to confirm."
+                sequence of steps you ran. Writes a file, so it may need the user's approval \
+                depending on their approval mode."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
@@ -117,39 +123,62 @@ pub struct ToolOutcome {
     pub is_error: bool,
 }
 
-/// Whether a tool call must be confirmed by the user before running.
-/// `save_script` writes a file (always gated); `run_command` is gated by verb.
-pub fn needs_confirmation(call: &ToolCall) -> bool {
+/// The approval [`RiskLevel`] of a tool call. `save_script` writes a file
+/// (FileWrite); `run_command` defers to the grammar's [`command_risk`] so risk is
+/// declared once, next to each command; perception tools are read-only.
+pub fn risk_of_call(call: &ToolCall) -> RiskLevel {
     match call.name.as_str() {
-        "save_script" => true,
+        "save_script" => RiskLevel::FileWrite,
         "run_command" => {
             let command = call
                 .input
                 .get("command")
                 .and_then(Value::as_str)
                 .unwrap_or_default();
-            command_needs_confirmation(command)
+            command_risk(command)
         }
-        _ => false,
+        _ => RiskLevel::ReadOnly,
     }
 }
 
-/// Classify a `.sls` command line as needing confirmation. Read-only / cheaply
-/// reversible commands (view/color/surface/representation/inspect) auto-run;
-/// delete, save/overwrite, md/qm runs, and script execution are gated.
-pub fn command_needs_confirmation(command: &str) -> bool {
-    let mut tokens = command.split_whitespace();
-    let verb = tokens.next().unwrap_or_default();
-    // `qm recommend` only prints hartree's level-of-theory table — it runs no
-    // calculation, so it is read-only introspection and should not be gated like
-    // an actual `qm energy|optimize|freq` job. Let the agent consult it freely.
-    if verb == "qm" && tokens.next() == Some("recommend") {
+/// The allow-set key for a call: a `run_command`'s top-level verb, else the tool
+/// name. "Always allow this command" remembers this key for the conversation.
+pub fn call_allow_key(call: &ToolCall) -> String {
+    match call.name.as_str() {
+        "run_command" => call
+            .input
+            .get("command")
+            .and_then(Value::as_str)
+            .and_then(|command| command.split_whitespace().next())
+            .unwrap_or_default()
+            .to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Whether a tool call must be confirmed, given the active [`ApprovalMode`] and
+/// the conversation's allow-set. `Destructive` always confirms — the
+/// non-bypassable floor, checked before mode and allow-set.
+pub fn needs_confirmation(
+    call: &ToolCall,
+    mode: ApprovalMode,
+    allowed_verbs: &HashSet<String>,
+    allowed_risks: &HashSet<RiskLevel>,
+) -> bool {
+    let risk = risk_of_call(call);
+    if risk == RiskLevel::Destructive {
+        return true;
+    }
+    if allowed_risks.contains(&risk) || allowed_verbs.contains(&call_allow_key(call)) {
         return false;
     }
-    matches!(
-        verb,
-        "delete" | "save" | "md" | "qm" | "dock" | "score" | "run" | "source"
-    )
+    match mode {
+        ApprovalMode::Manual => risk != RiskLevel::ReadOnly,
+        ApprovalMode::AutoSafe => matches!(risk, RiskLevel::FileWrite | RiskLevel::Expensive),
+        // Auto and Plan return false here only because Destructive is handled
+        // above and Plan never reaches execution (the batch driver short-circuits).
+        ApprovalMode::Auto | ApprovalMode::Plan => false,
+    }
 }
 
 /// Execute one tool call against `AppState`, returning its textual result.
@@ -427,65 +456,210 @@ mod tests {
         }
     }
 
-    #[test]
-    fn read_only_commands_auto_run() {
-        assert!(!needs_confirmation(&call("view background white")));
-        assert!(!needs_confirmation(&call("color chain A red")));
-        assert!(!needs_confirmation(&call("representation cartoon")));
-        assert!(!needs_confirmation(&call("open 1abc.pdb")));
+    fn save_script_call() -> ToolCall {
+        ToolCall {
+            id: "s".to_string(),
+            name: "save_script".to_string(),
+            input: json!({ "filename": "wf", "commands": ["open x.pdb"] }),
+        }
+    }
+
+    /// Gate with the default mode (AutoSafe) and an empty allow-set.
+    fn gated(command: &str) -> bool {
+        needs_confirmation(
+            &call(command),
+            ApprovalMode::AutoSafe,
+            &HashSet::new(),
+            &HashSet::new(),
+        )
     }
 
     #[test]
-    fn destructive_and_expensive_commands_are_gated() {
-        assert!(needs_confirmation(&call("delete chain A")));
-        assert!(needs_confirmation(&call("save image out.png")));
-        assert!(needs_confirmation(&call("md build")));
-        assert!(needs_confirmation(&call("qm energy")));
-        assert!(needs_confirmation(&call(
-            "dock --receptor active --ligand 2"
-        )));
-        assert!(needs_confirmation(&call(
-            "score --receptor active --ligand 2"
-        )));
-        assert!(needs_confirmation(&call("run setup.sls")));
+    fn risk_classification_matches_the_grammar() {
+        assert_eq!(
+            risk_of_call(&call("view background white")),
+            RiskLevel::ReadOnly
+        );
+        assert_eq!(
+            risk_of_call(&call("color chain A red")),
+            RiskLevel::ReadOnly
+        );
+        assert_eq!(risk_of_call(&call("open 1abc.pdb")), RiskLevel::ReadOnly);
+        assert_eq!(risk_of_call(&call("hydrogen add")), RiskLevel::ReadOnly);
+        assert_eq!(
+            risk_of_call(&call("qm recommend thermochemistry")),
+            RiskLevel::ReadOnly
+        );
+        assert_eq!(
+            risk_of_call(&call("phosphorylate --protein active --at A:1")),
+            RiskLevel::Mutating
+        );
+        assert_eq!(
+            risk_of_call(&call("save image out.png")),
+            RiskLevel::FileWrite
+        );
+        assert_eq!(risk_of_call(&save_script_call()), RiskLevel::FileWrite);
+        assert_eq!(risk_of_call(&call("md build")), RiskLevel::Expensive);
+        assert_eq!(
+            risk_of_call(&call("qm energy --method r2scan-3c")),
+            RiskLevel::Expensive
+        );
+        assert_eq!(
+            risk_of_call(&call("dock --receptor active --ligand 2")),
+            RiskLevel::Expensive
+        );
+        assert_eq!(
+            risk_of_call(&call("score --receptor active")),
+            RiskLevel::Expensive
+        );
+        assert_eq!(risk_of_call(&call("run setup.sls")), RiskLevel::Destructive);
+        // A bare `*.sls` token runs as a script via the console's pre-clap
+        // shortcut, so it must classify Destructive like an explicit `run`.
+        assert_eq!(risk_of_call(&call("setup.sls")), RiskLevel::Destructive);
+        assert_eq!(
+            risk_of_call(&call("delete chain A")),
+            RiskLevel::Destructive
+        );
     }
 
     #[test]
-    fn inspect_is_never_gated() {
+    fn structure_editing_commands_are_never_read_only() {
+        // The silent-bypass bug: PTM / structure-editing verbs must not auto-run
+        // as if read-only. Each must be Mutating; `delete` Destructive.
+        for command in [
+            "phosphorylate --protein active --at A:84",
+            "acetylate --protein active --at A:120",
+            "methylate --protein active --at A:9",
+            "lipidate --protein active --at A:3",
+            "ubiquitinate --protein active --at A:48",
+            "glycosylate --protein active",
+            "glycan GlcNAc",
+        ] {
+            assert_eq!(
+                risk_of_call(&call(command)),
+                RiskLevel::Mutating,
+                "{command}"
+            );
+            assert!(
+                gated_in(command, ApprovalMode::Manual),
+                "{command} must gate in Manual"
+            );
+        }
+        assert_eq!(
+            risk_of_call(&call("save image out.png")),
+            RiskLevel::FileWrite
+        );
+        assert!(gated_in("save image out.png", ApprovalMode::Manual));
+        assert_eq!(
+            risk_of_call(&call("delete chain A")),
+            RiskLevel::Destructive
+        );
+    }
+
+    fn gated_in(command: &str, mode: ApprovalMode) -> bool {
+        needs_confirmation(&call(command), mode, &HashSet::new(), &HashSet::new())
+    }
+
+    #[test]
+    fn autosafe_runs_edits_but_gates_writes_compute_and_destructive() {
+        assert!(!gated("view background white"));
+        assert!(!gated("phosphorylate --protein active --at A:1"));
+        assert!(gated("save image out.png"));
+        assert!(gated("qm energy"));
+        assert!(gated("delete chain A"));
+        assert!(needs_confirmation(
+            &save_script_call(),
+            ApprovalMode::AutoSafe,
+            &HashSet::new(),
+            &HashSet::new(),
+        ));
+    }
+
+    #[test]
+    fn manual_gates_everything_but_read_only() {
+        assert!(!gated_in("view background white", ApprovalMode::Manual));
+        assert!(gated_in("save image out.png", ApprovalMode::Manual));
+        assert!(gated_in("qm energy", ApprovalMode::Manual));
+        assert!(gated_in("delete chain A", ApprovalMode::Manual));
+    }
+
+    #[test]
+    fn auto_runs_everything_except_destructive() {
+        assert!(!gated_in("qm energy", ApprovalMode::Auto));
+        assert!(!gated_in("save image out.png", ApprovalMode::Auto));
+        assert!(gated_in("delete chain A", ApprovalMode::Auto));
+    }
+
+    #[test]
+    fn destructive_always_confirms_and_allow_set_cannot_bypass_it() {
+        let mut verbs = HashSet::new();
+        verbs.insert("delete".to_string());
+        let mut risks = HashSet::new();
+        risks.insert(RiskLevel::Destructive);
+        for mode in ApprovalMode::all() {
+            if mode == ApprovalMode::Plan {
+                continue; // Plan never executes; the gate is not consulted
+            }
+            for command in ["delete chain A", "run setup.sls", "setup.sls"] {
+                assert!(
+                    needs_confirmation(&call(command), mode, &verbs, &risks),
+                    "{command} must confirm in {mode:?} even with an allow-set"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn allow_set_suppresses_gating_for_verb_and_risk() {
+        // Allowing the `qm` verb auto-runs qm in AutoSafe.
+        let mut verbs = HashSet::new();
+        verbs.insert("qm".to_string());
+        assert!(!needs_confirmation(
+            &call("qm energy"),
+            ApprovalMode::AutoSafe,
+            &verbs,
+            &HashSet::new()
+        ));
+        // Allowing the whole Expensive level auto-runs dock too.
+        let mut risks = HashSet::new();
+        risks.insert(RiskLevel::Expensive);
+        assert!(!needs_confirmation(
+            &call("dock --receptor active"),
+            ApprovalMode::AutoSafe,
+            &HashSet::new(),
+            &risks,
+        ));
+    }
+
+    #[test]
+    fn unparseable_command_is_read_only_so_it_runs_and_self_reports_the_error() {
+        // An invalid command reaches no effect (it errors before dispatch), so
+        // gating it would only nag the user; let it run and fail instead.
+        assert_eq!(risk_of_call(&call("inspect")), RiskLevel::ReadOnly);
+        assert!(!gated("frobnicate the molecule"));
+    }
+
+    #[test]
+    fn perception_tools_are_never_gated() {
         let inspect_call = ToolCall {
             id: "t".to_string(),
             name: "inspect".to_string(),
             input: json!({}),
         };
-        assert!(!needs_confirmation(&inspect_call));
-    }
-
-    #[test]
-    fn recommend_method_tool_is_never_gated() {
         let recommend = ToolCall {
             id: "t".to_string(),
             name: "recommend_method".to_string(),
             input: json!({ "task": "thermochemistry" }),
         };
-        assert!(!needs_confirmation(&recommend));
-    }
-
-    #[test]
-    fn qm_recommend_is_read_only_and_not_gated() {
-        // `qm recommend` only prints the level-of-theory table — never gated,
-        // even though a real `qm` calculation is.
-        assert!(!needs_confirmation(&call("qm recommend thermochemistry")));
-        assert!(needs_confirmation(&call("qm energy --method r2scan-3c")));
-    }
-
-    #[test]
-    fn save_script_is_gated() {
-        let call = ToolCall {
-            id: "s".to_string(),
-            name: "save_script".to_string(),
-            input: json!({ "filename": "wf", "commands": ["open x.pdb"] }),
-        };
-        assert!(needs_confirmation(&call));
+        for c in [&inspect_call, &recommend] {
+            assert_eq!(risk_of_call(c), RiskLevel::ReadOnly);
+            assert!(!needs_confirmation(
+                c,
+                ApprovalMode::Manual,
+                &HashSet::new(),
+                &HashSet::new()
+            ));
+        }
     }
 
     #[test]

--- a/src/frontend/console.rs
+++ b/src/frontend/console.rs
@@ -268,13 +268,13 @@ pub fn command_catalog() -> String {
         "  surface chain <id>; surface style fill|mesh; surface transparency <0-100>; surface clear",
         "  show ions [--within 3.5]",
         "",
-        "Editing (gated — the user confirms before these run):",
+        "Editing & saving (`save` writes a file; `delete` is destructive and always asks):",
         "  hydrogen add                Add missing hydrogens to the active structure.",
         "  delete chain <A,B,...>      Delete the listed chains.",
-        "  save image <path.png>       Render the viewport to a PNG.",
-        "  save view <path.sls>        Save the current view as a replayable script.",
+        "  save image <path.png>       Render the viewport to a PNG (may overwrite).",
+        "  save view <path.sls>        Save the current view as a replayable script (may overwrite).",
         "",
-        "Simulation (gated — minutes/GPU):",
+        "Simulation (compute — minutes/GPU; runs in the background):",
         "  md build                    Box + capture topology for the active structure.",
         "  md simulate [--time 1ns] [--temperature 300] [--no-relax]",
         "  qm energy|optimize|freq|ts [--method b3lyp] [--basis def2-svp] [--charge 0] [--spin 1]",
@@ -288,7 +288,9 @@ pub fn command_catalog() -> String {
         "  score --receptor <entry> --ligand <entry> [--center x,y,z] [--size x,y,z]   (single-point pose score)",
         "",
         "Tips: render commands target the active entry unless given `--global`. Call `inspect` \
-         first when you are unsure what is loaded.",
+         first when you are unsure what is loaded. Commands are risk-classified; whether one \
+         needs the user's approval depends on their approval mode (Settings ▸ Assistant), and \
+         destructive commands (`delete`, running a script) always ask.",
     ]
     .join("\n")
 }

--- a/src/frontend/console/grammar.rs
+++ b/src/frontend/console/grammar.rs
@@ -424,7 +424,82 @@ pub(crate) enum SaveTarget {
     View { path: PathBuf },
 }
 
+/// How consequential a command is — the input to the assistant's approval gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum RiskLevel {
+    /// View/inspection and additive, low-stakes building; safe to auto-run.
+    ReadOnly,
+    /// Edits the active structure in memory (reversible by reloading).
+    Mutating,
+    /// Writes a file to disk, which may overwrite an existing one — not
+    /// reversible from the app, so it confirms even in the safe-auto default.
+    FileWrite,
+    /// Launches a compute job (minutes/GPU).
+    Expensive,
+    /// Irreversibly removes data, or executes an arbitrary script whose effects
+    /// cannot be known in advance — always prompts, in every mode.
+    Destructive,
+}
+
+impl RiskLevel {
+    /// A short human noun for the level, for approval cards and prose.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            RiskLevel::ReadOnly => "read-only",
+            RiskLevel::Mutating => "structure edit",
+            RiskLevel::FileWrite => "file write",
+            RiskLevel::Expensive => "compute",
+            RiskLevel::Destructive => "destructive",
+        }
+    }
+}
+
 impl Command {
+    /// This command's approval risk. The match is deliberately wildcard-free, so
+    /// a new `Command` variant fails to compile until it is classified — never
+    /// default a new command to safe.
+    pub(crate) fn risk(&self) -> RiskLevel {
+        use RiskLevel::*;
+        match self {
+            Command::Open { .. }
+            | Command::Activate { .. }
+            | Command::Sketch { .. }
+            | Command::Fetch { .. }
+            | Command::View(_)
+            | Command::Cartoon(_)
+            | Command::Color(_)
+            | Command::Surface(_)
+            | Command::Show(_)
+            | Command::Representation(_)
+            | Command::Hydrogen { .. }
+            | Command::Help => ReadOnly,
+            // `qm recommend` only prints the level-of-theory table (read-only);
+            // every other `qm` sub-verb launches a calculation.
+            Command::Qm { args } => {
+                if args.first().map(String::as_str) == Some("recommend") {
+                    ReadOnly
+                } else {
+                    Expensive
+                }
+            }
+            Command::Glycan(_)
+            | Command::Glycosylate(_)
+            | Command::Phosphorylate(_)
+            | Command::Acetylate(_)
+            | Command::Methylate(_)
+            | Command::Lipidate(_)
+            | Command::Ubiquitinate(_) => Mutating,
+            Command::Save { .. } => FileWrite,
+            Command::Md { .. }
+            | Command::Disorder { .. }
+            | Command::Dock(_)
+            | Command::Score(_) => Expensive,
+            // `Source` runs a script's lines straight through the console with no
+            // per-line gate, so it can `delete` — it must clear the floor itself.
+            Command::Delete { .. } | Command::Source { .. } => Destructive,
+        }
+    }
+
     /// Run the parsed command against `state`, mirroring the old `match` arms.
     /// The effect bodies live in the sibling modules; this only routes.
     pub(crate) fn dispatch(
@@ -493,6 +568,29 @@ pub(crate) fn run(
     };
     let root = Root::from_arg_matches(&matches).map_err(|err| anyhow!("{err}"))?;
     root.command.dispatch(state, context)
+}
+
+/// The approval [`RiskLevel`] of a raw `.sls` command line, for the assistant's
+/// gate. Classified through the exact same entry points as
+/// [`execute_console_line`](super::execute_console_line), so risk can never
+/// diverge from execution: first the bare-`*.sls` script shortcut (a
+/// whitespace-free `.sls` token runs a script with no per-line gate, so it is
+/// `Destructive` just like an explicit `run`), then the clap grammar. A line that
+/// reaches neither is `ReadOnly`: it errors before any effect, so there is nothing
+/// to gate and the model gets that error back to self-correct.
+pub(crate) fn command_risk(command: &str) -> RiskLevel {
+    if super::looks_like_script_path(command) {
+        return RiskLevel::Destructive;
+    }
+    let Ok(words) = super::shell_words(command) else {
+        return RiskLevel::ReadOnly;
+    };
+    match root_command().try_get_matches_from(&words) {
+        Ok(matches) => Root::from_arg_matches(&matches)
+            .map(|root| root.command.risk())
+            .unwrap_or(RiskLevel::ReadOnly),
+        Err(_) => RiskLevel::ReadOnly,
+    }
 }
 
 fn render_clap_error(err: clap::Error) -> Result<String> {

--- a/src/frontend/dispatcher/mod.rs
+++ b/src/frontend/dispatcher/mod.rs
@@ -332,6 +332,13 @@ pub fn dispatch(state: &mut AppState, action: AppAction, ctx: &egui::Context) {
             crate::frontend::agent::approve_tool_call(state, &id, ctx)
         }
         AppAction::RejectToolCall(id) => crate::frontend::agent::reject_tool_call(state, &id, ctx),
+        AppAction::AlwaysAllowCommand(id) => {
+            crate::frontend::agent::always_allow_command(state, &id, ctx)
+        }
+        AppAction::AlwaysAllowRisk(id) => {
+            crate::frontend::agent::always_allow_risk(state, &id, ctx)
+        }
+        AppAction::SetApprovalMode(mode) => crate::frontend::agent::set_approval_mode(state, mode),
         AppAction::RemoveQueuedAgentInput(index) => {
             crate::frontend::agent::remove_queued_agent_input(state, index)
         }

--- a/src/frontend/ui/panel_bodies/assistant.rs
+++ b/src/frontend/ui/panel_bodies/assistant.rs
@@ -29,7 +29,6 @@ pub(crate) fn render_assistant_panel(
     use crate::frontend::agent::TranscriptEntry;
     use crate::frontend::agent::registry;
     use crate::frontend::agent::session::AgentPhase;
-    use crate::frontend::theme::radius;
 
     let pal = crate::frontend::theme::palette(ui);
     ui.set_width(ui.available_width());
@@ -37,7 +36,8 @@ pub(crate) fn render_assistant_panel(
     let provider = registry::active_provider(&state.config.assistant);
     // Cached (the live check reads env + the key store); refreshed off the hot path.
     let key_present = state.ui.agent.key_available.unwrap_or(false);
-    let pending_call = state.ui.agent.pending_approval().cloned();
+    // Cloned so the cards can render without holding a borrow on `state`.
+    let gated_calls = crate::frontend::agent::gated_pending(state);
     let active_id = state.ui.agent.active_conversation;
     // Snapshot the queued (type-ahead) follow-ups so the strip can render without
     // holding a borrow on `state` while the composer mutably borrows the input.
@@ -75,17 +75,7 @@ pub(crate) fn render_assistant_panel(
                     0.0
                 };
             let panel_width = ui.available_width();
-            let approval_height = pending_call
-                .as_ref()
-                .map(|call| {
-                    let command = call
-                        .input
-                        .get("command")
-                        .and_then(|value| value.as_str())
-                        .unwrap_or(&call.name);
-                    approval_row_height(command, panel_width)
-                })
-                .unwrap_or(0.0);
+            let approval_height = approval_block_height(&gated_calls, panel_width);
             let running_height = running_strip_height(&running_jobs);
             let queued_height = queued_strip_height(&queued);
             let footer_height = status_height
@@ -214,64 +204,24 @@ pub(crate) fn render_assistant_panel(
 
             ui.add_space(3.0);
 
-            if let Some(call) = &pending_call {
-                let command = call
-                    .input
-                    .get("command")
-                    .and_then(|value| value.as_str())
-                    .unwrap_or(&call.name);
+            if !gated_calls.is_empty() {
                 assistant_inset_row(ui, approval_height, |ui| {
-                    let frame_inner_width = (panel_width - 20.0).max(48.0);
-                    Frame::default()
-                        .fill(blend(pal.status_amber, pal.input_fill, 0.86))
-                        .stroke(Stroke::new(1.0, blend(pal.status_amber, pal.hairline, 0.4)))
-                        .corner_radius(CornerRadius::same(radius::CARD))
-                        .inner_margin(Margin::symmetric(10, 8))
-                        .show(ui, |ui| {
-                            ui.set_width(frame_inner_width);
-                            ui.horizontal(|ui| {
-                                ui.label(
-                                    RichText::new(format!(
-                                        "{}  Approve to run",
-                                        egui_phosphor::regular::WARNING
-                                    ))
-                                    .strong()
-                                    .color(pal.status_amber),
-                                );
-                            });
-                            ui.add_space(2.0);
-                            ui.add(
-                                egui::Label::new(assistant_text(command).color(pal.text_primary))
-                                    .wrap_mode(egui::TextWrapMode::Wrap),
-                            );
-                            ui.add_space(6.0);
-                            ui.horizontal(|ui| {
-                                let approve = Button::new(
-                                    RichText::new(format!(
-                                        "{}  Approve",
-                                        egui_phosphor::regular::CHECK
-                                    ))
-                                    .color(Color32::WHITE),
-                                )
-                                .fill(pal.status_green)
-                                .corner_radius(CornerRadius::same(radius::CONTROL));
-                                if ui.add(approve).clicked() {
-                                    actions.push(AppAction::ApproveToolCall(call.id.clone()));
-                                }
-                                if ui
-                                    .add(
-                                        Button::new(
-                                            RichText::new("Reject").color(pal.text_primary),
-                                        )
-                                        .fill(pal.neutral_overlay(16))
-                                        .corner_radius(CornerRadius::same(radius::CONTROL)),
-                                    )
-                                    .clicked()
-                                {
-                                    actions.push(AppAction::RejectToolCall(call.id.clone()));
-                                }
-                            });
-                        });
+                    if gated_calls.len() > 1 {
+                        ui.label(
+                            RichText::new(format!(
+                                "{}  {} commands need your approval",
+                                egui_phosphor::regular::WARNING,
+                                gated_calls.len()
+                            ))
+                            .strong()
+                            .color(pal.status_amber),
+                        );
+                        ui.add_space(4.0);
+                    }
+                    for call in &gated_calls {
+                        render_approval_card(ui, &pal, actions, call, panel_width);
+                        ui.add_space(6.0);
+                    }
                 });
                 ui.add_space(4.0);
             }
@@ -426,11 +376,155 @@ fn assistant_toolbar(
     });
 }
 
-fn approval_row_height(command: &str, panel_width: f32) -> f32 {
+fn call_command_text(call: &crate::io::llm::types::ToolCall) -> &str {
+    call.input
+        .get("command")
+        .and_then(|value| value.as_str())
+        .unwrap_or(&call.name)
+}
+
+/// Height of one approval card: command lines, plus an impact line and the
+/// "always allow" row when present.
+fn approval_card_height(call: &crate::io::llm::types::ToolCall, panel_width: f32) -> f32 {
+    use crate::frontend::console::RiskLevel;
+    let command = call_command_text(call);
     let text_width = (panel_width - 40.0).max(48.0);
     let chars_per_line = (text_width / 7.0).max(8.0);
-    let command_lines = (command.chars().count() as f32 / chars_per_line).ceil();
-    74.0 + command_lines.max(1.0) * 22.0
+    let command_lines = (command.chars().count() as f32 / chars_per_line)
+        .ceil()
+        .max(1.0);
+    let mut height = 74.0 + command_lines * 22.0;
+    if crate::frontend::agent::impact_hint(call).is_some() {
+        height += 18.0;
+    }
+    if crate::frontend::agent::tools::risk_of_call(call) != RiskLevel::Destructive {
+        height += 28.0; // the "always allow" button row
+    }
+    height
+}
+
+/// Total height of the approval block: every card, gaps, and a multi-call header.
+fn approval_block_height(calls: &[crate::io::llm::types::ToolCall], panel_width: f32) -> f32 {
+    if calls.is_empty() {
+        return 0.0;
+    }
+    let header = if calls.len() > 1 { 24.0 } else { 0.0 };
+    let gaps = calls.len() as f32 * 6.0;
+    let cards: f32 = calls
+        .iter()
+        .map(|call| approval_card_height(call, panel_width))
+        .sum();
+    header + gaps + cards
+}
+
+/// One approval card: the command, its risk and (for compute) cost, and the
+/// approve / reject / remember controls. Destructive calls omit the remember
+/// controls — they always prompt, so "always allow" would be a lie.
+fn render_approval_card(
+    ui: &mut egui::Ui,
+    pal: &crate::frontend::theme::Palette,
+    actions: &mut Vec<AppAction>,
+    call: &crate::io::llm::types::ToolCall,
+    panel_width: f32,
+) {
+    use crate::frontend::console::RiskLevel;
+    use crate::frontend::theme::radius;
+
+    let command = call_command_text(call);
+    let risk = crate::frontend::agent::tools::risk_of_call(call);
+    let impact = crate::frontend::agent::impact_hint(call);
+    let accent = if risk == RiskLevel::Destructive {
+        pal.status_red
+    } else {
+        pal.status_amber
+    };
+    let card_height = approval_card_height(call, panel_width);
+
+    assistant_inset_row(ui, card_height, |ui| {
+        let frame_inner_width = (panel_width - 20.0).max(48.0);
+        Frame::default()
+            .fill(blend(accent, pal.input_fill, 0.86))
+            .stroke(Stroke::new(1.0, blend(accent, pal.hairline, 0.4)))
+            .corner_radius(CornerRadius::same(radius::CARD))
+            .inner_margin(Margin::symmetric(10, 8))
+            .show(ui, |ui| {
+                ui.set_width(frame_inner_width);
+                ui.horizontal(|ui| {
+                    ui.label(
+                        RichText::new(format!(
+                            "{}  Approve to run · {}",
+                            egui_phosphor::regular::WARNING,
+                            risk.label()
+                        ))
+                        .strong()
+                        .color(accent),
+                    );
+                });
+                ui.add_space(2.0);
+                ui.add(
+                    egui::Label::new(assistant_text(command).color(pal.text_primary))
+                        .wrap_mode(egui::TextWrapMode::Wrap),
+                );
+                if let Some(impact) = &impact {
+                    ui.label(RichText::new(impact).small().color(pal.text_tertiary));
+                }
+                ui.add_space(6.0);
+                ui.horizontal(|ui| {
+                    let approve = Button::new(
+                        RichText::new(format!("{}  Approve", egui_phosphor::regular::CHECK))
+                            .color(Color32::WHITE),
+                    )
+                    .fill(pal.status_green)
+                    .corner_radius(CornerRadius::same(radius::CONTROL));
+                    if ui.add(approve).clicked() {
+                        actions.push(AppAction::ApproveToolCall(call.id.clone()));
+                    }
+                    if ui
+                        .add(
+                            Button::new(RichText::new("Reject").color(pal.text_primary))
+                                .fill(pal.neutral_overlay(16))
+                                .corner_radius(CornerRadius::same(radius::CONTROL)),
+                        )
+                        .clicked()
+                    {
+                        actions.push(AppAction::RejectToolCall(call.id.clone()));
+                    }
+                });
+                if risk != RiskLevel::Destructive {
+                    ui.add_space(4.0);
+                    ui.horizontal(|ui| {
+                        let verb = crate::frontend::agent::tools::call_allow_key(call);
+                        if ui
+                            .add(small_allow_button(pal, &format!("Always allow `{verb}`")))
+                            .clicked()
+                        {
+                            actions.push(AppAction::AlwaysAllowCommand(call.id.clone()));
+                        }
+                        if ui
+                            .add(small_allow_button(
+                                pal,
+                                &format!("Always allow all {} commands", risk.label()),
+                            ))
+                            .clicked()
+                        {
+                            actions.push(AppAction::AlwaysAllowRisk(call.id.clone()));
+                        }
+                    });
+                }
+            });
+    });
+}
+
+/// A small, low-emphasis "remember this decision" button.
+fn small_allow_button(pal: &crate::frontend::theme::Palette, text: &str) -> Button<'static> {
+    use crate::frontend::theme::radius;
+    Button::new(
+        RichText::new(text.to_string())
+            .small()
+            .color(pal.text_muted),
+    )
+    .fill(pal.neutral_overlay(10))
+    .corner_radius(CornerRadius::same(radius::CONTROL))
 }
 
 pub(crate) fn assistant_inset_row<R>(

--- a/src/frontend/ui/settings_registry/custom.rs
+++ b/src/frontend/ui/settings_registry/custom.rs
@@ -237,6 +237,30 @@ pub(crate) fn render_assistant_settings(
             });
         });
     });
+    let current_mode = state.config.assistant.approval_mode;
+    ui.horizontal(|ui| {
+        ui.label("Approvals");
+        egui::ComboBox::from_id_salt("assistant.approval_mode")
+            .selected_text(current_mode.short_label())
+            .show_ui(ui, |ui| {
+                crate::frontend::theme::stabilize_selectable_rows(ui);
+                for mode in crate::backend::config::ApprovalMode::all() {
+                    if ui
+                        .selectable_label(mode == current_mode, mode.label())
+                        .clicked()
+                        && mode != current_mode
+                    {
+                        actions.push(AppAction::SetApprovalMode(mode));
+                    }
+                }
+            });
+    });
+    ui.label(
+        RichText::new("Destructive commands (delete, running a script) always ask.")
+            .size(CAPTION_SIZE)
+            .color(pal.text_tertiary),
+    );
+
     // OpenAI-compatible endpoints take arbitrary model ids the built-in table
     // can't know, so let the user pin effort support for the active model. The
     // checkbox shows the effective capability; toggling it persists an override.


### PR DESCRIPTION
## Summary

Redesigns the in-app assistant's command-approval gate around a single source of truth, fixing a silent-bypass bug where PTM / structure-editing commands auto-ran unclassified.

Risk now lives in the console grammar: a new `RiskLevel` and `Command::risk()` declare each command's consequence next to its definition, via an exhaustive **wildcard-free** match — a new `Command` variant cannot compile until it is classified, so nothing ever defaults to "safe". `command_risk()` parses a raw line through the *same* clap grammar as dispatch, so risk can never drift from execution. The hardcoded verb blacklist is deleted.

## Risk tiers

Separated by reversibility:

| Tier | Examples | Reversible? |
|------|----------|-------------|
| `ReadOnly` | view/inspect, `open`, `fetch`, `qm recommend` | n/a |
| `Mutating` | PTMs, `glycosylate`, in-memory structure edits | by reloading |
| `FileWrite` | `save image`, `save view`, `save_script` | no — may overwrite |
| `Expensive` | `md`, `qm`, `dock`, `score` | n/a (compute) |
| `Destructive` | `delete`, `run`/`source` (arbitrary script) | no |

## Policy

A global `ApprovalMode` (Manual / AutoSafe / Auto / Plan; default **AutoSafe**), persisted in `AssistantConfig`. The gate = risk + mode + a session-scoped allow-set. `Destructive` always prompts — the non-bypassable floor, defended in the gate, the allow-set, and the UI.

In the default AutoSafe mode, in-memory edits auto-run, but **file writes, compute, and destructive commands confirm** — so the assistant never overwrites a file or launches a job without a click.

## UX

- Gated calls in a turn render together as a **batch of cards** (per-item approve/reject, resolvable in any order while execution stays in queue order).
- Expensive cards show the heavy/background impact.
- "Always allow this command" / "always allow all <risk>" remember the decision for the conversation.
- **Plan mode** records doer commands as proposals without running them — but read-only perception (`inspect`, `recommend_method`) still runs, so the model can ground its plan in the actual workspace.

`AssistantConfig` + `ApprovalMode` moved to a new `backend/assistant_config.rs` to keep `config.rs` under the file-size cap. The command catalog, persona prompt, and tool descriptions are updated to match.

## Tests

New coverage for the risk↔grammar mapping, the no-bypass property (every PTM/destructive command), per-mode gating, the allow-set (including that it can't bypass the Destructive floor), batch any-order resolution, and Plan mode (perception runs, doers don't).

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib` ✅ 331 passed