### PR TITLE
chore: add local PR check command

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[alias]
+pr-check = "run -p xtask -- pr-check"
+xtask = "run -p xtask --"

--- a/.rules
+++ b/.rules
@@ -51,7 +51,7 @@ The GUI uses an Elm-style flow.
 # Commit and PR hygiene
 
 * Use Conventional Commits for commit messages, matching the existing project style.
-* Before opening a PR, make CI's checks pass locally with `RUSTFLAGS=-D warnings`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features`, `cargo test --workspace --all-features`.
+* Before opening a PR, make CI's local Rust gates pass with `cargo pr-check`; update `xtask` when CI's local checks change.
 
 # Rules hygiene
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,14 +54,15 @@ now, and hold the integration code until its real-run test exists.
 
 ### Pre-commit gates
 
-All of the following must pass before you commit. They mirror the CI merge gate,
-which runs with `RUSTFLAGS=-D warnings` across the whole workspace:
+Run the local PR check before you commit:
 
-1. `cargo fmt --all --check`
-2. `cargo clippy --workspace --all-targets --all-features`
-3. `cargo test --workspace --all-features`
+```powershell
+cargo pr-check
+```
 
-Set `RUSTFLAGS=-D warnings` so clippy and test fail on warnings exactly as CI does.
+The command mirrors CI's local Rust gates, including warning-as-error builds. It
+does not replace CI's cross-OS matrix or the ignored machine-specific acceptance
+tests.
 
 ## Code conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7571,6 +7571,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["compute-core", "silicolab-compute"]
