### PR TITLE
feat: add floating task panel default

### DIFF
--- a/src/backend/config.rs
+++ b/src/backend/config.rs
@@ -135,6 +135,34 @@ pub enum ComputeTarget {
     Remote(String),
 }
 
+/// Where newly opened task panels appear by default. The user can still drag a
+/// task tab between dock areas after it opens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum TaskPanelPlacement {
+    #[default]
+    Floating,
+    RightSidebar,
+    BottomPanel,
+}
+
+impl TaskPanelPlacement {
+    pub const fn all() -> [TaskPanelPlacement; 3] {
+        [
+            TaskPanelPlacement::Floating,
+            TaskPanelPlacement::RightSidebar,
+            TaskPanelPlacement::BottomPanel,
+        ]
+    }
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            TaskPanelPlacement::Floating => "Floating window",
+            TaskPanelPlacement::RightSidebar => "Right sidebar",
+            TaskPanelPlacement::BottomPanel => "Bottom panel",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
     pub default_project_dir: PathBuf,
@@ -155,6 +183,10 @@ pub struct AppConfig {
     /// it at launch. Defaults to [`ComputeTarget::Local`].
     #[serde(default)]
     pub default_compute_target: ComputeTarget,
+    /// App-wide default host for newly opened task panels. Per-panel task tabs
+    /// remain session state and can still be dragged between hosts after opening.
+    #[serde(default)]
+    pub default_task_panel_placement: TaskPanelPlacement,
     /// Light/dark preference. Defaults to following the system.
     #[serde(default)]
     pub theme: ThemeMode,
@@ -338,6 +370,7 @@ impl Default for AppConfig {
             engine_overrides: HashMap::default(),
             remote_hosts: HashMap::default(),
             default_compute_target: ComputeTarget::default(),
+            default_task_panel_placement: TaskPanelPlacement::default(),
             theme: ThemeMode::default(),
             color_scheme: ColorScheme::default(),
             glass: default_glass(),

--- a/src/frontend/actions.rs
+++ b/src/frontend/actions.rs
@@ -275,6 +275,9 @@ pub enum AppAction {
     /// panel can still override it per run). Written to the settings file by the
     /// dispatcher.
     SetDefaultComputeTarget(crate::backend::config::ComputeTarget),
+    /// Set where newly opened task panels appear by default. Users can still drag
+    /// an open task panel into another dock host.
+    SetDefaultTaskPanelPlacement(crate::backend::config::TaskPanelPlacement),
     /// Fetch the static hardware inventory (CPU/memory/GPU) of the host with this
     /// id over SSH, for the Hardware ▸ Remote settings panel (worker thread).
     FetchRemoteHardware(String),

--- a/src/frontend/dispatcher/mod.rs
+++ b/src/frontend/dispatcher/mod.rs
@@ -317,6 +317,9 @@ pub fn dispatch(state: &mut AppState, action: AppAction, ctx: &egui::Context) {
         AppAction::SetupRemoteHostKey(id) => setup_remote_host_key(state, id),
         AppAction::OpenRemoteHostsSettings => open_remote_hosts_settings(state),
         AppAction::SetDefaultComputeTarget(target) => set_default_compute_target(state, target),
+        AppAction::SetDefaultTaskPanelPlacement(placement) => {
+            set_default_task_panel_placement(state, placement)
+        }
         AppAction::FetchRemoteHardware(id) => fetch_remote_hardware(state, id),
         AppAction::RefreshRemoteJobs => refresh_remote_jobs(state),
         AppAction::RemoveRemoteScratch(run_uuid) => remove_remote_job_scratch(state, &run_uuid),

--- a/src/frontend/dispatcher/settings.rs
+++ b/src/frontend/dispatcher/settings.rs
@@ -40,6 +40,18 @@ pub(crate) fn set_default_compute_target(
     }
 }
 
+pub(crate) fn set_default_task_panel_placement(
+    state: &mut AppState,
+    placement: crate::backend::config::TaskPanelPlacement,
+) {
+    state.config.default_task_panel_placement = placement;
+    if let Err(error) = save_config(&state.config) {
+        state.set_message(format!(
+            "Could not save default task panel location: {error}"
+        ));
+    }
+}
+
 /// Apply one Representation default edit and persist. These defaults only seed
 /// the appearance of *future* new entries/surfaces, so there is no live
 /// re-render here — the change lands the next time a structure is built/loaded

--- a/src/frontend/dispatcher/tasks.rs
+++ b/src/frontend/dispatcher/tasks.rs
@@ -11,9 +11,13 @@ pub(crate) fn create_task_from_template(state: &mut AppState, template_id: &'sta
     state.ui.layout.show_primary_sidebar = true;
     if controller.requires_panel() {
         state.tasks.open_panel(task_run_id);
-        // Dock the panel as a tab in its home area (revealing the area). Task tabs
-        // are session state, so this placement is never persisted.
-        state.ui.layout.dock.add_task(task_run_id);
+        // Task panel placement is session state; only the default preference is
+        // persisted.
+        state
+            .ui
+            .layout
+            .dock
+            .add_task(task_run_id, state.config.default_task_panel_placement);
     }
     state.set_message(format!(
         "Opened task #{}: {}",
@@ -144,7 +148,11 @@ pub(crate) fn record_task_result_entry(state: &mut AppState, task_run_id: u64, e
 
 pub(crate) fn open_task_panel(state: &mut AppState, task_run_id: u64) {
     state.tasks.open_panel(task_run_id);
-    state.ui.layout.dock.add_task(task_run_id);
+    state
+        .ui
+        .layout
+        .dock
+        .add_task(task_run_id, state.config.default_task_panel_placement);
     ensure_panel_form(state, task_run_id);
 }
 

--- a/src/frontend/state/dock.rs
+++ b/src/frontend/state/dock.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::backend::config::{DockAreaLayout, DockLayoutConfig};
+use crate::backend::config::{DockAreaLayout, DockLayoutConfig, TaskPanelPlacement};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrimaryView {
@@ -143,6 +143,14 @@ pub struct DockAreaState {
     pub collapsed: bool,
 }
 
+/// Session-only placement for a task panel shown as an in-window floating
+/// window. The window's live position and size are owned by egui's window memory;
+/// this model only records which task panels are currently floating.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FloatingTaskPanel {
+    pub task_run_id: u64,
+}
+
 /// Placement and sizing of the two dock areas. The single source of truth for
 /// which view/panel is shown where; the renderer and the dispatcher both drive
 /// it through the helpers below (none of which touch `egui::Context`). The fixed
@@ -152,6 +160,7 @@ pub struct DockAreaState {
 pub struct DockModel {
     pub bottom: DockAreaState,
     pub right: DockAreaState,
+    pub floating_tasks: Vec<FloatingTaskPanel>,
     pub right_width: f32,
     pub bottom_height: f32,
 }
@@ -178,6 +187,7 @@ impl Default for DockModel {
                 active: Some(DockTab::Static(StaticView::Assistant)),
                 collapsed: false,
             },
+            floating_tasks: Vec::new(),
             right_width: SIDEBAR_DEFAULT_WIDTH_SECONDARY,
             bottom_height: PANEL_DEFAULT_HEIGHT,
         }
@@ -226,6 +236,10 @@ impl DockModel {
     /// tab to the last remaining one when the removed tab was active (mirrors
     /// `TaskManager::close_panel`). Returns the area it left.
     pub fn remove_tab(&mut self, tab: DockTab) -> Option<DockArea> {
+        if let DockTab::Task(task_run_id) = tab {
+            self.floating_tasks
+                .retain(|panel| panel.task_run_id != task_run_id);
+        }
         let area = self.area_of(tab)?;
         let state = self.area_mut(area);
         state.tabs.retain(|candidate| *candidate != tab);
@@ -285,11 +299,31 @@ impl DockModel {
         self.activate(area, tab);
     }
 
-    /// Add a task panel tab to its home area (the area already holding a task tab,
-    /// else the right sidebar), make it active, and reveal the area.
-    pub fn add_task(&mut self, task_run_id: u64) {
-        let home = self.task_home_area();
-        self.insert_tab(home, DockTab::Task(task_run_id), None);
+    /// Add a task panel to the requested default host, unless it is already open.
+    /// Existing docked panels stay docked; existing floating panels are brought
+    /// to the front by rendering them last.
+    pub fn add_task(&mut self, task_run_id: u64, placement: TaskPanelPlacement) {
+        let tab = DockTab::Task(task_run_id);
+        if let Some(area) = self.area_of(tab) {
+            self.activate(area, tab);
+            return;
+        }
+        if let Some(index) = self
+            .floating_tasks
+            .iter()
+            .position(|panel| panel.task_run_id == task_run_id)
+        {
+            let panel = self.floating_tasks.remove(index);
+            self.floating_tasks.push(panel);
+            return;
+        }
+        match placement {
+            TaskPanelPlacement::Floating => {
+                self.floating_tasks.push(FloatingTaskPanel { task_run_id });
+            }
+            TaskPanelPlacement::RightSidebar => self.insert_tab(DockArea::Right, tab, None),
+            TaskPanelPlacement::BottomPanel => self.insert_tab(DockArea::Bottom, tab, None),
+        }
     }
 
     pub fn remove_task(&mut self, task_run_id: u64) {
@@ -298,6 +332,7 @@ impl DockModel {
 
     /// Drop every task tab (keeping the fixed views), e.g. on project close.
     pub fn clear_task_tabs(&mut self) {
+        self.floating_tasks.clear();
         for area in DockArea::all() {
             let state = self.area_mut(area);
             state.tabs.retain(|tab| matches!(tab, DockTab::Static(_)));
@@ -308,21 +343,6 @@ impl DockModel {
                 state.active = state.tabs.last().copied();
             }
         }
-    }
-
-    /// Where a freshly opened task panel docks: the area already hosting a task
-    /// tab (so a run of tasks stays grouped after the user moves one), else the
-    /// right sidebar.
-    fn task_home_area(&self) -> DockArea {
-        DockArea::all()
-            .into_iter()
-            .find(|&area| {
-                self.area(area)
-                    .tabs
-                    .iter()
-                    .any(|tab| matches!(tab, DockTab::Task(_)))
-            })
-            .unwrap_or(DockArea::Right)
     }
 
     /// Serialize the fixed-view placement (task tabs are excluded structurally).
@@ -342,6 +362,7 @@ impl DockModel {
         let mut model = Self {
             bottom: area_from_config(&config.bottom),
             right: area_from_config(&config.right),
+            floating_tasks: Vec::new(),
             right_width: config.right_width,
             bottom_height: config.bottom_height,
         };

--- a/src/frontend/state/tests.rs
+++ b/src/frontend/state/tests.rs
@@ -1,5 +1,12 @@
 use super::{AppState, DockArea, DockModel, DockTab, MdRunPrompt, MdStageEdit, StaticView};
+use crate::backend::config::TaskPanelPlacement;
 use crate::workflows::molecular_dynamics::{MdStage, StageLength};
+
+fn has_floating_task(dock: &DockModel, task_run_id: u64) -> bool {
+    dock.floating_tasks
+        .iter()
+        .any(|panel| panel.task_run_id == task_run_id)
+}
 
 /// The config-side literal default (`DockLayoutConfig::default`, in the
 /// backend layer) must stay in lock-step with `DockModel::default`, since the
@@ -158,23 +165,41 @@ fn remove_tab_repoints_active_to_last() {
 }
 
 #[test]
-fn add_task_is_sticky_to_the_area_holding_tasks() {
+fn add_task_defaults_to_floating_window() {
     let mut dock = DockModel::default();
-    // First task homes to the right sidebar.
-    dock.add_task(1);
+    dock.add_task(1, TaskPanelPlacement::Floating);
+
+    assert!(has_floating_task(&dock, 1));
+    assert_eq!(dock.area_of(DockTab::Task(1)), None);
+}
+
+#[test]
+fn add_task_honors_docked_default_location() {
+    let mut dock = DockModel::default();
+    dock.add_task(1, TaskPanelPlacement::BottomPanel);
+
+    assert_eq!(dock.area_of(DockTab::Task(1)), Some(DockArea::Bottom));
+    assert!(!has_floating_task(&dock, 1));
+}
+
+#[test]
+fn moving_floating_task_to_dock_removes_floating_copy() {
+    let mut dock = DockModel::default();
+    dock.add_task(1, TaskPanelPlacement::Floating);
+
+    dock.move_tab(DockTab::Task(1), DockArea::Right, None);
+
     assert_eq!(dock.area_of(DockTab::Task(1)), Some(DockArea::Right));
-    // Drag it to the bottom; a second task now homes alongside it (sticky).
-    dock.move_tab(DockTab::Task(1), DockArea::Bottom, None);
-    dock.add_task(2);
-    assert_eq!(dock.area_of(DockTab::Task(2)), Some(DockArea::Bottom));
+    assert!(!has_floating_task(&dock, 1));
 }
 
 #[test]
 fn clear_task_tabs_keeps_fixed_views() {
     let mut dock = DockModel::default();
-    dock.add_task(7); // -> right, active
+    dock.add_task(7, TaskPanelPlacement::Floating);
     dock.clear_task_tabs();
     assert!(dock.area_of(DockTab::Task(7)).is_none());
+    assert!(!has_floating_task(&dock, 7));
     // The fixed Assistant view remains and is the right area's active tab again.
     assert!(
         dock.right

--- a/src/frontend/ui/dock.rs
+++ b/src/frontend/ui/dock.rs
@@ -4,7 +4,7 @@ use super::panel_bodies::{
 };
 use super::secondary_sidebar::*;
 use super::*;
-use crate::backend::tasks::TaskPanelKind;
+use crate::backend::tasks::{TaskPanelKind, TaskRun};
 use crate::frontend::state::{DockArea, DockModel, DockTab, StaticView};
 use crate::frontend::theme::Palette;
 
@@ -258,6 +258,84 @@ fn collapsed_area_label(state: &AppState, area: DockArea) -> String {
             .unwrap_or_else(|| "Panel".to_string()),
         None => "Panel".to_string(),
     }
+}
+
+/// Render task panels that are not currently docked in the bottom panel or the
+/// right sidebar. They stay session-only, like docked task tabs, but default to
+/// their own movable window so opening a builder does not consume the right
+/// sidebar unless the user drags it there.
+pub(super) fn render_floating_task_windows(
+    state: &mut AppState,
+    ctx: &egui::Context,
+    actions: &mut Vec<AppAction>,
+) {
+    let floating = state.ui.layout.dock.floating_tasks.clone();
+    let mut stale_tasks = Vec::new();
+
+    for (index, panel) in floating.into_iter().enumerate() {
+        let task_run_id = panel.task_run_id;
+        let Some(task) = state.tasks.task_run(task_run_id).cloned() else {
+            stale_tasks.push(task_run_id);
+            continue;
+        };
+
+        let mut open = true;
+        egui::Window::new(task.title.clone())
+            .id(Id::new(("floating_task_window", task_run_id)))
+            .default_pos(default_floating_task_pos(ctx, index))
+            .default_size(egui::vec2(380.0, 560.0))
+            .min_width(320.0)
+            .min_height(260.0)
+            .resizable(true)
+            .collapsible(false)
+            .order(Order::Foreground)
+            .open(&mut open)
+            .show(ctx, |ui| {
+                render_floating_task_handle(ui, &task, actions);
+                weak_panel_hairline(ui, 10);
+                docked_sidebar_scroll_area()
+                    .auto_shrink([false, true])
+                    .show(ui, |ui| {
+                        render_task_body(state, ui, task_run_id, actions);
+                    });
+            });
+
+        if !open {
+            actions.push(AppAction::CloseTaskPanel(task_run_id));
+        }
+    }
+
+    for task_run_id in stale_tasks {
+        state.ui.layout.dock.remove_task(task_run_id);
+    }
+}
+
+fn default_floating_task_pos(ctx: &egui::Context, index: usize) -> egui::Pos2 {
+    let rect = ctx.content_rect();
+    let offset = (index.min(5) as f32) * 26.0;
+    rect.center() - egui::vec2(190.0 - offset, 280.0 - offset)
+}
+
+fn render_floating_task_handle(ui: &mut egui::Ui, task: &TaskRun, actions: &mut Vec<AppAction>) {
+    let pal = crate::frontend::theme::palette(ui);
+    ui.horizontal(|ui| {
+        let tab = DockTab::Task(task.id);
+        let id = Id::new(("floating_task_handle", task.id));
+        let info = TabInfo {
+            tab,
+            label: task.title.clone(),
+            closeable: false,
+            selected: true,
+        };
+        let dragged = drag_source(ui, id, DraggedTab { tab }, |ui| {
+            render_tab_inner(ui, id, &info, &pal)
+        });
+        let (chip, _) = dragged.inner;
+        if chip.clicked() {
+            actions.push(AppAction::ActivateTaskPanel(task.id));
+        }
+        chip.on_hover_text("Drag to dock this task panel");
+    });
 }
 
 /// The floating-preview half of a dock-tab drag, standing in for the painting

--- a/src/frontend/ui/mod.rs
+++ b/src/frontend/ui/mod.rs
@@ -33,7 +33,7 @@ mod settings_representation;
 mod style_panel;
 mod workspace;
 
-use dock::{drag_in_flight, render_dock_reveal_targets};
+use dock::{drag_in_flight, render_dock_reveal_targets, render_floating_task_windows};
 use notification::render_notification;
 use panel_bodies::render_status_bar;
 use style_panel::render_style_panel;
@@ -421,6 +421,8 @@ pub fn show_workbench(state: &mut AppState, ui: &mut egui::Ui, actions: &mut Vec
             }
         }
     }
+
+    render_floating_task_windows(state, &ctx, actions);
 
     // While a tab is being dragged, offer inset drop targets along the workspace
     // edges so a hidden/empty dock area can receive the tab (and reveal itself).

--- a/src/frontend/ui/settings_registry/accessors.rs
+++ b/src/frontend/ui/settings_registry/accessors.rs
@@ -7,7 +7,7 @@
 //! and the action that restores that default.
 
 use crate::{
-    backend::config::{AppConfig, ColorScheme, MonitorRefresh, ThemeMode},
+    backend::config::{AppConfig, ColorScheme, MonitorRefresh, TaskPanelPlacement, ThemeMode},
     frontend::{actions::AppAction, state::AppState},
 };
 
@@ -24,6 +24,15 @@ pub(crate) const SCHEME_OPTIONS: [&str; 5] = {
         schemes[2].label(),
         schemes[3].label(),
         schemes[4].label(),
+    ]
+};
+
+pub(crate) const TASK_PANEL_PLACEMENT_OPTIONS: [&str; 3] = {
+    let placements = TaskPanelPlacement::all();
+    [
+        placements[0].label(),
+        placements[1].label(),
+        placements[2].label(),
     ]
 };
 
@@ -47,6 +56,22 @@ pub(crate) fn scheme_read(state: &AppState) -> usize {
 
 pub(crate) fn scheme_change(index: usize) -> AppAction {
     AppAction::SetColorScheme(ColorScheme::all().get(index).copied().unwrap_or_default())
+}
+
+pub(crate) fn task_panel_placement_read(state: &AppState) -> usize {
+    TaskPanelPlacement::all()
+        .iter()
+        .position(|placement| *placement == state.config.default_task_panel_placement)
+        .unwrap_or(0)
+}
+
+pub(crate) fn task_panel_placement_change(index: usize) -> AppAction {
+    AppAction::SetDefaultTaskPanelPlacement(
+        TaskPanelPlacement::all()
+            .get(index)
+            .copied()
+            .unwrap_or_default(),
+    )
 }
 
 pub(crate) fn glass_read(state: &AppState) -> bool {
@@ -83,6 +108,14 @@ pub(crate) fn scheme_is_default(state: &AppState) -> bool {
 
 pub(crate) fn scheme_reset() -> AppAction {
     AppAction::SetColorScheme(AppConfig::default().color_scheme)
+}
+
+pub(crate) fn task_panel_placement_is_default(state: &AppState) -> bool {
+    state.config.default_task_panel_placement == AppConfig::default().default_task_panel_placement
+}
+
+pub(crate) fn task_panel_placement_reset() -> AppAction {
+    AppAction::SetDefaultTaskPanelPlacement(AppConfig::default().default_task_panel_placement)
 }
 
 pub(crate) fn glass_is_default(state: &AppState) -> bool {

--- a/src/frontend/ui/settings_registry/catalog.rs
+++ b/src/frontend/ui/settings_registry/catalog.rs
@@ -46,6 +46,27 @@ pub fn registry() -> Vec<SettingDescriptor> {
             reset: Some(scheme_reset),
             subgroup: None,
         },
+        SettingDescriptor {
+            id: "workbench.default_task_panel_location",
+            category: SettingCategory::General,
+            group: "Workbench",
+            title: "Default task panel location",
+            description: "Where newly opened task panels appear; open panels can still be dragged to another dock host.",
+            keywords: &[
+                "task", "panel", "floating", "window", "sidebar", "dock", "bottom", "default",
+                "location",
+            ],
+            control: Control::Choice {
+                read: task_panel_placement_read,
+                options: &TASK_PANEL_PLACEMENT_OPTIONS,
+                on_change: task_panel_placement_change,
+            },
+            enabled: None,
+            indent: false,
+            is_default: Some(task_panel_placement_is_default),
+            reset: Some(task_panel_placement_reset),
+            subgroup: None,
+        },
     ];
 
     // Frosted-glass settings only exist where the platform supports the material


### PR DESCRIPTION
## Summary

- Add a configurable default placement for newly opened task panels: floating window, right sidebar, or bottom panel.
- Make floating window the default so task builder panels no longer occupy the right sidebar by default.
- Keep task panels dockable by dragging the floating task handle into the existing right/bottom dock targets.
- Add the setting under General -> Workbench -> Default task panel location.
- Keep per-task panel placement session-only; only the default placement preference is persisted.

## Testing

- cargo pr-check