### PR TITLE
fix(ui): render Chinese text in assistant on Windows

### DIFF
--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -192,10 +192,10 @@ const UI_NAMED_FONT_FAMILIES: &[(&str, egui::FontFamily)] = &[
     (CONSOLE_CJK_MONO_FONT, egui::FontFamily::Monospace),
 ];
 
-/// On macOS, prefer the system font (SF Pro for UI text, SF Mono for code) and
-/// keep system CJK faces as fallbacks so mixed English/Chinese assistant output
-/// does not render as missing-glyph boxes. On every platform, the tail loop
-/// guarantees the named families above resolve to real fonts.
+/// On native desktop targets, prefer the platform UI/code font and keep system
+/// CJK faces as fallbacks so mixed English/Chinese assistant output does not
+/// render as missing-glyph boxes. On every platform, the tail loop guarantees
+/// the named families above resolve to real fonts.
 fn install_system_fonts(fonts: &mut egui::FontDefinitions) {
     #[cfg(target_os = "macos")]
     {
@@ -203,100 +203,192 @@ fn install_system_fonts(fonts: &mut egui::FontDefinitions) {
         let console_cjk_mono = egui::FontFamily::Name(CONSOLE_CJK_MONO_FONT.into());
         fonts.families.insert(assistant_cjk.clone(), Vec::new());
         fonts.families.insert(console_cjk_mono.clone(), Vec::new());
-        let mut install = |name: &str, path: &str, family: egui::FontFamily, prepend: bool| {
-            if let Ok(bytes) = std::fs::read(path) {
-                fonts.font_data.insert(
-                    name.to_owned(),
-                    std::sync::Arc::new(egui::FontData::from_owned(bytes)),
-                );
-                if let Some(list) = fonts.families.get_mut(&family) {
-                    if prepend {
-                        list.insert(0, name.to_owned());
-                    } else {
-                        list.push(name.to_owned());
-                    }
-                }
-            }
-        };
-        install(
+        install_font(
+            fonts,
             "SF Pro",
             "/System/Library/Fonts/SFNS.ttf",
             egui::FontFamily::Proportional,
             true,
         );
-        install(
+        install_font(
+            fonts,
             "SF Mono",
             "/System/Library/Fonts/SFNSMono.ttf",
             egui::FontFamily::Monospace,
             true,
         );
-        install(
+        install_font(
+            fonts,
             "Hiragino Sans GB Assistant",
             "/System/Library/Fonts/Hiragino Sans GB.ttc",
             assistant_cjk.clone(),
             false,
         );
-        install(
+        install_font(
+            fonts,
             "STHeiti Medium Assistant",
             "/System/Library/Fonts/STHeiti Medium.ttc",
             assistant_cjk.clone(),
             false,
         );
-        install(
+        install_font(
+            fonts,
             "SF Pro Assistant Fallback",
             "/System/Library/Fonts/SFNS.ttf",
             assistant_cjk,
             false,
         );
-        install(
+        install_font(
+            fonts,
             "Hiragino Sans GB Console",
             "/System/Library/Fonts/Hiragino Sans GB.ttc",
             console_cjk_mono.clone(),
             false,
         );
-        install(
+        install_font(
+            fonts,
             "STHeiti Medium Console",
             "/System/Library/Fonts/STHeiti Medium.ttc",
             console_cjk_mono.clone(),
             false,
         );
-        install(
+        install_font(
+            fonts,
             "Menlo Console Fallback",
             "/System/Library/Fonts/Menlo.ttc",
             console_cjk_mono,
             false,
         );
-        install(
+        install_font(
+            fonts,
             "Hiragino Sans GB",
             "/System/Library/Fonts/Hiragino Sans GB.ttc",
             egui::FontFamily::Proportional,
             false,
         );
-        install(
+        install_font(
+            fonts,
             "STHeiti Medium",
             "/System/Library/Fonts/STHeiti Medium.ttc",
             egui::FontFamily::Proportional,
             false,
         );
-        install(
+        install_font(
+            fonts,
             "Hiragino Sans GB Mono Fallback",
             "/System/Library/Fonts/Hiragino Sans GB.ttc",
             egui::FontFamily::Monospace,
             false,
         );
-        install(
+        install_font(
+            fonts,
             "STHeiti Medium Mono Fallback",
             "/System/Library/Fonts/STHeiti Medium.ttc",
             egui::FontFamily::Monospace,
             false,
         );
     }
+
+    #[cfg(target_os = "windows")]
+    {
+        let assistant_cjk = egui::FontFamily::Name(ASSISTANT_CJK_FONT.into());
+        let console_cjk_mono = egui::FontFamily::Name(CONSOLE_CJK_MONO_FONT.into());
+        fonts.families.insert(assistant_cjk.clone(), Vec::new());
+        fonts.families.insert(console_cjk_mono.clone(), Vec::new());
+        let windir = std::env::var("WINDIR").unwrap_or_else(|_| "C:\\Windows".to_string());
+        let font_path = |file: &str| format!("{windir}\\Fonts\\{file}");
+
+        install_font(
+            fonts,
+            "Segoe UI",
+            font_path("segoeui.ttf"),
+            egui::FontFamily::Proportional,
+            true,
+        );
+        install_font(
+            fonts,
+            "Consolas",
+            font_path("consola.ttf"),
+            egui::FontFamily::Monospace,
+            true,
+        );
+        install_font(
+            fonts,
+            "Microsoft YaHei Assistant",
+            font_path("msyh.ttc"),
+            assistant_cjk.clone(),
+            false,
+        );
+        install_font(
+            fonts,
+            "SimSun Assistant",
+            font_path("simsun.ttc"),
+            assistant_cjk.clone(),
+            false,
+        );
+        install_font(
+            fonts,
+            "Segoe UI Assistant Fallback",
+            font_path("segoeui.ttf"),
+            assistant_cjk,
+            false,
+        );
+        install_font(
+            fonts,
+            "Microsoft YaHei Console",
+            font_path("msyh.ttc"),
+            console_cjk_mono.clone(),
+            false,
+        );
+        install_font(
+            fonts,
+            "SimSun Console",
+            font_path("simsun.ttc"),
+            console_cjk_mono.clone(),
+            false,
+        );
+        install_font(
+            fonts,
+            "Consolas Console Fallback",
+            font_path("consola.ttf"),
+            console_cjk_mono,
+            false,
+        );
+        install_font(
+            fonts,
+            "Microsoft YaHei",
+            font_path("msyh.ttc"),
+            egui::FontFamily::Proportional,
+            false,
+        );
+        install_font(
+            fonts,
+            "SimSun",
+            font_path("simsun.ttc"),
+            egui::FontFamily::Proportional,
+            false,
+        );
+        install_font(
+            fonts,
+            "Microsoft YaHei Mono Fallback",
+            font_path("msyh.ttc"),
+            egui::FontFamily::Monospace,
+            false,
+        );
+        install_font(
+            fonts,
+            "SimSun Mono Fallback",
+            font_path("simsun.ttc"),
+            egui::FontFamily::Monospace,
+            false,
+        );
+    }
+
     // epaint panics when a `FontFamily::Name` resolves to no fonts. The macOS
-    // block above binds the named families to system CJK faces; everywhere else
-    // they are still missing here (and a failed macOS font read could leave one
-    // empty). Alias every unbound or empty named family to its default stack so
-    // layout always has real fonts and the app starts. CJK coverage off macOS is
-    // then whatever the bundled fonts provide.
+    // and Windows blocks above bind the named families to system CJK faces;
+    // elsewhere they are still missing here (and a failed platform font read
+    // could leave one empty). Alias every unbound or empty named family to its
+    // default stack so layout always has real fonts and the app starts.
     for (name, base) in UI_NAMED_FONT_FAMILIES {
         let family = egui::FontFamily::Name((*name).into());
         if fonts
@@ -306,6 +398,29 @@ fn install_system_fonts(fonts: &mut egui::FontDefinitions) {
         {
             let fallback = fonts.families.get(base).cloned().unwrap_or_default();
             fonts.families.insert(family, fallback);
+        }
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn install_font(
+    fonts: &mut egui::FontDefinitions,
+    name: &str,
+    path: impl AsRef<std::path::Path>,
+    family: egui::FontFamily,
+    prepend: bool,
+) {
+    if let Ok(bytes) = std::fs::read(path) {
+        fonts.font_data.insert(
+            name.to_owned(),
+            std::sync::Arc::new(egui::FontData::from_owned(bytes)),
+        );
+        if let Some(list) = fonts.families.get_mut(&family) {
+            if prepend {
+                list.insert(0, name.to_owned());
+            } else {
+                list.push(name.to_owned());
+            }
         }
     }
 }
@@ -603,5 +718,42 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_assistant_fonts_include_system_cjk_fallbacks() {
+        use super::{ASSISTANT_CJK_FONT, CONSOLE_CJK_MONO_FONT};
+
+        let windir = std::env::var("WINDIR").unwrap_or_else(|_| "C:\\Windows".to_string());
+        if !std::path::Path::new(&windir)
+            .join("Fonts")
+            .join("msyh.ttc")
+            .exists()
+        {
+            return;
+        }
+
+        let mut fonts = egui::FontDefinitions::default();
+        egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Regular);
+        install_system_fonts(&mut fonts);
+
+        let assistant = egui::FontFamily::Name(ASSISTANT_CJK_FONT.into());
+        let console = egui::FontFamily::Name(CONSOLE_CJK_MONO_FONT.into());
+        let assistant_fonts = fonts.families.get(&assistant).unwrap();
+        let console_fonts = fonts.families.get(&console).unwrap();
+
+        assert!(
+            assistant_fonts
+                .iter()
+                .any(|font| font == "Microsoft YaHei Assistant"),
+            "assistant-cjk should use Microsoft YaHei as a Windows CJK fallback",
+        );
+        assert!(
+            console_fonts
+                .iter()
+                .any(|font| font == "Microsoft YaHei Console"),
+            "console-cjk-mono should use Microsoft YaHei as a Windows CJK fallback",
+        );
     }
 }


### PR DESCRIPTION
## Summary
- load Windows system UI/code fonts plus Microsoft YaHei and SimSun CJK fallbacks at startup
- bind Assistant-specific named font families to Windows CJK-capable stacks
- add a Windows regression test for Assistant and console CJK font fallbacks

## Tests
- cargo fmt --all --check
- cargo test -p silicolab font
- git diff --check