### PR TITLE
feat(ui): add sequence viewer and biopolymer sequence helpers

### DIFF
--- a/compute-core/src/domain/biopolymer.rs
+++ b/compute-core/src/domain/biopolymer.rs
@@ -2,6 +2,9 @@ use std::collections::HashMap;
 
 use super::structure::Atom;
 
+mod sequence;
+pub use sequence::{ResiduePolymerKind, residue_polymer_kind, residue_sequence_symbol};
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ResidueId {
     pub chain_id: char,
@@ -60,7 +63,6 @@ impl ResidueRecord {
         self.alpha_carbon.is_some() && (self.has_peptide_backbone() || self.is_standard_amino_acid)
     }
 }
-
 /// Upper bound, in ångström, on the C(i)–N(i+1) peptide bond joining two
 /// consecutive residues. A real peptide bond is ~1.33 Å; the generous ceiling
 /// tolerates strained or coarse coordinates while still rejecting a chain break,
@@ -233,6 +235,7 @@ pub fn build_biopolymer(
     let has_overlay_residues = residues.iter().any(|residue| {
         residue.is_standard_amino_acid
             || residue.has_peptide_backbone()
+            || is_nucleic_acid_residue(&residue.residue_name)
             || is_carbohydrate_residue(&residue.residue_name)
     });
     if !has_overlay_residues && secondary_structures.is_empty() {
@@ -350,6 +353,7 @@ pub fn is_nucleic_acid_residue(residue_name: &str) -> bool {
             | "A"
             | "C"
             | "G"
+            | "T"
             | "U"
             | "I"
             | "RA"
@@ -600,6 +604,34 @@ mod tests {
             backbone_oxygen: None,
             is_standard_amino_acid: true,
         }
+    }
+
+    #[test]
+    fn nucleic_acid_only_annotations_build_biopolymer() {
+        let annotations = [
+            ("P", "DA", 1),
+            ("C1'", "DA", 1),
+            ("N9", "DA", 1),
+            ("P", "DC", 2),
+            ("C1'", "DC", 2),
+            ("N1", "DC", 2),
+        ]
+        .into_iter()
+        .map(|(atom_name, residue_name, residue_seq)| PdbAtomAnnotation {
+            atom_name: atom_name.to_string(),
+            residue_name: residue_name.to_string(),
+            chain_id: 'A',
+            residue_seq,
+            insertion_code: ' ',
+        })
+        .collect::<Vec<_>>();
+
+        let biopolymer = build_biopolymer(&annotations, Vec::new()).expect("biopolymer");
+        assert_eq!(biopolymer.residues.len(), 2);
+        assert!(biopolymer.residues.iter().all(|residue| {
+            residue_polymer_kind(&residue.residue_name, residue)
+                == Some(ResiduePolymerKind::NucleicAcid)
+        }));
     }
 
     #[test]

--- a/compute-core/src/domain/biopolymer/sequence.rs
+++ b/compute-core/src/domain/biopolymer/sequence.rs
@@ -1,0 +1,206 @@
+use super::{ResidueRecord, is_nucleic_acid_residue, is_standard_amino_acid};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ResiduePolymerKind {
+    Protein,
+    NucleicAcid,
+}
+
+pub fn residue_polymer_kind(
+    residue_name: &str,
+    residue: &ResidueRecord,
+) -> Option<ResiduePolymerKind> {
+    if is_standard_amino_acid(residue_name) || residue.has_peptide_backbone() {
+        return Some(ResiduePolymerKind::Protein);
+    }
+
+    if is_nucleic_acid_residue(residue_name) {
+        return Some(ResiduePolymerKind::NucleicAcid);
+    }
+
+    None
+}
+
+pub fn residue_sequence_symbol(residue_name: &str, kind: ResiduePolymerKind) -> char {
+    match kind {
+        ResiduePolymerKind::Protein => amino_acid_sequence_symbol(residue_name).unwrap_or('X'),
+        ResiduePolymerKind::NucleicAcid => {
+            nucleic_acid_sequence_symbol(residue_name).unwrap_or('N')
+        }
+    }
+}
+
+fn amino_acid_sequence_symbol(residue_name: &str) -> Option<char> {
+    Some(match normalized_residue_name(residue_name).as_str() {
+        "ALA" => 'A',
+        "ARG" => 'R',
+        "ASN" => 'N',
+        "ASP" => 'D',
+        "CYS" => 'C',
+        "GLN" => 'Q',
+        "GLU" => 'E',
+        "GLY" => 'G',
+        "HIS" => 'H',
+        "ILE" => 'I',
+        "LEU" => 'L',
+        "LYS" => 'K',
+        "MET" => 'M',
+        "PHE" => 'F',
+        "PRO" => 'P',
+        "SER" => 'S',
+        "THR" => 'T',
+        "TRP" => 'W',
+        "TYR" => 'Y',
+        "VAL" => 'V',
+        _ => return None,
+    })
+}
+
+fn nucleic_acid_sequence_symbol(residue_name: &str) -> Option<char> {
+    Some(match normalized_residue_name(residue_name).as_str() {
+        "A" | "DA" | "RA" | "ADE" => 'A',
+        "C" | "DC" | "RC" | "CYT" => 'C',
+        "G" | "DG" | "RG" | "GUA" => 'G',
+        "T" | "DT" | "THY" => 'T',
+        "U" | "DU" | "RU" | "URA" => 'U',
+        "I" | "DI" => 'I',
+        _ => return None,
+    })
+}
+
+fn normalized_residue_name(residue_name: &str) -> String {
+    residue_name.trim().to_ascii_uppercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::biopolymer::ResidueId;
+
+    fn residue(
+        alpha_carbon: Option<usize>,
+        backbone_nitrogen: Option<usize>,
+        backbone_carbon: Option<usize>,
+    ) -> ResidueRecord {
+        ResidueRecord {
+            id: ResidueId::new('A', 1, ' '),
+            residue_name: "ALA".to_string(),
+            atom_indices: Vec::new(),
+            alpha_carbon,
+            backbone_nitrogen,
+            backbone_carbon,
+            backbone_oxygen: None,
+            is_standard_amino_acid: true,
+        }
+    }
+
+    #[test]
+    fn residue_sequence_symbol_maps_standard_amino_acids() {
+        for (residue_name, symbol) in [
+            ("ALA", 'A'),
+            ("ARG", 'R'),
+            ("ASN", 'N'),
+            ("ASP", 'D'),
+            ("CYS", 'C'),
+            ("GLN", 'Q'),
+            ("GLU", 'E'),
+            ("GLY", 'G'),
+            ("HIS", 'H'),
+            ("ILE", 'I'),
+            ("LEU", 'L'),
+            ("LYS", 'K'),
+            ("MET", 'M'),
+            ("PHE", 'F'),
+            ("PRO", 'P'),
+            ("SER", 'S'),
+            ("THR", 'T'),
+            ("TRP", 'W'),
+            ("TYR", 'Y'),
+            ("VAL", 'V'),
+        ] {
+            assert_eq!(
+                residue_sequence_symbol(residue_name, ResiduePolymerKind::Protein),
+                symbol,
+                "{residue_name}"
+            );
+        }
+        assert_eq!(
+            residue_sequence_symbol("MSE", ResiduePolymerKind::Protein),
+            'X'
+        );
+    }
+
+    #[test]
+    fn residue_sequence_symbol_maps_common_nucleic_acids() {
+        for (residue_name, symbol) in [
+            ("DA", 'A'),
+            ("DC", 'C'),
+            ("DG", 'G'),
+            ("DT", 'T'),
+            ("A", 'A'),
+            ("C", 'C'),
+            ("G", 'G'),
+            ("U", 'U'),
+            ("RA", 'A'),
+            ("RC", 'C'),
+            ("RG", 'G'),
+            ("RU", 'U'),
+            ("ADE", 'A'),
+            ("CYT", 'C'),
+            ("GUA", 'G'),
+            ("THY", 'T'),
+            ("URA", 'U'),
+            ("DI", 'I'),
+        ] {
+            assert_eq!(
+                residue_sequence_symbol(residue_name, ResiduePolymerKind::NucleicAcid),
+                symbol,
+                "{residue_name}"
+            );
+        }
+        assert_eq!(
+            residue_sequence_symbol("PSU", ResiduePolymerKind::NucleicAcid),
+            'N'
+        );
+    }
+
+    #[test]
+    fn residue_polymer_kind_classifies_sequence_supported_residues() {
+        let standard = residue(None, None, None);
+        assert_eq!(
+            residue_polymer_kind("ALA", &standard),
+            Some(ResiduePolymerKind::Protein)
+        );
+
+        let non_standard_backbone = ResidueRecord {
+            residue_name: "MSE".to_string(),
+            is_standard_amino_acid: false,
+            ..residue(Some(0), Some(1), Some(2))
+        };
+        assert_eq!(
+            residue_polymer_kind("MSE", &non_standard_backbone),
+            Some(ResiduePolymerKind::Protein)
+        );
+        assert_eq!(
+            residue_sequence_symbol("MSE", ResiduePolymerKind::Protein),
+            'X'
+        );
+
+        let nucleic = ResidueRecord {
+            residue_name: "DG".to_string(),
+            is_standard_amino_acid: false,
+            ..residue(None, None, None)
+        };
+        assert_eq!(
+            residue_polymer_kind("DG", &nucleic),
+            Some(ResiduePolymerKind::NucleicAcid)
+        );
+
+        let water = ResidueRecord {
+            residue_name: "HOH".to_string(),
+            is_standard_amino_acid: false,
+            ..residue(None, None, None)
+        };
+        assert_eq!(residue_polymer_kind("HOH", &water), None);
+    }
+}

--- a/src/backend/config.rs
+++ b/src/backend/config.rs
@@ -259,6 +259,7 @@ impl Default for DockLayoutConfig {
             bottom: DockAreaLayout {
                 tabs: vec![
                     "console".to_string(),
+                    "sequence".to_string(),
                     "task_monitor".to_string(),
                     "output".to_string(),
                 ],

--- a/src/backend/representation.rs
+++ b/src/backend/representation.rs
@@ -17,9 +17,9 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Default base representation for non-polymer atoms and their bonds. The four
+/// Default representation for atoms that use base atom/bond geometry. The four
 /// styles the renderer can draw as a *base* geometry; each maps 1:1 onto an
-/// [`crate::frontend::state::AtomStyle`] frontend-side. (Biopolymer chains keep
+/// [`crate::frontend::state::AtomStyle`] frontend-side. (Protein chains keep
 /// their Cartoon default and follow [`CartoonPrefs`] instead.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum BaseStyle {

--- a/src/frontend/actions.rs
+++ b/src/frontend/actions.rs
@@ -33,6 +33,16 @@ pub enum AppAction {
         atom_index: usize,
         toggle: bool,
     },
+    SelectResidue {
+        residue_index: usize,
+        toggle: bool,
+    },
+    SelectResidueRange {
+        chain_id: char,
+        start: usize,
+        end: usize,
+        toggle: bool,
+    },
     /// Apply a per-atom *base* drawing style to the current selection (or, when
     /// the selection is empty, to every atom as the new default).
     SetSelectionStyle(crate::frontend::state::AtomStyle),

--- a/src/frontend/dispatcher/mod.rs
+++ b/src/frontend/dispatcher/mod.rs
@@ -128,6 +128,16 @@ pub fn dispatch(state: &mut AppState, action: AppAction, ctx: &egui::Context) {
         AppAction::ClearSelection => clear_selection(state),
         AppAction::SelectCategory(category) => select_category(state, category),
         AppAction::SelectAtom { atom_index, toggle } => select_atom(state, atom_index, toggle),
+        AppAction::SelectResidue {
+            residue_index,
+            toggle,
+        } => select_residue(state, residue_index, toggle),
+        AppAction::SelectResidueRange {
+            chain_id,
+            start,
+            end,
+            toggle,
+        } => select_residue_range(state, chain_id, start, end, toggle),
         AppAction::SetSelectionStyle(style) => set_selection_style(state, style),
         AppAction::SetCartoonOverlay(on) => set_overlay(state, OverlayKind::Cartoon, on),
         AppAction::SetSurfaceOverlay(on) => set_overlay(state, OverlayKind::Surface, on),

--- a/src/frontend/dispatcher/selection.rs
+++ b/src/frontend/dispatcher/selection.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+mod residue;
+pub(crate) use residue::{select_residue, select_residue_range};
+
 pub(crate) fn select_all(state: &mut AppState) {
     state.ui.selection.select_all(state.structure().atoms.len());
     state.set_message(format!("Selected {} atom(s)", state.ui.selection.len()));

--- a/src/frontend/dispatcher/selection/residue.rs
+++ b/src/frontend/dispatcher/selection/residue.rs
@@ -1,0 +1,324 @@
+use super::*;
+
+pub(crate) fn select_residue(state: &mut AppState, residue_index: usize, toggle: bool) {
+    let atom_count = state.structure().atoms.len();
+    let Some(atom_indices) = residue_atom_indices(state, residue_index, atom_count) else {
+        state.ui.selection.retain_valid(atom_count);
+        state.set_message("Residue selection is unavailable for the active entry".to_string());
+        return;
+    };
+
+    select_residue_atoms(
+        state,
+        atom_indices,
+        toggle,
+        "Selected residue has no valid atoms",
+    );
+}
+
+pub(crate) fn select_residue_range(
+    state: &mut AppState,
+    chain_id: char,
+    start: usize,
+    end: usize,
+    toggle: bool,
+) {
+    let atom_count = state.structure().atoms.len();
+    let Some(atom_indices) = residue_range_atom_indices(state, chain_id, start, end, atom_count)
+    else {
+        state.ui.selection.retain_valid(atom_count);
+        state
+            .set_message("Residue range selection is unavailable for the active entry".to_string());
+        return;
+    };
+
+    select_residue_atoms(
+        state,
+        atom_indices,
+        toggle,
+        "Selected residue range has no valid atoms",
+    );
+}
+
+fn select_residue_atoms(
+    state: &mut AppState,
+    atom_indices: Vec<usize>,
+    toggle: bool,
+    empty_message: &str,
+) {
+    let atom_count = state.structure().atoms.len();
+    if atom_indices.is_empty() {
+        state.ui.selection.retain_valid(atom_count);
+        state.set_message(empty_message.to_string());
+        return;
+    }
+
+    if toggle {
+        for atom_index in atom_indices {
+            state.ui.selection.toggle(atom_index);
+        }
+    } else {
+        state.ui.selection.select_indices(atom_indices);
+    }
+    state.ui.selection.retain_valid(atom_count);
+
+    if state.ui.selection.is_empty() {
+        state.set_message("Cleared atom selection".to_string());
+    } else {
+        state.set_message(format!("Selected {} atom(s)", state.ui.selection.len()));
+    }
+}
+
+fn residue_atom_indices(
+    state: &AppState,
+    residue_index: usize,
+    atom_count: usize,
+) -> Option<Vec<usize>> {
+    let biopolymer = state.structure().biopolymer.as_ref()?;
+    if !biopolymer.is_compatible_with_atom_count(atom_count) {
+        return None;
+    }
+    let residue = biopolymer.residues.get(residue_index)?;
+    Some(valid_residue_atoms(residue, atom_count))
+}
+
+fn residue_range_atom_indices(
+    state: &AppState,
+    chain_id: char,
+    start: usize,
+    end: usize,
+    atom_count: usize,
+) -> Option<Vec<usize>> {
+    let biopolymer = state.structure().biopolymer.as_ref()?;
+    if !biopolymer.is_compatible_with_atom_count(atom_count) {
+        return None;
+    }
+    let chain = biopolymer
+        .chains
+        .iter()
+        .find(|chain| chain.id == chain_id)?;
+    let start_pos = chain
+        .residue_indices
+        .iter()
+        .position(|&residue_index| residue_index == start)?;
+    let end_pos = chain
+        .residue_indices
+        .iter()
+        .position(|&residue_index| residue_index == end)?;
+    let (lo, hi) = if start_pos <= end_pos {
+        (start_pos, end_pos)
+    } else {
+        (end_pos, start_pos)
+    };
+
+    Some(
+        chain.residue_indices[lo..=hi]
+            .iter()
+            .filter_map(|&residue_index| biopolymer.residues.get(residue_index))
+            .flat_map(|residue| valid_residue_atoms(residue, atom_count))
+            .collect(),
+    )
+}
+
+fn valid_residue_atoms(
+    residue: &crate::domain::biopolymer::ResidueRecord,
+    atom_count: usize,
+) -> Vec<usize> {
+    residue
+        .atom_indices
+        .iter()
+        .copied()
+        .filter(|&atom_index| atom_index < atom_count)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use eframe::egui::Context;
+    use nalgebra::Point3;
+
+    use crate::{
+        backend::project::WorkspaceSession,
+        domain::{Atom, PdbAtomAnnotation, Structure, build_biopolymer},
+        frontend::{actions::AppAction, state::AppState},
+    };
+
+    fn annotated_atom(element: &str, x: f32) -> Atom {
+        Atom {
+            element: element.to_string(),
+            position: Point3::new(x, 0.0, 0.0),
+            charge: 0.0,
+        }
+    }
+
+    fn annotation(atom_name: &str, residue_name: &str, residue_seq: i32) -> PdbAtomAnnotation {
+        annotation_on_chain(atom_name, residue_name, 'A', residue_seq)
+    }
+
+    fn annotation_on_chain(
+        atom_name: &str,
+        residue_name: &str,
+        chain_id: char,
+        residue_seq: i32,
+    ) -> PdbAtomAnnotation {
+        PdbAtomAnnotation {
+            atom_name: atom_name.to_string(),
+            residue_name: residue_name.to_string(),
+            chain_id,
+            residue_seq,
+            insertion_code: ' ',
+        }
+    }
+
+    fn residue_structure() -> Structure {
+        let mut structure = Structure::new(
+            "protein",
+            vec![
+                annotated_atom("N", 0.0),
+                annotated_atom("C", 1.0),
+                annotated_atom("C", 2.0),
+                annotated_atom("O", 3.0),
+            ],
+        );
+        let annotations = vec![
+            annotation("N", "ALA", 1),
+            annotation("CA", "ALA", 1),
+            annotation("C", "GLY", 2),
+            annotation("O", "GLY", 2),
+        ];
+        structure.biopolymer = build_biopolymer(&annotations, Vec::new());
+        structure
+    }
+
+    fn interleaved_chain_structure() -> Structure {
+        let mut structure = Structure::new(
+            "interleaved protein",
+            vec![
+                annotated_atom("N", 0.0),
+                annotated_atom("C", 1.0),
+                annotated_atom("N", 2.0),
+                annotated_atom("C", 3.0),
+                annotated_atom("N", 4.0),
+                annotated_atom("C", 5.0),
+            ],
+        );
+        let annotations = vec![
+            annotation_on_chain("N", "ALA", 'A', 1),
+            annotation_on_chain("CA", "ALA", 'A', 1),
+            annotation_on_chain("N", "GLY", 'B', 1),
+            annotation_on_chain("CA", "GLY", 'B', 1),
+            annotation_on_chain("N", "SER", 'A', 2),
+            annotation_on_chain("CA", "SER", 'A', 2),
+        ];
+        structure.biopolymer = build_biopolymer(&annotations, Vec::new());
+        structure
+    }
+
+    fn scratch_state(structure: Structure) -> AppState {
+        AppState::new(
+            structure,
+            None,
+            WorkspaceSession::Scratch,
+            Default::default(),
+            Vec::new(),
+            None,
+        )
+    }
+
+    #[test]
+    fn select_residue_selects_all_atoms_in_residue() {
+        let ctx = Context::default();
+        let mut state = scratch_state(residue_structure());
+        let fingerprint = state.entries_fingerprint();
+
+        crate::frontend::dispatcher::dispatch(
+            &mut state,
+            AppAction::SelectResidue {
+                residue_index: 1,
+                toggle: false,
+            },
+            &ctx,
+        );
+
+        assert_eq!(state.ui.selection.ordered_indices(), vec![2, 3]);
+        assert_eq!(state.entries_fingerprint(), fingerprint);
+    }
+
+    #[test]
+    fn select_residue_invalid_index_does_not_panic() {
+        let ctx = Context::default();
+        let mut state = scratch_state(residue_structure());
+        state.ui.selection.select_indices([0, 99]);
+
+        crate::frontend::dispatcher::dispatch(
+            &mut state,
+            AppAction::SelectResidue {
+                residue_index: 99,
+                toggle: false,
+            },
+            &ctx,
+        );
+
+        assert_eq!(state.ui.selection.ordered_indices(), vec![0]);
+    }
+
+    #[test]
+    fn select_residue_range_selects_atoms_in_inclusive_range() {
+        let ctx = Context::default();
+        let mut state = scratch_state(residue_structure());
+        let fingerprint = state.entries_fingerprint();
+
+        crate::frontend::dispatcher::dispatch(
+            &mut state,
+            AppAction::SelectResidueRange {
+                chain_id: 'A',
+                start: 1,
+                end: 0,
+                toggle: false,
+            },
+            &ctx,
+        );
+
+        assert_eq!(state.ui.selection.ordered_indices(), vec![0, 1, 2, 3]);
+        assert_eq!(state.entries_fingerprint(), fingerprint);
+    }
+
+    #[test]
+    fn select_residue_range_toggle_updates_existing_selection() {
+        let ctx = Context::default();
+        let mut state = scratch_state(residue_structure());
+        state.ui.selection.select_indices([0, 2]);
+
+        crate::frontend::dispatcher::dispatch(
+            &mut state,
+            AppAction::SelectResidueRange {
+                chain_id: 'A',
+                start: 0,
+                end: 1,
+                toggle: true,
+            },
+            &ctx,
+        );
+
+        assert_eq!(state.ui.selection.ordered_indices(), vec![1, 3]);
+    }
+
+    #[test]
+    fn select_residue_range_stays_within_chain_record() {
+        let ctx = Context::default();
+        let mut state = scratch_state(interleaved_chain_structure());
+
+        crate::frontend::dispatcher::dispatch(
+            &mut state,
+            AppAction::SelectResidueRange {
+                chain_id: 'A',
+                start: 0,
+                end: 2,
+                toggle: false,
+            },
+            &ctx,
+        );
+
+        assert_eq!(state.ui.selection.ordered_indices(), vec![0, 1, 4, 5]);
+    }
+}

--- a/src/frontend/state/app.rs
+++ b/src/frontend/state/app.rs
@@ -26,7 +26,7 @@ pub use monitor::RemoteGpuLive;
 // non-test code reaches it through `RemoteGpuLive::gpus`, so gate the re-export.
 #[cfg(test)]
 pub use monitor::RemoteGpuView;
-pub use ui_state::{SelfUpdateStatus, TextViewer, UiState};
+pub use ui_state::{SelfUpdateStatus, SequenceViewerState, TextViewer, UiState};
 
 use super::*;
 

--- a/src/frontend/state/app/ui_state.rs
+++ b/src/frontend/state/app/ui_state.rs
@@ -54,11 +54,19 @@ pub struct StyleState {
     pub search_query: String,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct SequenceViewerState {
+    pub chain_filter: Option<char>,
+    pub last_clicked_residue: Option<usize>,
+    pub last_scrolled_primary_atom: Option<usize>,
+}
+
 pub struct UiState {
     pub layout: LayoutState,
     pub entry_list: EntryListState,
     pub settings: SettingsState,
     pub style: StyleState,
+    pub sequence: SequenceViewerState,
     pub camera: ViewCamera,
     pub viewport_cache: ViewportCache,
     /// Set once at startup when the GPU molecule renderer initializes
@@ -190,6 +198,7 @@ impl Default for UiState {
             entry_list: EntryListState::default(),
             settings: SettingsState::default(),
             style: StyleState::default(),
+            sequence: SequenceViewerState::default(),
             camera: ViewCamera::default(),
             viewport_cache: ViewportCache::default(),
             gpu_ready: false,

--- a/src/frontend/state/dock.rs
+++ b/src/frontend/state/dock.rs
@@ -49,6 +49,7 @@ impl PrimaryView {
 pub enum StaticView {
     Output,
     Console,
+    Sequence,
     Assistant,
     TaskMonitor,
 }
@@ -60,6 +61,7 @@ impl StaticView {
     pub fn all() -> &'static [Self] {
         &[
             Self::Console,
+            Self::Sequence,
             Self::Assistant,
             Self::TaskMonitor,
             Self::Output,
@@ -69,6 +71,7 @@ impl StaticView {
     pub fn label(self) -> &'static str {
         match self {
             Self::Console => "Console",
+            Self::Sequence => "Sequence",
             Self::Assistant => "Assistant",
             Self::TaskMonitor => "Task Monitor",
             Self::Output => "Output",
@@ -81,6 +84,7 @@ impl StaticView {
     pub fn token(self) -> &'static str {
         match self {
             Self::Console => "console",
+            Self::Sequence => "sequence",
             Self::Assistant => "assistant",
             Self::TaskMonitor => "task_monitor",
             Self::Output => "output",
@@ -90,6 +94,7 @@ impl StaticView {
     pub fn from_token(token: &str) -> Option<Self> {
         Some(match token {
             "console" => Self::Console,
+            "sequence" => Self::Sequence,
             "assistant" => Self::Assistant,
             "task_monitor" => Self::TaskMonitor,
             "output" => Self::Output,
@@ -159,6 +164,7 @@ impl Default for DockModel {
             bottom: DockAreaState {
                 tabs: vec![
                     DockTab::Static(StaticView::Console),
+                    DockTab::Static(StaticView::Sequence),
                     DockTab::Static(StaticView::TaskMonitor),
                     DockTab::Static(StaticView::Output),
                 ],
@@ -429,6 +435,30 @@ mod tests {
     use crate::backend::config::{DockAreaLayout, DockLayoutConfig};
 
     #[test]
+    fn from_config_restores_missing_sequence() {
+        let config = DockLayoutConfig {
+            bottom: DockAreaLayout {
+                tabs: vec!["console".into()],
+                active: Some("console".into()),
+                collapsed: false,
+            },
+            right: DockAreaLayout {
+                tabs: vec!["assistant".into()],
+                active: Some("assistant".into()),
+                collapsed: false,
+            },
+            right_width: 320.0,
+            bottom_height: 240.0,
+        };
+        let model = DockModel::from_config(&config);
+        assert!(
+            model
+                .bottom
+                .tabs
+                .contains(&DockTab::Static(StaticView::Sequence))
+        );
+    }
+    #[test]
     fn from_config_restores_missing_task_monitor() {
         let config = DockLayoutConfig {
             bottom: DockAreaLayout {
@@ -451,5 +481,20 @@ mod tests {
                 .tabs
                 .contains(&DockTab::Static(StaticView::TaskMonitor))
         );
+    }
+
+    #[test]
+    fn dock_model_default_matches_layout_config_default() {
+        let model = DockModel::default().to_config();
+        let config = DockLayoutConfig::default();
+
+        assert_eq!(model.bottom.tabs, config.bottom.tabs);
+        assert_eq!(model.right.tabs, config.right.tabs);
+        assert_eq!(model.bottom.active, config.bottom.active);
+        assert_eq!(model.right.active, config.right.active);
+        assert_eq!(model.bottom.collapsed, config.bottom.collapsed);
+        assert_eq!(model.right.collapsed, config.right.collapsed);
+        assert_eq!(model.right_width, config.right_width);
+        assert_eq!(model.bottom_height, config.bottom_height);
     }
 }

--- a/src/frontend/state/tests.rs
+++ b/src/frontend/state/tests.rs
@@ -130,17 +130,18 @@ fn insert_tab_dedups_across_areas_and_focuses() {
 
 #[test]
 fn move_tab_reorders_within_area_with_index_adjustment() {
-    // Bottom default order: Console, TaskMonitor, Output.
+    // Bottom default order: Console, Sequence, TaskMonitor, Output.
     let mut dock = DockModel::default();
     let console = DockTab::Static(StaticView::Console);
-    // Move Console (index 0) toward the end (index 2): after removing it the
-    // list is [TaskMonitor, Output] and the requested index adjusts to 2.
+    // Move Console (index 0) toward index 2: after removing it the list is
+    // [Sequence, TaskMonitor, Output], so the requested index adjusts to 1.
     dock.move_tab(console, DockArea::Bottom, Some(2));
     assert_eq!(
         dock.bottom.tabs,
         vec![
-            DockTab::Static(StaticView::TaskMonitor),
+            DockTab::Static(StaticView::Sequence),
             console,
+            DockTab::Static(StaticView::TaskMonitor),
             DockTab::Static(StaticView::Output),
         ]
     );

--- a/src/frontend/ui/dock.rs
+++ b/src/frontend/ui/dock.rs
@@ -1,6 +1,6 @@
 use super::panel_bodies::{
-    render_assistant_panel, render_console_panel, render_output_panel, render_task_monitor_panel,
-    weak_panel_hairline,
+    render_assistant_panel, render_console_panel, render_output_panel, render_sequence_panel,
+    render_task_monitor_panel, weak_panel_hairline,
 };
 use super::secondary_sidebar::*;
 use super::*;
@@ -171,6 +171,7 @@ pub(super) fn render_dock_area(
     match state.ui.layout.dock.area(area).active {
         Some(DockTab::Static(StaticView::Output)) => render_output_panel(state, ui),
         Some(DockTab::Static(StaticView::Console)) => render_console_panel(state, ui, actions),
+        Some(DockTab::Static(StaticView::Sequence)) => render_sequence_panel(state, ui, actions),
         Some(DockTab::Static(StaticView::Assistant)) => render_assistant_panel(state, ui, actions),
         Some(DockTab::Static(StaticView::TaskMonitor)) => {
             render_task_monitor_panel(state, ui, actions)

--- a/src/frontend/ui/panel_bodies.rs
+++ b/src/frontend/ui/panel_bodies.rs
@@ -7,6 +7,7 @@ mod assistant_composer;
 mod assistant_transcript;
 mod console;
 mod monitor;
+mod sequence;
 mod task_monitor;
 
 pub(crate) use assistant::*;
@@ -14,6 +15,7 @@ pub(crate) use assistant_composer::*;
 use assistant_transcript::*;
 pub(crate) use console::*;
 pub(crate) use monitor::*;
+pub(crate) use sequence::*;
 pub(crate) use task_monitor::*;
 
 /// Width reserved at the right edge of the log/transcript scroll areas so their

--- a/src/frontend/ui/panel_bodies/sequence.rs
+++ b/src/frontend/ui/panel_bodies/sequence.rs
@@ -1,0 +1,408 @@
+use eframe::egui::{self, Align, Color32, FontFamily, FontId, RichText, ScrollArea, Stroke, Vec2};
+
+use crate::{
+    domain::{
+        Structure,
+        biopolymer::{
+            ResiduePolymerKind, SecondaryStructureKind, residue_polymer_kind,
+            residue_sequence_symbol,
+        },
+    },
+    frontend::{
+        AtomSelection,
+        actions::AppAction,
+        state::{AppState, SequenceViewerState},
+    },
+};
+
+#[derive(Debug, Clone)]
+struct SequenceResidue {
+    residue_index: usize,
+    symbol: char,
+    kind: ResiduePolymerKind,
+    secondary: Option<SecondaryStructureKind>,
+    chain_id: char,
+    sequence_number: i32,
+    insertion_code: char,
+    residue_name: String,
+    atom_count: usize,
+    any_selected: bool,
+    all_selected: bool,
+    primary_selected: bool,
+}
+
+#[derive(Debug, Clone)]
+struct SequenceChain {
+    id: char,
+    residues: Vec<SequenceResidue>,
+}
+
+pub(crate) fn render_sequence_panel(
+    state: &mut AppState,
+    ui: &mut egui::Ui,
+    actions: &mut Vec<AppAction>,
+) {
+    let pal = crate::frontend::theme::palette(ui);
+    ui.set_width(ui.available_width());
+
+    ui.horizontal(|ui| {
+        ui.label(RichText::new("Sequence").strong());
+        ui.with_layout(egui::Layout::right_to_left(Align::Center), |ui| {
+            let selected = state.ui.selection.len();
+            if selected > 0 {
+                ui.label(
+                    RichText::new(format!("{selected} atom(s) selected"))
+                        .small()
+                        .color(pal.text_tertiary),
+                );
+            }
+        });
+    });
+    ui.separator();
+
+    let selection = state.ui.selection.clone();
+    let chains = sequence_chains(state.structure(), &selection);
+    if chains.is_empty() {
+        state.ui.sequence.last_clicked_residue = None;
+        state.ui.sequence.last_scrolled_primary_atom = None;
+        ui.add_space(8.0);
+        ui.label(
+            RichText::new("No protein or nucleic-acid sequence metadata for the active structure.")
+                .small()
+                .color(pal.text_tertiary),
+        );
+        return;
+    }
+
+    let primary_atom = selection.primary();
+    let primary_residue = primary_residue(&chains);
+    let primary_chain = primary_residue.map(|(_, chain_id)| chain_id);
+    let viewer = &mut state.ui.sequence;
+    if viewer
+        .chain_filter
+        .is_some_and(|id| !chains.iter().any(|chain| chain.id == id))
+    {
+        viewer.chain_filter = None;
+    }
+
+    render_sequence_toolbar(ui, viewer, &chains, primary_chain);
+
+    let scroll_target = primary_atom.and_then(|atom_index| {
+        (viewer.last_scrolled_primary_atom != Some(atom_index))
+            .then(|| primary_residue.map(|(residue_index, _)| residue_index))
+            .flatten()
+    });
+    if primary_atom.is_none() {
+        viewer.last_scrolled_primary_atom = None;
+    }
+
+    let chain_filter = viewer.chain_filter;
+    let mut scrolled_to_primary = false;
+    ScrollArea::both()
+        .auto_shrink([false, false])
+        .show(ui, |ui| {
+            ui.set_min_width(ui.available_width());
+            for chain in chains
+                .iter()
+                .filter(|chain| chain_filter.is_none_or(|id| chain.id == id))
+            {
+                ui.horizontal_wrapped(|ui| {
+                    ui.spacing_mut().item_spacing = Vec2::new(3.0, 4.0);
+                    ui.label(
+                        RichText::new(format!("Chain {}", display_chain_id(chain.id)))
+                            .small()
+                            .strong()
+                            .color(pal.text_primary),
+                    );
+                    ui.add_space(4.0);
+                    for residue in &chain.residues {
+                        scrolled_to_primary |=
+                            render_residue_cell(ui, residue, chain, viewer, actions, scroll_target);
+                    }
+                });
+                ui.add_space(8.0);
+            }
+        });
+
+    if scrolled_to_primary {
+        viewer.last_scrolled_primary_atom = primary_atom;
+    }
+}
+
+fn render_sequence_toolbar(
+    ui: &mut egui::Ui,
+    viewer: &mut SequenceViewerState,
+    chains: &[SequenceChain],
+    primary_chain: Option<char>,
+) {
+    ui.horizontal(|ui| {
+        if chains.len() > 1 {
+            let before = viewer.chain_filter;
+            egui::ComboBox::from_id_salt("sequence_chain_filter")
+                .selected_text(
+                    viewer
+                        .chain_filter
+                        .map(display_chain_id)
+                        .unwrap_or_else(|| "All chains".to_string()),
+                )
+                .width(120.0)
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(&mut viewer.chain_filter, None, "All chains");
+                    for chain in chains {
+                        ui.selectable_value(
+                            &mut viewer.chain_filter,
+                            Some(chain.id),
+                            format!("Chain {}", display_chain_id(chain.id)),
+                        );
+                    }
+                });
+            if viewer.chain_filter != before {
+                viewer.last_scrolled_primary_atom = None;
+            }
+        }
+
+        if let Some(chain_id) = primary_chain {
+            if ui
+                .button("Primary")
+                .on_hover_text("Show primary residue")
+                .clicked()
+            {
+                viewer.chain_filter = Some(chain_id);
+                viewer.last_scrolled_primary_atom = None;
+            }
+        } else {
+            ui.add_enabled(false, egui::Button::new("Primary"))
+                .on_hover_text("Show primary residue");
+        }
+    });
+    ui.add_space(4.0);
+}
+
+fn sequence_chains(structure: &Structure, selection: &AtomSelection) -> Vec<SequenceChain> {
+    let Some(biopolymer) = structure
+        .biopolymer
+        .as_ref()
+        .filter(|bio| bio.is_compatible_with_atom_count(structure.atoms.len()))
+    else {
+        return Vec::new();
+    };
+
+    let primary = selection.primary();
+    biopolymer
+        .chains
+        .iter()
+        .filter_map(|chain| {
+            let residues = chain
+                .residue_indices
+                .iter()
+                .filter_map(|&residue_index| {
+                    let residue = biopolymer.residues.get(residue_index)?;
+                    let kind = residue_polymer_kind(&residue.residue_name, residue)?;
+                    let selected_count = residue
+                        .atom_indices
+                        .iter()
+                        .filter(|&&atom_index| selection.contains(atom_index))
+                        .count();
+                    let atom_count = residue.atom_indices.len();
+                    Some(SequenceResidue {
+                        residue_index,
+                        symbol: residue_sequence_symbol(&residue.residue_name, kind),
+                        kind,
+                        secondary: (kind == ResiduePolymerKind::Protein)
+                            .then(|| secondary_structure_for_residue(biopolymer, residue))
+                            .flatten(),
+                        chain_id: residue.id.chain_id,
+                        sequence_number: residue.id.sequence_number,
+                        insertion_code: residue.id.insertion_code,
+                        residue_name: residue.residue_name.clone(),
+                        atom_count,
+                        any_selected: selected_count > 0,
+                        all_selected: atom_count > 0 && selected_count == atom_count,
+                        primary_selected: primary
+                            .is_some_and(|atom_index| residue.atom_indices.contains(&atom_index)),
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            (!residues.is_empty()).then_some(SequenceChain {
+                id: chain.id,
+                residues,
+            })
+        })
+        .collect()
+}
+
+fn secondary_structure_for_residue(
+    biopolymer: &crate::domain::biopolymer::Biopolymer,
+    residue: &crate::domain::biopolymer::ResidueRecord,
+) -> Option<SecondaryStructureKind> {
+    let residue_key = residue.id.ordering_key();
+    biopolymer
+        .secondary_structures
+        .iter()
+        .find(|span| {
+            if span.start.chain_id != residue.id.chain_id
+                || span.end.chain_id != residue.id.chain_id
+            {
+                return false;
+            }
+            let start = span.start.ordering_key();
+            let end = span.end.ordering_key();
+            if start <= end {
+                residue_key >= start && residue_key <= end
+            } else {
+                residue_key >= end && residue_key <= start
+            }
+        })
+        .map(|span| span.kind)
+}
+
+fn render_residue_cell(
+    ui: &mut egui::Ui,
+    residue: &SequenceResidue,
+    chain: &SequenceChain,
+    viewer: &mut SequenceViewerState,
+    actions: &mut Vec<AppAction>,
+    scroll_target: Option<usize>,
+) -> bool {
+    const CELL: Vec2 = Vec2::new(24.0, 24.0);
+    let pal = crate::frontend::theme::palette(ui);
+    let (rect, response) = ui.allocate_exact_size(CELL, egui::Sense::click());
+    let hovered = response.hovered();
+
+    let fill = if residue.primary_selected {
+        pal.accent
+    } else if residue.all_selected {
+        pal.selection_fill
+    } else if residue.any_selected {
+        pal.selection_fill.gamma_multiply(0.55)
+    } else if hovered {
+        pal.neutral_overlay(18)
+    } else if let Some(kind) = residue.secondary {
+        secondary_structure_fill(ui, kind)
+    } else {
+        Color32::TRANSPARENT
+    };
+    if fill != Color32::TRANSPARENT {
+        ui.painter().rect_filled(
+            rect,
+            egui::CornerRadius::same(crate::frontend::theme::radius::CHIP),
+            fill,
+        );
+    }
+
+    let stroke = if residue.any_selected || residue.primary_selected || hovered {
+        Stroke::new(1.0, pal.accent)
+    } else {
+        Stroke::new(1.0, pal.neutral_overlay(24))
+    };
+    ui.painter().rect_stroke(
+        rect,
+        egui::CornerRadius::same(crate::frontend::theme::radius::CHIP),
+        stroke,
+        egui::StrokeKind::Inside,
+    );
+
+    let text_color = if residue.primary_selected {
+        Color32::WHITE
+    } else {
+        pal.text_primary
+    };
+    ui.painter().text(
+        rect.center(),
+        egui::Align2::CENTER_CENTER,
+        residue.symbol,
+        FontId::new(13.0, FontFamily::Monospace),
+        text_color,
+    );
+
+    let response = response.on_hover_text(residue_tooltip(residue));
+    let mut scrolled = false;
+    if scroll_target == Some(residue.residue_index) {
+        response.scroll_to_me(Some(Align::Center));
+        scrolled = true;
+    }
+
+    if response.clicked() {
+        let modifiers = ui.input(|input| input.modifiers);
+        let toggle = modifiers.ctrl || modifiers.command;
+        if let Some(anchor) = viewer.last_clicked_residue.filter(|anchor| {
+            modifiers.shift
+                && chain
+                    .residues
+                    .iter()
+                    .any(|residue| residue.residue_index == *anchor)
+        }) {
+            actions.push(AppAction::SelectResidueRange {
+                chain_id: residue.chain_id,
+                start: anchor,
+                end: residue.residue_index,
+                toggle,
+            });
+        } else {
+            actions.push(AppAction::SelectResidue {
+                residue_index: residue.residue_index,
+                toggle,
+            });
+        }
+        viewer.last_clicked_residue = Some(residue.residue_index);
+        viewer.last_scrolled_primary_atom = None;
+    }
+
+    scrolled
+}
+
+fn secondary_structure_fill(ui: &egui::Ui, kind: SecondaryStructureKind) -> Color32 {
+    match (ui.visuals().dark_mode, kind) {
+        (false, SecondaryStructureKind::Helix) => Color32::from_rgba_unmultiplied(230, 135, 68, 64),
+        (false, SecondaryStructureKind::Sheet) => Color32::from_rgba_unmultiplied(70, 156, 118, 64),
+        (true, SecondaryStructureKind::Helix) => Color32::from_rgba_unmultiplied(202, 103, 50, 88),
+        (true, SecondaryStructureKind::Sheet) => Color32::from_rgba_unmultiplied(54, 139, 105, 88),
+    }
+}
+
+fn primary_residue(chains: &[SequenceChain]) -> Option<(usize, char)> {
+    chains.iter().find_map(|chain| {
+        chain
+            .residues
+            .iter()
+            .find(|residue| residue.primary_selected)
+            .map(|residue| (residue.residue_index, chain.id))
+    })
+}
+
+fn residue_tooltip(residue: &SequenceResidue) -> String {
+    let kind = match residue.kind {
+        ResiduePolymerKind::Protein => "protein",
+        ResiduePolymerKind::NucleicAcid => "nucleic acid",
+    };
+    let secondary = match residue.secondary {
+        Some(SecondaryStructureKind::Helix) => " / helix",
+        Some(SecondaryStructureKind::Sheet) => " / sheet",
+        None => "",
+    };
+    format!(
+        "Chain {} / Residue {}{} / {} / {} atom(s) / {kind}{secondary}",
+        display_chain_id(residue.chain_id),
+        residue.sequence_number,
+        display_insertion_code(residue.insertion_code),
+        residue.residue_name,
+        residue.atom_count,
+    )
+}
+
+fn display_chain_id(chain_id: char) -> String {
+    if chain_id == ' ' {
+        "(blank)".to_string()
+    } else {
+        chain_id.to_string()
+    }
+}
+
+fn display_insertion_code(insertion_code: char) -> String {
+    if insertion_code == ' ' || insertion_code == '\0' {
+        String::new()
+    } else {
+        insertion_code.to_string()
+    }
+}

--- a/src/frontend/ui/settings_representation.rs
+++ b/src/frontend/ui/settings_representation.rs
@@ -249,8 +249,8 @@ fn render_base_intro(_state: &mut AppState, ui: &mut egui::Ui, _actions: &mut Ve
     let pal = crate::frontend::theme::palette(ui);
     ui.label(
         RichText::new(
-            "Applies to ligands, ions, solvent, and other non-polymer atoms; biopolymer \
-             chains follow the Cartoon defaults below.",
+            "Applies to nucleic acids, ligands, ions, solvent, and other base-rendered atoms; \
+             protein chains follow the Cartoon defaults below.",
         )
         .color(pal.text_muted),
     );
@@ -399,7 +399,7 @@ pub(super) fn descriptors() -> Vec<SettingDescriptor> {
             "representation.base.scope",
             BASE_GROUP,
             "Base scope",
-            &["ligand", "ion", "solvent", "non-polymer", "base"],
+            &["nucleic", "ligand", "ion", "solvent", "base"],
             render_base_intro,
         ),
         SettingDescriptor {
@@ -407,8 +407,8 @@ pub(super) fn descriptors() -> Vec<SettingDescriptor> {
             category: SettingCategory::Representation,
             group: BASE_GROUP,
             title: "Default base style",
-            description: "Base representation for ligands, ions, solvent, and other \
-                          non-polymer atoms.",
+            description: "Base representation for nucleic acids, ligands, ions, solvent, \
+                          and other base-rendered atoms.",
             keywords: &[
                 "base",
                 "style",

--- a/src/frontend/viewport/visual_state.rs
+++ b/src/frontend/viewport/visual_state.rs
@@ -9,12 +9,13 @@ use crate::{domain::AtomCategory, domain::Structure, frontend::state::AtomStyle}
 /// category, and individual atoms may override the project.
 pub fn software_default_style(category: AtomCategory) -> AtomStyle {
     match category {
-        AtomCategory::Protein | AtomCategory::NucleicAcid => AtomStyle::Cartoon,
+        AtomCategory::Protein => AtomStyle::Cartoon,
         AtomCategory::Ion => AtomStyle::Sphere,
         // Solvent is shown like any other molecule by default; the user hides it
         // on demand from the View panel (or `view water off`). No automatic
         // program-side hiding.
-        AtomCategory::Carbohydrate
+        AtomCategory::NucleicAcid
+        | AtomCategory::Carbohydrate
         | AtomCategory::Solvent
         | AtomCategory::Ligand
         | AtomCategory::Other => AtomStyle::BallAndStick,
@@ -286,7 +287,7 @@ impl ViewportVisualState {
     /// ribbon — a peptide backbone (decided from atoms via
     /// [`Structure::atom_has_peptide_backbone`], so force-field-protonated,
     /// disulfide, and modified residues count too) or a category whose software
-    /// default is cartoon (e.g. nucleic acids). The residue name never gates this.
+    /// default is cartoon. The residue name never gates this.
     pub fn cartoon_enabled(&self, structure: &Structure, atom_index: usize) -> bool {
         let category = structure.atom_category(atom_index);
         let default_on = structure.atom_has_peptide_backbone(atom_index)

--- a/src/frontend/viewport_defaults.rs
+++ b/src/frontend/viewport_defaults.rs
@@ -29,14 +29,15 @@ pub fn apply_entry_render_defaults(
     // is essential context.
     viewport.show_cell = structure.cell.is_some() && structure.biopolymer.is_none();
 
-    // Seed the global base-style default for non-polymer categories. Biopolymer
-    // chains (Protein/NucleicAcid) are intentionally untouched so they keep their
-    // Cartoon default and follow the cartoon geometry below. `Other` is included
-    // so freshly *built* structures (which classify as `Other`) inherit the
-    // default too. `set_category_style` clears the override when it equals the
-    // software default, so the map stays sparse.
+    // Seed the global base-style default for categories that use base geometry.
+    // Protein chains are intentionally untouched so they keep their Cartoon
+    // default and follow the cartoon geometry below. `Other` is included so
+    // freshly *built* structures (which classify as `Other`) inherit the default
+    // too. `set_category_style` clears the override when it equals the software
+    // default, so the map stays sparse.
     let base = base_style_to_atom_style(prefs.base.default_style);
     for category in [
+        AtomCategory::NucleicAcid,
         AtomCategory::Ligand,
         AtomCategory::Ion,
         AtomCategory::Solvent,
@@ -134,7 +135,7 @@ mod tests {
     }
 
     #[test]
-    fn category_resolution_cartoons_protein_seeds_nonpolymer_base_style() {
+    fn category_resolution_cartoons_protein_seeds_base_styles() {
         // Protein CA, water O, and a sodium ion — no per-atom overrides stored.
         let annotations = vec![
             annotation("CA", "ALA", 1),
@@ -153,10 +154,10 @@ mod tests {
         let mut viewport = ViewportVisualState::default();
         apply_entry_render_defaults(&mut viewport, &structure, &RepresentationPrefs::default());
 
-        // No *per-atom* overrides are materialized; non-polymer base styles come
+        // No *per-atom* overrides are materialized; base styles come
         // from the project-level category tier the defaults just seeded.
         assert!(viewport.atom_styles.is_empty());
-        // Biopolymer chains are untouched and keep their Cartoon default.
+        // Protein chains are untouched and keep their Cartoon default.
         assert_eq!(
             viewport.resolved_atom_style(&structure, 0),
             AtomStyle::Cartoon
@@ -174,6 +175,52 @@ mod tests {
         );
     }
 
+    #[test]
+    fn nucleic_acid_only_entry_defaults_to_drawable_base_style() {
+        let annotations = vec![
+            annotation("P", "DA", 1),
+            annotation("C1'", "DA", 1),
+            annotation("N9", "DA", 1),
+            annotation("P", "DC", 2),
+            annotation("C1'", "DC", 2),
+            annotation("N1", "DC", 2),
+        ];
+        let biopolymer = build_biopolymer(&annotations, Vec::new()).expect("biopolymer");
+        let structure = Structure {
+            title: "dna".to_string(),
+            atoms: vec![
+                atom("P"),
+                atom("C"),
+                atom("N"),
+                atom("P"),
+                atom("C"),
+                atom("N"),
+            ],
+            bonds: Vec::new(),
+            cell: None,
+            biopolymer: Some(biopolymer),
+        };
+
+        let mut viewport = ViewportVisualState::default();
+        apply_entry_render_defaults(&mut viewport, &structure, &RepresentationPrefs::default());
+
+        for index in 0..structure.atoms.len() {
+            assert_eq!(structure.atom_category(index), AtomCategory::NucleicAcid);
+            assert_eq!(
+                viewport.resolved_atom_style(&structure, index),
+                AtomStyle::BallAndStick
+            );
+            assert_eq!(
+                viewport.resolved_base_style(&structure, index),
+                AtomStyle::BallAndStick
+            );
+            assert!(!viewport.cartoon_enabled(&structure, index));
+        }
+        assert_eq!(
+            heavy_render_atom_count(&structure, &viewport),
+            structure.atoms.len()
+        );
+    }
     /// One protein anchor (so a biopolymer exists and SOL classifies as Solvent)
     /// plus `water` SOL oxygens.
     fn solvated(water: usize) -> Structure {


### PR DESCRIPTION
## Summary
- add biopolymer sequence helpers in `compute-core`
- add a dockable sequence viewer panel with frontend state, actions, and dispatcher wiring
- keep nucleic acid structures drawable by updating viewport/representation defaults

## Details
- introduce sequence-related domain support in `compute-core/src/domain/biopolymer.rs` and `compute-core/src/domain/biopolymer/sequence.rs`
- add sequence viewer UI and docking integration across frontend state, actions, dispatcher, and panel rendering
- add residue-selection plumbing for sequence interactions
- adjust representation and viewport defaults so nucleic-acid structures remain drawable

## Testing
- cargo fmt --all --check ✅
- cargo clippy --workspace --all-targets --all-features ✅
- cargo test --workspace --all-features ✅