### PR TITLE
fix(ui): confirm destructive actions and tighten rename semantics

### DIFF
--- a/src/backend/entries.rs
+++ b/src/backend/entries.rs
@@ -512,6 +512,23 @@ mod tests {
     }
 
     #[test]
+    fn rename_entry_keeps_existing_name_when_blank() {
+        let mut store = EntryStore::with_initial(
+            Structure::empty(),
+            None,
+            PathBuf::from(r"C:\tmp\untitled.xyz"),
+        );
+        let id = store.active_entry_id().expect("seeded entry");
+        let original = store.entry(id).expect("entry exists").name.clone();
+
+        store.rename_entry(id, "   ".to_string());
+        assert_eq!(store.entry(id).unwrap().name, original);
+
+        store.rename_entry(id, "  Ethanol  ".to_string());
+        assert_eq!(store.entry(id).unwrap().name, "Ethanol");
+    }
+
+    #[test]
     fn deleting_group_moves_entries_to_fallback() {
         let mut store = EntryStore::with_initial(
             Structure::empty(),

--- a/src/frontend/dispatcher/selection.rs
+++ b/src/frontend/dispatcher/selection.rs
@@ -315,6 +315,19 @@ pub(crate) fn delete_group_with_entries(state: &mut AppState, group_id: &str) {
     delete_group(state, group_id);
 }
 
+/// The group's display name and how many entries would be destroyed alongside
+/// it, for a delete confirmation prompt. `None` if the group id is unknown.
+pub(crate) fn group_delete_summary(state: &AppState, group_id: &str) -> Option<(String, usize)> {
+    let name = state.entries.group(group_id)?.name.clone();
+    let count = state
+        .entries
+        .records
+        .iter()
+        .filter(|entry| entry.group_id == group_id)
+        .count();
+    Some((name, count))
+}
+
 pub(crate) fn move_entry_to_group(state: &mut AppState, entry_id: u64, group_id: &str) {
     if state.entries.move_entry_to_group(entry_id, group_id) {
         if group_id.is_empty() {
@@ -540,6 +553,35 @@ mod tests {
             Vec::new(),
             None,
         )
+    }
+
+    #[test]
+    fn group_delete_summary_counts_members() {
+        let mut state = scratch_state(test_structure("mol"));
+        let gid = state
+            .entries
+            .create_group("Proteins")
+            .expect("group created");
+        state.entries.add_entry_to_group(
+            test_structure("1abc"),
+            None,
+            PathBuf::from("1abc.xyz"),
+            gid.clone(),
+            None,
+            false,
+        );
+        state.entries.add_entry_to_group(
+            test_structure("2xyz"),
+            None,
+            PathBuf::from("2xyz.xyz"),
+            gid.clone(),
+            None,
+            false,
+        );
+
+        let (name, count) = super::group_delete_summary(&state, &gid).expect("group exists");
+        assert_eq!(name, "Proteins");
+        assert_eq!(count, 2);
     }
 
     #[test]

--- a/src/frontend/ui/entry_item.rs
+++ b/src/frontend/ui/entry_item.rs
@@ -23,14 +23,17 @@ pub(crate) fn render_entry_list_item(
             [ui.available_width(), 20.0],
             egui::TextEdit::singleline(&mut state.ui.entry_list.rename_buffer),
         );
-        if response.lost_focus() {
-            actions.push(AppAction::RenameEntry {
-                entry_id,
-                new_name: state.ui.entry_list.rename_buffer.clone(),
-            });
-            state.ui.entry_list.renaming_entry_id = None;
-        }
+        // Commit only on Enter; committing on any lost_focus would rename on an
+        // incidental click-away.
         if ui.input(|i| i.key_pressed(egui::Key::Escape)) {
+            state.ui.entry_list.renaming_entry_id = None;
+        } else if response.lost_focus() {
+            if ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                actions.push(AppAction::RenameEntry {
+                    entry_id,
+                    new_name: state.ui.entry_list.rename_buffer.clone(),
+                });
+            }
             state.ui.entry_list.renaming_entry_id = None;
         }
     } else {

--- a/src/frontend/ui/entry_item.rs
+++ b/src/frontend/ui/entry_item.rs
@@ -242,6 +242,7 @@ pub(crate) fn render_entry_list_item(
             }
             ui.separator();
             render_delete_menu_items(
+                state,
                 ui,
                 actions,
                 &sel_entry_ids,

--- a/src/frontend/ui/entry_list.rs
+++ b/src/frontend/ui/entry_list.rs
@@ -434,7 +434,7 @@ pub(crate) fn render_group_header(
                 egui::Button::new(RichText::new(egui_phosphor::regular::TRASH).size(11.0))
                     .frame(false),
             )
-            .on_hover_text("Delete group")
+            .on_hover_text("Ungroup")
             .clicked();
         let pencil = right_ui
             .add(

--- a/src/frontend/ui/entry_list.rs
+++ b/src/frontend/ui/entry_list.rs
@@ -476,6 +476,7 @@ pub(crate) fn render_group_header(
         }
         ui.separator();
         render_delete_menu_items(
+            state,
             ui,
             actions,
             &sel_entry_ids,
@@ -550,6 +551,7 @@ pub(crate) fn render_group_header(
 }
 
 pub(crate) fn render_delete_menu_items(
+    state: &AppState,
     ui: &mut egui::Ui,
     actions: &mut Vec<AppAction>,
     sel_entry_ids: &[u64],
@@ -571,7 +573,19 @@ pub(crate) fn render_delete_menu_items(
                 actions.push(AppAction::DeleteGroup(gid.to_string()));
                 ui.close();
             }
-            if ui.button("Delete Group and All Entries").clicked() {
+            let (gname, gcount) = crate::frontend::dispatcher::group_delete_summary(state, gid)
+                .unwrap_or_else(|| (gid.to_string(), 0));
+            let noun = if gcount == 1 { "entry" } else { "entries" };
+            let prompt = format!(
+                "Delete \u{201c}{gname}\u{201d} and {gcount} {noun}? This cannot be undone."
+            );
+            if crate::frontend::ui::widgets::confirm_destructive(
+                ui,
+                ("del_group_entries", gid),
+                &prompt,
+                "Delete",
+                |ui| ui.button("Delete Group and All Entries"),
+            ) {
                 actions.push(AppAction::DeleteGroupWithEntries(gid.to_string()));
                 ui.close();
             }
@@ -607,7 +621,25 @@ pub(crate) fn render_delete_menu_items(
         } else {
             format!("Delete {} Groups and Their Entries", n_groups)
         };
-        if ui.button(lbl2).clicked() {
+        let total_entries: usize = sel_group_ids
+            .iter()
+            .filter_map(|gid| crate::frontend::dispatcher::group_delete_summary(state, gid))
+            .map(|(_, count)| count)
+            .sum();
+        let noun = if total_entries == 1 {
+            "entry"
+        } else {
+            "entries"
+        };
+        let prompt =
+            format!("Delete {n_groups} groups and {total_entries} {noun}? This cannot be undone.");
+        if crate::frontend::ui::widgets::confirm_destructive(
+            ui,
+            "del_groups_entries_batch",
+            &prompt,
+            "Delete",
+            |ui| ui.button(lbl2),
+        ) {
             for gid in sel_group_ids {
                 actions.push(AppAction::DeleteGroupWithEntries(gid.clone()));
             }

--- a/src/frontend/ui/entry_list.rs
+++ b/src/frontend/ui/entry_list.rs
@@ -420,8 +420,10 @@ pub(crate) fn render_group_header(
         state.ui.entry_list.rename_group_focus_requested = false;
     }
 
-    // Edit / delete buttons in the right area.
-    let (btn_pencil, btn_trash) = {
+    // Edit / delete buttons in the right area, revealed on row hover. Gate on
+    // `contains_pointer` rather than `hovered`: the buttons win the pointer once
+    // it reaches them, so a `hovered` gate would drop them mid-reach.
+    let (btn_pencil, btn_trash) = if row_resp.contains_pointer() {
         let mut right_ui = ui.new_child(
             egui::UiBuilder::new()
                 .max_rect(right_rect)
@@ -432,6 +434,7 @@ pub(crate) fn render_group_header(
                 egui::Button::new(RichText::new(egui_phosphor::regular::TRASH).size(11.0))
                     .frame(false),
             )
+            .on_hover_text("Delete group")
             .clicked();
         let pencil = right_ui
             .add(
@@ -440,8 +443,11 @@ pub(crate) fn render_group_header(
                 )
                 .frame(false),
             )
+            .on_hover_text("Rename group")
             .clicked();
         (pencil, trash)
+    } else {
+        (false, false)
     };
 
     if btn_pencil {

--- a/src/frontend/ui/panel_bodies/assistant.rs
+++ b/src/frontend/ui/panel_bodies/assistant.rs
@@ -272,8 +272,10 @@ fn assistant_toolbar(
                     egui::TextEdit::singleline(&mut state.ui.agent.rename_buffer)
                         .desired_width(edit_width),
                 );
-                let submit =
-                    response.lost_focus() && ui.input(|input| input.key_pressed(egui::Key::Enter));
+                let name_filled = !state.ui.agent.rename_buffer.trim().is_empty();
+                let submit = response.lost_focus()
+                    && ui.input(|input| input.key_pressed(egui::Key::Enter))
+                    && name_filled;
                 if submit {
                     actions.push(AppAction::RenameAssistantConversation {
                         id: active_id,
@@ -282,7 +284,7 @@ fn assistant_toolbar(
                 }
                 if ui
                     .add_enabled(
-                        can_manage,
+                        can_manage && name_filled,
                         Button::new(RichText::new(egui_phosphor::regular::CHECK))
                             .min_size(button_size),
                     )

--- a/src/frontend/ui/panel_bodies/assistant.rs
+++ b/src/frontend/ui/panel_bodies/assistant.rs
@@ -360,15 +360,26 @@ fn assistant_toolbar(
                     state.ui.agent.renaming_conversation = Some(active_id);
                     state.ui.agent.rename_buffer = active_title.to_string();
                 }
-                if ui
-                    .add_enabled(
-                        can_manage,
-                        Button::new(RichText::new(egui_phosphor::regular::TRASH))
-                            .min_size(button_size),
-                    )
-                    .on_hover_text("Delete conversation")
-                    .clicked()
-                {
+                let is_last = conversations.len() <= 1;
+                let (prompt, confirm_word, hover) = if is_last {
+                    ("Clear this conversation?", "Clear", "Clear conversation")
+                } else {
+                    ("Delete this conversation?", "Delete", "Delete conversation")
+                };
+                if crate::frontend::ui::widgets::confirm_destructive(
+                    ui,
+                    ("del_conversation", active_id),
+                    prompt,
+                    confirm_word,
+                    |ui| {
+                        ui.add_enabled(
+                            can_manage,
+                            Button::new(RichText::new(egui_phosphor::regular::TRASH))
+                                .min_size(button_size),
+                        )
+                        .on_hover_text(hover)
+                    },
+                ) {
                     actions.push(AppAction::DeleteAssistantConversation(active_id));
                 }
             }

--- a/src/frontend/ui/secondary_sidebar/md_run.rs
+++ b/src/frontend/ui/secondary_sidebar/md_run.rs
@@ -470,10 +470,26 @@ pub(crate) fn render_md_stage_card(
                 {
                     actions.push(AppAction::ToggleMdRunStageExpanded(index));
                 }
-                if ui
-                    .add(egui::Button::new(egui_phosphor::regular::TRASH).frame(false))
-                    .clicked()
-                {
+                // A stage carrying free-form raw passthrough holds user-entered
+                // Details that a delete would discard; gate it behind a confirm.
+                // A stage without any deletes directly.
+                let remove_clicked = if stage.raw_passthrough.is_empty() {
+                    ui.add(egui::Button::new(egui_phosphor::regular::TRASH))
+                        .on_hover_text("Remove stage")
+                        .clicked()
+                } else {
+                    crate::frontend::ui::widgets::confirm_destructive(
+                        ui,
+                        ("del_md_stage", index),
+                        "Remove this stage and its custom details?",
+                        "Remove",
+                        |ui| {
+                            ui.add(egui::Button::new(egui_phosphor::regular::TRASH))
+                                .on_hover_text("Remove stage")
+                        },
+                    )
+                };
+                if remove_clicked {
                     actions.push(AppAction::RemoveMdRunStage(index));
                 }
                 if ui
@@ -481,6 +497,7 @@ pub(crate) fn render_md_stage_card(
                         index + 1 < total,
                         egui::Button::new(egui_phosphor::regular::ARROW_DOWN),
                     )
+                    .on_hover_text("Move down")
                     .clicked()
                 {
                     actions.push(AppAction::MoveMdRunStage { index, up: false });
@@ -490,6 +507,7 @@ pub(crate) fn render_md_stage_card(
                         index > 0,
                         egui::Button::new(egui_phosphor::regular::ARROW_UP),
                     )
+                    .on_hover_text("Move up")
                     .clicked()
                 {
                     actions.push(AppAction::MoveMdRunStage { index, up: true });

--- a/src/frontend/ui/secondary_sidebar/md_run.rs
+++ b/src/frontend/ui/secondary_sidebar/md_run.rs
@@ -472,16 +472,18 @@ pub(crate) fn render_md_stage_card(
                 }
                 // A stage carrying free-form raw passthrough holds user-entered
                 // Details that a delete would discard; gate it behind a confirm.
-                // A stage without any deletes directly.
                 let remove_clicked = if stage.raw_passthrough.is_empty() {
                     ui.add(egui::Button::new(egui_phosphor::regular::TRASH))
                         .on_hover_text("Remove stage")
                         .clicked()
                 } else {
+                    // Salt by stage name as well as index: keyed on index alone, a
+                    // reorder mid-confirm would carry the armed state onto whatever
+                    // stage slides into this slot.
                     crate::frontend::ui::widgets::confirm_destructive(
                         ui,
-                        ("del_md_stage", index),
-                        "Remove this stage and its custom details?",
+                        ("del_md_stage", index, stage.name.as_str()),
+                        "Remove stage and its details?",
                         "Remove",
                         |ui| {
                             ui.add(egui::Button::new(egui_phosphor::regular::TRASH))

--- a/src/frontend/ui/views/engines.rs
+++ b/src/frontend/ui/views/engines.rs
@@ -171,7 +171,13 @@ pub(crate) fn render_engine_settings(
             if ui.button("Apply & Detect").clicked() {
                 actions.push(AppAction::ApplyEngineOverride(row.id));
             }
-            if ui.button("Clear").clicked() {
+            if crate::frontend::ui::widgets::confirm_destructive(
+                ui,
+                ("clear_engine_override", row.id.as_str()),
+                "Clear this engine override?",
+                "Clear",
+                |ui| ui.button("Clear"),
+            ) {
                 actions.push(AppAction::ClearEngineOverride(row.id));
             }
         });

--- a/src/frontend/ui/views/remote.rs
+++ b/src/frontend/ui/views/remote.rs
@@ -162,10 +162,18 @@ pub(crate) fn render_remote_hosts_settings(
             if ui.button("Set up passwordless login").clicked() {
                 actions.push(AppAction::SetupRemoteHostKey(id.clone()));
             }
-            if ui.button("Remove").clicked() {
-                actions.push(AppAction::RemoveRemoteHost(id.clone()));
-            }
         });
+
+        ui.add_space(8.0);
+        if crate::frontend::ui::widgets::confirm_destructive(
+            ui,
+            ("remove_remote_host", id.as_str()),
+            "Remove this host and its connection settings?",
+            "Remove",
+            |ui| ui.button(RichText::new("Remove").color(pal.status_red)),
+        ) {
+            actions.push(AppAction::RemoveRemoteHost(id.clone()));
+        }
 
         if let Some(mut command) = bootstrap_cmd {
             ui.label(caption_text(

--- a/src/frontend/ui/widgets.rs
+++ b/src/frontend/ui/widgets.rs
@@ -277,6 +277,46 @@ pub(crate) fn lerp_color(a: egui::Color32, b: egui::Color32, t: f32) -> egui::Co
     )
 }
 
+/// Two-step inline confirmation for a destructive action. `trigger` renders the
+/// resting control and returns its `Response`; on first click the row swaps in
+/// place to `confirm_prompt` followed by a `confirm_label`/Cancel pair. Returns
+/// `true` only on the frame the confirm button is clicked. The armed state lives
+/// in egui per-widget temp memory keyed by `id_salt`, so it is transient and is
+/// never persisted to workspace state.
+// The colocated unit test references this, so the dead-code expectation applies
+// only to non-test builds.
+#[cfg_attr(not(test), expect(dead_code))]
+pub(crate) fn confirm_destructive(
+    ui: &mut egui::Ui,
+    id_salt: impl std::hash::Hash,
+    confirm_prompt: &str,
+    confirm_label: &str,
+    trigger: impl FnOnce(&mut egui::Ui) -> egui::Response,
+) -> bool {
+    let pal = crate::frontend::theme::palette(ui);
+    let confirm_id = ui.id().with(id_salt);
+    let confirming = ui
+        .data(|data| data.get_temp::<bool>(confirm_id))
+        .unwrap_or(false);
+
+    let mut fired = false;
+    if confirming {
+        ui.horizontal(|ui| {
+            ui.label(RichText::new(confirm_prompt).color(pal.status_red));
+            if ui.button(confirm_label).clicked() {
+                fired = true;
+                ui.data_mut(|data| data.insert_temp(confirm_id, false));
+            }
+            if ui.button("Cancel").clicked() {
+                ui.data_mut(|data| data.insert_temp(confirm_id, false));
+            }
+        });
+    } else if trigger(ui).clicked() {
+        ui.data_mut(|data| data.insert_temp(confirm_id, true));
+    }
+    fired
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -285,6 +325,37 @@ mod tests {
     fn fill_alpha(scheme: ColorScheme, dark: bool, selected: bool, hovered: bool) -> u8 {
         let pal = Palette::for_scheme(scheme, dark);
         core_button_fill(&pal, dark, selected, hovered).to_array()[3]
+    }
+
+    #[test]
+    fn confirm_destructive_requires_two_steps() {
+        let ctx = egui::Context::default();
+        let salt = "unit_test_confirm";
+
+        // Resting frame: with no pointer input the trigger never registers a
+        // click, so the helper must neither fire nor arm the confirm flag.
+        let mut fired_resting = true;
+        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+            fired_resting =
+                confirm_destructive(ui, salt, "Delete it?", "Delete", |ui| ui.button("Delete"));
+        });
+        assert!(!fired_resting, "resting frame with no click must not fire");
+
+        // Arm the flag the same way a trigger click does.
+        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+            let id = ui.id().with(salt);
+            ui.data_mut(|data| data.insert_temp(id, true));
+        });
+
+        // Confirming frame: the armed flag selects the danger-prompt branch.
+        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+            let id = ui.id().with(salt);
+            let confirming = ui.data(|data| data.get_temp::<bool>(id)).unwrap_or(false);
+            assert!(
+                confirming,
+                "after arming, the confirm branch must be active"
+            );
+        });
     }
 
     #[test]

--- a/src/frontend/ui/widgets.rs
+++ b/src/frontend/ui/widgets.rs
@@ -280,9 +280,13 @@ pub(crate) fn lerp_color(a: egui::Color32, b: egui::Color32, t: f32) -> egui::Co
 /// Two-step inline confirmation for a destructive action. `trigger` renders the
 /// resting control and returns its `Response`; on first click the row swaps in
 /// place to `confirm_prompt` followed by a `confirm_label`/Cancel pair. Returns
-/// `true` only on the frame the confirm button is clicked. The armed state lives
-/// in egui per-widget temp memory keyed by `id_salt`, so it is transient and is
-/// never persisted to workspace state.
+/// `true` only on the frame the confirm button is clicked.
+///
+/// The armed state lives in egui per-widget temp memory keyed by `id_salt`, so it
+/// is transient and never reaches workspace state. It also auto-disarms: the
+/// flag stores the pass it was last shown on, so a control whose container is
+/// dismissed while armed (a context menu clicked away, a settings page navigated
+/// off) resets to resting instead of reappearing pre-armed.
 pub(crate) fn confirm_destructive(
     ui: &mut egui::Ui,
     id_salt: impl std::hash::Hash,
@@ -292,26 +296,32 @@ pub(crate) fn confirm_destructive(
 ) -> bool {
     let pal = crate::frontend::theme::palette(ui);
     let confirm_id = ui.id().with(id_salt);
-    let confirming = ui
-        .data(|data| data.get_temp::<bool>(confirm_id))
-        .unwrap_or(false);
+    let now = ui.ctx().cumulative_pass_nr();
+    let armed_at = ui.data(|data| data.get_temp::<u64>(confirm_id));
 
     let mut fired = false;
-    if confirming {
+    if confirm_is_armed(armed_at, now) {
         ui.horizontal(|ui| {
             ui.label(RichText::new(confirm_prompt).color(pal.status_red));
             if ui.button(confirm_label).clicked() {
                 fired = true;
-                ui.data_mut(|data| data.insert_temp(confirm_id, false));
-            }
-            if ui.button("Cancel").clicked() {
-                ui.data_mut(|data| data.insert_temp(confirm_id, false));
+                ui.data_mut(|data| data.remove::<u64>(confirm_id));
+            } else if ui.button("Cancel").clicked() {
+                ui.data_mut(|data| data.remove::<u64>(confirm_id));
+            } else {
+                ui.data_mut(|data| data.insert_temp(confirm_id, now));
             }
         });
     } else if trigger(ui).clicked() {
-        ui.data_mut(|data| data.insert_temp(confirm_id, true));
+        ui.data_mut(|data| data.insert_temp(confirm_id, now));
     }
     fired
+}
+
+/// Armed only if the flag was refreshed on the current or immediately preceding
+/// pass; a wider gap means the control was off-screen for a pass, which disarms.
+fn confirm_is_armed(armed_at: Option<u64>, now: u64) -> bool {
+    armed_at.is_some_and(|seen| now.saturating_sub(seen) <= 1)
 }
 
 #[cfg(test)]
@@ -325,34 +335,29 @@ mod tests {
     }
 
     #[test]
-    fn confirm_destructive_requires_two_steps() {
+    fn confirm_arm_disarms_after_an_off_screen_pass() {
+        assert!(!confirm_is_armed(None, 10), "never armed");
+        assert!(confirm_is_armed(Some(10), 10), "armed this pass");
+        assert!(
+            confirm_is_armed(Some(9), 10),
+            "armed last pass, still on screen"
+        );
+        assert!(
+            !confirm_is_armed(Some(8), 10),
+            "a pass elapsed off-screen, so disarm"
+        );
+        assert!(!confirm_is_armed(Some(0), 1000), "long gone");
+    }
+
+    #[test]
+    fn confirm_destructive_resting_frame_does_not_fire() {
         let ctx = egui::Context::default();
-        let salt = "unit_test_confirm";
-
-        // Resting frame: with no pointer input the trigger never registers a
-        // click, so the helper must neither fire nor arm the confirm flag.
-        let mut fired_resting = true;
+        let mut fired = true;
         let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
-            fired_resting =
-                confirm_destructive(ui, salt, "Delete it?", "Delete", |ui| ui.button("Delete"));
+            fired =
+                confirm_destructive(ui, "salt", "Delete it?", "Delete", |ui| ui.button("Delete"));
         });
-        assert!(!fired_resting, "resting frame with no click must not fire");
-
-        // Arm the flag the same way a trigger click does.
-        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
-            let id = ui.id().with(salt);
-            ui.data_mut(|data| data.insert_temp(id, true));
-        });
-
-        // Confirming frame: the armed flag selects the danger-prompt branch.
-        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
-            let id = ui.id().with(salt);
-            let confirming = ui.data(|data| data.get_temp::<bool>(id)).unwrap_or(false);
-            assert!(
-                confirming,
-                "after arming, the confirm branch must be active"
-            );
-        });
+        assert!(!fired, "resting frame with no click must not fire");
     }
 
     #[test]

--- a/src/frontend/ui/widgets.rs
+++ b/src/frontend/ui/widgets.rs
@@ -283,9 +283,6 @@ pub(crate) fn lerp_color(a: egui::Color32, b: egui::Color32, t: f32) -> egui::Co
 /// `true` only on the frame the confirm button is clicked. The armed state lives
 /// in egui per-widget temp memory keyed by `id_salt`, so it is transient and is
 /// never persisted to workspace state.
-// The colocated unit test references this, so the dead-code expectation applies
-// only to non-test builds.
-#[cfg_attr(not(test), expect(dead_code))]
 pub(crate) fn confirm_destructive(
     ui: &mut egui::Ui,
     id_salt: impl std::hash::Hash,


### PR DESCRIPTION
## Summary

This PR makes destructive and easily mistaken UI actions more forgiving and makes rename editing explicit. Before this change, several irreversible actions fired on the first click, including deleting a group and all of its entries, deleting or clearing an assistant conversation, removing a remote host, clearing an engine override, and removing an MD stage. Rename fields also committed on focus loss and could accept empty names.

The change adds one reusable inline confirmation control, applies it to the destructive paths, and updates rename behavior so Enter commits, Escape or other focus loss cancels, and blank names are rejected. The confirmation UI is an in-place two-step control using egui transient temp memory rather than a new modal subsystem.

## What changed

### Inline confirmation

`confirm_destructive` (`src/frontend/ui/widgets.rs`) swaps the resting control in place to a red prompt with `Confirm` and `Cancel` actions on first click, then only fires on the second click. The armed state lives in egui transient temp memory, not workspace state.

The control also auto-disarms when it is no longer shown. It records the frame pass where it last rendered, so a confirmation armed inside a dismissed context menu or a settings page that was navigated away from resets before the control is shown again.

### Guarded actions

| Action | Before | After |
|---|---|---|
| Delete group and all entries | Instant, unrecoverable | Confirm with the group name and entry count |
| Delete multiple groups and their entries | Instant | Confirm with the total entry count |
| Delete or clear assistant conversation | Instant | Confirm; the last conversation is labeled `Clear` instead of `Delete` |
| Remove remote host | Instant, mixed in with Save/Test | Confirmed, visually separated, red action |
| Clear engine override | Instant | Confirmed |
| Remove MD stage | Instant | Confirmed only when the stage has user-entered Details |

### Rename and affordance fixes

- Group rows reveal pencil and trash actions on hover, with `Rename group` and `Ungroup` tooltips. The hover trash action ungroups entries; the entry-deleting path remains in the context menu.
- MD stage header controls now have `Move up`, `Move down`, and `Remove stage` tooltips.
- Rename behavior for entries, groups, and conversations now commits only on Enter. Escape or any other focus loss cancels editing.
- Empty or whitespace-only names are rejected in the UI and guarded in the backend, so a blank rename cannot overwrite an existing name.

## Validation

Latest PR checks are green:

- Format
- Clippy
- Test on macOS, Ubuntu, and Windows
- File size
- Worker is pure Rust
- CI
- Claude review

Relevant test coverage includes:

- `confirm_is_armed` disarm behavior and resting-frame no-op behavior.
- `group_delete_summary` entry counting.
- `rename_entry` rejection of blank and whitespace-only names.

## Notes

- The engine override and remote host confirmations are wired into the split `views/engines.rs` and `views/remote.rs` layout.
- The MD stage confirmation key is salted by `(index, name)`. Since MD stages do not have stable IDs, using only the render index could carry an armed confirmation onto a different stage after reorder. The salt makes reorder disarm the confirmation instead.
- The egui interaction polish is still best reviewed visually with `cargo run -p silicolab`; compilation and logic are covered by CI and the test suite.