+members = ["compute-core", "silicolab-compute", "xtask"]
 
 # Single source of truth for the version shared across the GUI, the headless
 # worker, and `compute-core`. The deploy version pin and release tag require all

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "xtask"
+version.workspace = true
+edition = "2024"
+publish = false
+
+[dependencies]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,217 @@
+use std::{
+    collections::BTreeSet,
+    env, fs, io,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let mut args = env::args().skip(1);
+    match args.next().as_deref() {
+        Some("pr-check") => {
+            if args.next().is_some() {
+                return Err("usage: cargo pr-check".to_owned());
+            }
+            pr_check()
+        }
+        Some(command) => Err(format!("unknown xtask command: {command}")),
+        None => Err("usage: cargo xtask <command>".to_owned()),
+    }
+}
+
+fn pr_check() -> Result<(), String> {
+    let repo_root = repo_root()?;
+
+    run_cargo(
+        &repo_root,
+        "Format",
+        &["fmt", "--all", "--check"],
+        Stdio::inherit(),
+    )?;
+    run_cargo(
+        &repo_root,
+        "Clippy",
+        &["clippy", "--workspace", "--all-targets", "--all-features"],
+        Stdio::inherit(),
+    )?;
+    assert_worker_pure_rust(&repo_root)?;
+    assert_rust_file_sizes(&repo_root)?;
+    run_cargo(
+        &repo_root,
+        "Test",
+        &["test", "--workspace", "--all-features"],
+        Stdio::inherit(),
+    )?;
+
+    println!();
+    println!("PR checks passed.");
+    Ok(())
+}
+
+fn repo_root() -> Result<PathBuf, String> {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| "could not resolve repository root".to_owned())
+}
+
+fn run_cargo(repo_root: &Path, name: &str, args: &[&str], stdout: Stdio) -> Result<(), String> {
+    println!();
+    println!("==> {name}");
+
+    let status = Command::new("cargo")
+        .args(args)
+        .current_dir(repo_root)
+        .env("CARGO_TERM_COLOR", "always")
+        .env("RUSTFLAGS", "-D warnings")
+        .env("CARGO_PROFILE_DEV_DEBUG", "line-tables-only")
+        .stdout(stdout)
+        .stderr(Stdio::inherit())
+        .status()
+        .map_err(|error| format!("failed to run cargo {}: {error}", args.join(" ")))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("{name} failed with {status}."))
+    }
+}
+
+fn assert_worker_pure_rust(repo_root: &Path) -> Result<(), String> {
+    println!();
+    println!("==> Worker is pure Rust");
+
+    let output = cargo_output(
+        repo_root,
+        &[
+            "tree",
+            "--color",
+            "never",
+            "-p",
+            "silicolab-compute",
+            "--target",
+            "x86_64-unknown-linux-musl",
+            "-e",
+            "normal,build",
+            "--prefix",
+            "none",
+        ],
+    )?;
+
+    io::copy(&mut output.stderr.as_slice(), &mut io::stderr())
+        .map_err(|error| format!("failed to print cargo tree diagnostics: {error}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "worker dependency check failed with {}.",
+            output.status
+        ));
+    }
+
+    let tree = String::from_utf8_lossy(&output.stdout);
+    let tree_lines: BTreeSet<_> = tree.lines().collect();
+    for line in &tree_lines {
+        println!("{line}");
+    }
+
+    let native_dependencies: Vec<_> = tree_lines
+        .iter()
+        .copied()
+        .filter(|line| {
+            ["cc", "ring", "aws-lc-rs", "aws-lc-sys", "openssl-sys"]
+                .iter()
+                .any(|name| line.starts_with(&format!("{name} ")))
+        })
+        .collect();
+
+    if native_dependencies.is_empty() {
+        Ok(())
+    } else {
+        for dependency in native_dependencies {
+            eprintln!("{dependency}");
+        }
+        Err(
+            "silicolab-compute pulls a C-toolchain / native build dependency; keep it pure Rust."
+                .to_owned(),
+        )
+    }
+}
+
+fn cargo_output(repo_root: &Path, args: &[&str]) -> Result<std::process::Output, String> {
+    Command::new("cargo")
+        .args(args)
+        .current_dir(repo_root)
+        .env("CARGO_TERM_COLOR", "always")
+        .env("RUSTFLAGS", "-D warnings")
+        .env("CARGO_PROFILE_DEV_DEBUG", "line-tables-only")
+        .output()
+        .map_err(|error| format!("failed to run cargo {}: {error}", args.join(" ")))
+}
+
+fn assert_rust_file_sizes(repo_root: &Path) -> Result<(), String> {
+    println!();
+    println!("==> Rust file size");
+
+    let output = Command::new("git")
+        .args(["ls-files", "--", "*.rs"])
+        .current_dir(repo_root)
+        .output()
+        .map_err(|error| format!("failed to list tracked Rust files: {error}"))?;
+
+    io::copy(&mut output.stderr.as_slice(), &mut io::stderr())
+        .map_err(|error| format!("failed to print git diagnostics: {error}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "failed to list tracked Rust files with {}.",
+            output.status
+        ));
+    }
+
+    let files = String::from_utf8(output.stdout)
+        .map_err(|error| format!("git produced non-UTF-8 file output: {error}"))?;
+    let oversized_files = oversized_rust_files(repo_root, files.lines())?;
+
+    if oversized_files.is_empty() {
+        println!("All Rust source files are within the 800 physical-line limit.");
+        Ok(())
+    } else {
+        for (path, line_count) in oversized_files {
+            eprintln!("{path} has {line_count} physical lines (limit 800).");
+        }
+        Err("Split the files above; see the size rule in .rules.".to_owned())
+    }
+}
+
+fn oversized_rust_files<'a>(
+    repo_root: &Path,
+    files: impl Iterator<Item = &'a str>,
+) -> Result<BTreeSet<(String, usize)>, String> {
+    let mut oversized_files = BTreeSet::new();
+    for file in files {
+        let path = repo_root.join(file);
+        let contents = fs::read(&path)
+            .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+        let line_count = physical_line_count(&contents);
+        if line_count > 800 {
+            oversized_files.insert((file.to_owned(), line_count));
+        }
+    }
+    Ok(oversized_files)
+}
+
+fn physical_line_count(contents: &[u8]) -> usize {
+    let newline_count = contents.iter().filter(|byte| **byte == b'\n').count();
+    if contents.last().is_some_and(|byte| *byte == b'\n') {
+        newline_count
+    } else {
+        newline_count + usize::from(!contents.is_empty())
+    }
+}


### PR DESCRIPTION
## Summary

- add cargo pr-check as a local alias for running the Rust PR gate
- add an xtask implementation that mirrors CI local Rust checks: fmt, clippy, worker pure-Rust dependency check, Rust file size check, and workspace tests
- update contributing docs and .rules to point contributors at cargo pr-check

## Verification

- cargo pr-check