### PR TITLE
feat(jobs): add unified job control plane

### DIFF
--- a/compute-core/src/wire.rs
+++ b/compute-core/src/wire.rs
@@ -110,6 +110,7 @@ pub struct Running {
     updates: Receiver<JobUpdate>,
 }
 
+#[derive(Clone)]
 enum CancelHandle {
     /// The cooperative flag the in-process engine polls.
     Flag(Arc<AtomicBool>),
@@ -117,13 +118,33 @@ enum CancelHandle {
     Child(Arc<Mutex<Child>>),
 }
 
-impl Running {
-    pub fn updates(&self) -> &Receiver<JobUpdate> {
-        &self.updates
+#[derive(Clone)]
+pub struct JobCancelHandle {
+    inner: CancelHandle,
+}
+
+impl JobCancelHandle {
+    pub fn from_flag(flag: Arc<AtomicBool>) -> Self {
+        Self {
+            inner: CancelHandle::Flag(flag),
+        }
     }
 
     pub fn cancel(&self) {
-        match &self.cancel {
+        self.inner.cancel();
+    }
+
+    pub fn flag(&self) -> Option<Arc<AtomicBool>> {
+        match &self.inner {
+            CancelHandle::Flag(flag) => Some(Arc::clone(flag)),
+            CancelHandle::Child(_) => None,
+        }
+    }
+}
+
+impl CancelHandle {
+    fn cancel(&self) {
+        match self {
             CancelHandle::Flag(flag) => flag.store(true, Ordering::SeqCst),
             CancelHandle::Child(child) => {
                 if let Ok(mut child) = child.lock() {
@@ -132,16 +153,29 @@ impl Running {
             }
         }
     }
+}
+
+impl Running {
+    pub fn updates(&self) -> &Receiver<JobUpdate> {
+        &self.updates
+    }
+
+    pub fn cancel(&self) {
+        self.cancel.cancel();
+    }
+
+    pub fn cancel_handle(&self) -> JobCancelHandle {
+        JobCancelHandle {
+            inner: self.cancel.clone(),
+        }
+    }
 
     /// The cooperative cancel flag, when the job runs in-process. Lets a caller
     /// that already speaks the flag protocol (the engine-specific UI handles) share
     /// one cancel signal with the worker. `None` for a subprocess job, which
     /// cancels by kill instead.
     pub fn cancel_flag(&self) -> Option<Arc<AtomicBool>> {
-        match &self.cancel {
-            CancelHandle::Flag(flag) => Some(Arc::clone(flag)),
-            CancelHandle::Child(_) => None,
-        }
+        self.cancel_handle().flag()
     }
 }
 

--- a/docs/adding-a-feature.md
+++ b/docs/adding-a-feature.md
@@ -49,8 +49,8 @@ arms won't build); ⚠ marks the steps it does **not** catch.
 4. ⚠ **`frontend/task_executor.rs`** — a `TaskExecutor` + `run_<x>_panel`. The
    `every_task_controller_has_frontend_executor` test fails if you forget this.
 5. **`frontend/jobs.rs`** — `RunningXJob` + `XWorkerMessage` + `spawn_x_job`, a
-   `JobManager` slot + accessors, and a `cancel_x()` call in
-   `AppState::cancel_transient_jobs`.
+   `JobManager` slot + accessors, and a `JobControlId`/`LocalJobSlot` arm in the
+   unified job control plane used by `AppState::cancel_transient_jobs`.
 6. **`frontend/state/<x>_prompts.rs`** — the draft struct; `mod`/`pub use` in
    `state.rs`; a `pending_x` field on `UiState` (struct + init +
    `restore_edit_snapshot`).

--- a/src/backend/storage/jobs.rs
+++ b/src/backend/storage/jobs.rs
@@ -28,6 +28,7 @@ pub enum RemoteJobStatus {
     Done,
     Failed,
     Lost,
+    Cancelled,
 }
 
 impl RemoteJobStatus {
@@ -38,6 +39,7 @@ impl RemoteJobStatus {
             RemoteJobStatus::Done => "done",
             RemoteJobStatus::Failed => "failed",
             RemoteJobStatus::Lost => "lost",
+            RemoteJobStatus::Cancelled => "cancelled",
         }
     }
 
@@ -48,6 +50,7 @@ impl RemoteJobStatus {
             "done" => RemoteJobStatus::Done,
             "failed" => RemoteJobStatus::Failed,
             "lost" => RemoteJobStatus::Lost,
+            "cancelled" => RemoteJobStatus::Cancelled,
             _ => return None,
         })
     }
@@ -55,7 +58,10 @@ impl RemoteJobStatus {
     pub fn is_terminal(self) -> bool {
         matches!(
             self,
-            RemoteJobStatus::Done | RemoteJobStatus::Failed | RemoteJobStatus::Lost
+            RemoteJobStatus::Done
+                | RemoteJobStatus::Failed
+                | RemoteJobStatus::Lost
+                | RemoteJobStatus::Cancelled
         )
     }
 }
@@ -363,6 +369,7 @@ mod tests {
             RemoteJobStatus::Done,
             RemoteJobStatus::Failed,
             RemoteJobStatus::Lost,
+            RemoteJobStatus::Cancelled,
         ] {
             assert_eq!(RemoteJobStatus::from_token(status.token()), Some(status));
         }

--- a/src/backend/storage/tasks.rs
+++ b/src/backend/storage/tasks.rs
@@ -76,8 +76,10 @@ pub(crate) fn task_status_token(status: TaskStatus) -> &'static str {
         TaskStatus::Ready => "ready",
         TaskStatus::WaitingInput => "waiting_input",
         TaskStatus::Running => "running",
+        TaskStatus::Cancelling => "cancelling",
         TaskStatus::Completed => "completed",
         TaskStatus::Failed => "failed",
+        TaskStatus::Cancelled => "cancelled",
     }
 }
 
@@ -85,8 +87,10 @@ fn parse_task_status(token: &str) -> TaskStatus {
     match token {
         "waiting_input" => TaskStatus::WaitingInput,
         "running" => TaskStatus::Running,
+        "cancelling" => TaskStatus::Cancelling,
         "completed" => TaskStatus::Completed,
         "failed" => TaskStatus::Failed,
+        "cancelled" => TaskStatus::Cancelled,
         _ => TaskStatus::Ready,
     }
 }

--- a/src/backend/tasks.rs
+++ b/src/backend/tasks.rs
@@ -393,8 +393,10 @@ pub enum TaskStatus {
     Ready,
     WaitingInput,
     Running,
+    Cancelling,
     Completed,
     Failed,
+    Cancelled,
 }
 
 impl TaskStatus {
@@ -403,8 +405,10 @@ impl TaskStatus {
             Self::Ready => "Ready",
             Self::WaitingInput => "Waiting Input",
             Self::Running => "Running",
+            Self::Cancelling => "Cancelling",
             Self::Completed => "Completed",
             Self::Failed => "Failed",
+            Self::Cancelled => "Cancelled",
         }
     }
 }
@@ -521,7 +525,10 @@ impl TaskManager {
     pub fn mark_status(&mut self, task_run_id: u64, status: TaskStatus) {
         if let Some(task) = self.task_run_mut(task_run_id) {
             task.status = status;
-            if matches!(status, TaskStatus::Completed | TaskStatus::Failed) {
+            if matches!(
+                status,
+                TaskStatus::Completed | TaskStatus::Failed | TaskStatus::Cancelled
+            ) {
                 task.finished_at_ms = Some(now_unix_ms());
             }
         }
@@ -596,7 +603,7 @@ impl TaskManager {
     pub fn running_task_runs(&self) -> Vec<&TaskRun> {
         self.tasks
             .iter()
-            .filter(|task| task.status == TaskStatus::Running)
+            .filter(|task| matches!(task.status, TaskStatus::Running | TaskStatus::Cancelling))
             .collect()
     }
 }

--- a/src/frontend/actions.rs
+++ b/src/frontend/actions.rs
@@ -284,6 +284,8 @@ pub enum AppAction {
     /// Opt-in refresh of every detached remote job: probe liveness and retrieve
     /// any finished outcome over SSH (off the UI thread). Never automatic.
     RefreshRemoteJobs,
+    /// Request cancellation for a job through the unified control plane.
+    CancelControlledJob(crate::frontend::jobs::JobControlId),
     /// Remove the remote scratch directory of the remote job with this `run_uuid`
     /// and drop its registry row.
     RemoveRemoteScratch(String),
@@ -319,8 +321,6 @@ pub enum AppAction {
     SetApprovalMode(crate::backend::config::ApprovalMode),
     /// Drop the queued (type-ahead) assistant follow-up message at this index.
     RemoveQueuedAgentInput(usize),
-    /// Cancel the running background (qm/md/dock) agent job with this id.
-    CancelAgentJob(u64),
     /// Switch the active assistant provider + model and persist.
     SwitchProviderModel {
         provider: String,

--- a/src/frontend/agent/loop_driver.rs
+++ b/src/frontend/agent/loop_driver.rs
@@ -49,11 +49,15 @@ Tools:
 - `run_command` runs one SilicoLab `.sls` console command (the same line a user types \
 in the console). One command per call.
 - `inspect` returns a read-only view of the current workspace.
+- `list_jobs` returns local, assistant, and remote jobs from the unified job control plane.
+- `cancel_job` requests cancellation for a job id returned by `list_jobs`.
 - `save_script` saves a reusable `.sls` workflow of commands to the project.
 
 Working style:
 - Call `inspect` before acting when you are unsure of the current state — never guess \
 what is loaded.
+- For task control, use `list_jobs` and `cancel_job`. Do not guess or invent \
+cancel/stop/kill/abort console commands.
 - Take one concrete step at a time and keep your prose short; the user sees both your \
 text and the commands you run.
 - Commands are risk-classified (read-only, structure edit, file write, compute, destructive). \
@@ -125,6 +129,13 @@ fn describe_call(call: &crate::io::llm::types::ToolCall) -> String {
             .map(|command| command.to_string())
             .unwrap_or_else(|| "run_command".to_string()),
         "inspect" => "inspect".to_string(),
+        "list_jobs" => "list_jobs".to_string(),
+        "cancel_job" => call
+            .input
+            .get("id")
+            .and_then(|value| value.as_str())
+            .map(|id| format!("cancel_job {id}"))
+            .unwrap_or_else(|| "cancel_job".to_string()),
         "recommend_method" => call
             .input
             .get("task")

--- a/src/frontend/agent/loop_driver/heavy.rs
+++ b/src/frontend/agent/loop_driver/heavy.rs
@@ -244,25 +244,6 @@ pub fn poll_agent_jobs(state: &mut AppState, ctx: &egui::Context) {
     }
 }
 
-/// Cancel one background job by id (composer running-jobs ✕). Leaves a notice in
-/// the originating conversation; a no-op if the id is unknown.
-pub fn cancel_agent_job(state: &mut AppState, id: u64) {
-    let Some(pos) = state.jobs.agent_jobs.iter().position(|job| job.id == id) else {
-        return;
-    };
-    let tracked = state.jobs.agent_jobs.remove(pos);
-    tracked.job.cancel();
-    complete_agent_task_run(state, tracked.task_run_id, true);
-    if let Some(conversation) = state.ui.agent.conversation_mut(tracked.conversation) {
-        conversation
-            .transcript
-            .push(TranscriptEntry::Notice(format!(
-                "Cancelled background job #{id} ({}).",
-                tracked.label
-            )));
-    }
-}
-
 /// Cancel and remove every background job belonging to `conversation`, returning
 /// how many were stopped. Used when the user Stops the agent or deletes a chat, so
 /// detached workers and their orphaned results don't linger.
@@ -281,7 +262,7 @@ pub fn cancel_conversation_jobs(
         }
     });
     for task_run_id in &cancelled_runs {
-        complete_agent_task_run(state, *task_run_id, true);
+        crate::frontend::dispatcher::mark_task_status(state, *task_run_id, TaskStatus::Cancelled);
     }
     cancelled_runs.len()
 }
@@ -295,8 +276,23 @@ fn finish_agent_job(
     summary: String,
     is_error: bool,
 ) {
-    complete_agent_task_run(state, tracked.task_run_id, is_error);
-    let verb = if is_error { "failed" } else { "finished" };
+    let cancelled = matches!(&tracked.job, AgentHeavyJob::Qm(job) if job.cancel_requested);
+    if cancelled {
+        crate::frontend::dispatcher::mark_task_status(
+            state,
+            tracked.task_run_id,
+            TaskStatus::Cancelled,
+        );
+    } else {
+        complete_agent_task_run(state, tracked.task_run_id, is_error);
+    }
+    let verb = if cancelled {
+        "cancelled"
+    } else if is_error {
+        "failed"
+    } else {
+        "finished"
+    };
     let note = format!("Background job #{} ({}) {verb}.", tracked.id, tracked.label);
     if let Some(conversation) = state.ui.agent.conversation_mut(tracked.conversation) {
         conversation.transcript.push(TranscriptEntry::Notice(note));
@@ -331,7 +327,7 @@ fn drain_docking(state: &mut AppState, running: &RunningDockingJob) -> Option<(S
 
 fn drain_qm(
     state: &mut AppState,
-    running: &RunningQmJob,
+    running: &mut RunningQmJob,
     task_run_id: u64,
 ) -> Option<(String, bool)> {
     let mut completion = None;
@@ -339,8 +335,13 @@ fn drain_qm(
         match message {
             QmWorkerMessage::Progress { stage } => {
                 state.set_message(format!("QM: {stage}; running in background"));
+                running.latest_stage = Some(stage);
             }
             QmWorkerMessage::Finished(outcome) => {
+                if running.cancel_requested {
+                    completion = Some(("QM calculation cancelled".to_string(), true));
+                    continue;
+                }
                 let outcome = *outcome;
                 if let Some(optimized) = outcome.optimized_structure {
                     let save_path = default_structure_save_path(&optimized, None);
@@ -359,7 +360,11 @@ fn drain_qm(
                 completion = Some((outcome.summary, false));
             }
             QmWorkerMessage::Failed(error) => {
-                completion = Some((format!("QM calculation failed: {error}"), true));
+                completion = if running.cancel_requested {
+                    Some(("QM calculation cancelled".to_string(), true))
+                } else {
+                    Some((format!("QM calculation failed: {error}"), true))
+                };
             }
         }
     }

--- a/src/frontend/agent/loop_driver/tests/mod.rs
+++ b/src/frontend/agent/loop_driver/tests/mod.rs
@@ -27,8 +27,10 @@ fn fake_qm_job(
         label: "qm optimize".to_string(),
         task_run_id: 0,
         job: AgentHeavyJob::Qm(RunningQmJob {
-            cancel: Arc::new(AtomicBool::new(false)),
+            cancel: crate::wire::JobCancelHandle::from_flag(Arc::new(AtomicBool::new(false))),
             receiver: sender,
+            latest_stage: None,
+            cancel_requested: false,
         }),
     }
 }

--- a/src/frontend/agent/loop_driver/tool_batch.rs
+++ b/src/frontend/agent/loop_driver/tool_batch.rs
@@ -72,7 +72,10 @@ pub fn gated_pending(state: &AppState) -> Vec<ToolCall> {
 /// to see the workspace to propose a grounded plan.
 fn propose_in_plan_mode(state: &mut AppState, ctx: &egui::Context) {
     while let Some(call) = state.ui.agent.pending_calls.pop_front() {
-        if matches!(call.name.as_str(), "run_command" | "save_script") {
+        if matches!(
+            call.name.as_str(),
+            "run_command" | "save_script" | "cancel_job"
+        ) {
             push_tool_call_entry(state, &call);
             let summary = format!(
                 "Plan mode: not executed. Proposed {}.",

--- a/src/frontend/agent/mod.rs
+++ b/src/frontend/agent/mod.rs
@@ -12,8 +12,8 @@ pub mod tools;
 mod mock;
 
 pub use loop_driver::{
-    always_allow_command, always_allow_risk, approve_tool_call, cancel_agent, cancel_agent_job,
-    clear_stored_key, delete_assistant_conversation, fetch_models, gated_pending, impact_hint,
+    always_allow_command, always_allow_risk, approve_tool_call, cancel_agent, clear_stored_key,
+    delete_assistant_conversation, fetch_models, gated_pending, impact_hint,
     new_assistant_conversation, poll_agent_jobs, poll_agent_turn, poll_model_fetch,
     refresh_key_status, reject_tool_call, remove_queued_agent_input, rename_assistant_conversation,
     send_agent_message, set_approval_mode, set_assistant_api_key, set_assistant_base_url,

--- a/src/frontend/agent/tools.rs
+++ b/src/frontend/agent/tools.rs
@@ -34,8 +34,9 @@ pub fn tool_defs() -> Vec<ToolDef> {
                 command line a user types in the console. Commands are risk-classified \
                 (read-only, structure edit, file write, compute, destructive); whether one \
                 needs the user's approval depends on their approval mode, and destructive \
-                commands (`delete`, running a script) always ask. Call the right command \
-                regardless and explain briefly."
+                commands (`delete`, running a script) always ask. For task control, use \
+                `list_jobs` and `cancel_job`; do not guess cancel/stop/kill/abort console \
+                commands. Call the right command regardless and explain briefly."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
@@ -54,8 +55,10 @@ pub fn tool_defs() -> Vec<ToolDef> {
             description: "Read-only look at the current workspace: the active entry, its \
                 atom/bond/chain counts, composition and bond geometry, MD/QM provenance and \
                 trajectory state, the list of open entries, available compute engines, and the \
-                latest status. Call this before acting so you know the current state. Takes no \
-                required arguments."
+                latest status, including a short running-jobs summary. Call this before acting so \
+                you know the current state. For detailed task control, use `list_jobs` and \
+                `cancel_job`; do not guess cancel/stop/kill/abort commands. Takes no required \
+                arguments."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
@@ -65,6 +68,35 @@ pub fn tool_defs() -> Vec<ToolDef> {
                         "description": "Optional free-text focus (currently advisory)."
                     }
                 },
+                "additionalProperties": false
+            }),
+        },
+        ToolDef {
+            name: "list_jobs".to_string(),
+            description: "Read-only task-control view. Lists local, assistant, and remote jobs \
+                from the unified job control plane with job id, kind, label, status, stage, \
+                backend, and cancel capability. Use this before cancelling a job."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        },
+        ToolDef {
+            name: "cancel_job".to_string(),
+            description: "Request cancellation for a job id returned by `list_jobs`, using the \
+                unified job control plane. Do not invent stop/kill/abort console commands."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Job id from list_jobs, e.g. local:qm, agent:7, or remote:<uuid>."
+                    }
+                },
+                "required": ["id"],
                 "additionalProperties": false
             }),
         },
@@ -129,6 +161,7 @@ pub struct ToolOutcome {
 pub fn risk_of_call(call: &ToolCall) -> RiskLevel {
     match call.name.as_str() {
         "save_script" => RiskLevel::FileWrite,
+        "cancel_job" => RiskLevel::Destructive,
         "run_command" => {
             let command = call
                 .input
@@ -198,6 +231,17 @@ pub fn execute_tool(state: &mut AppState, call: &ToolCall) -> ToolOutcome {
                 is_error: false,
             }
         }
+        "list_jobs" => ToolOutcome {
+            content: list_jobs_tool(state),
+            is_error: false,
+        },
+        "cancel_job" => match call.input.get("id").and_then(Value::as_str) {
+            Some(id) => cancel_job_tool(state, id),
+            None => ToolOutcome {
+                content: "cancel_job requires an `id` string from list_jobs.".to_string(),
+                is_error: true,
+            },
+        },
         "recommend_method" => {
             let task = call
                 .input
@@ -214,6 +258,50 @@ pub fn execute_tool(state: &mut AppState, call: &ToolCall) -> ToolOutcome {
             content: format!("Unknown tool `{other}`."),
             is_error: true,
         },
+    }
+}
+
+fn list_jobs_tool(state: &AppState) -> String {
+    let jobs = crate::frontend::jobs::list_controlled_jobs(state);
+    if jobs.is_empty() {
+        return "[]".to_string();
+    }
+    let rows = jobs
+        .iter()
+        .map(|job| {
+            json!({
+                "id": job.id.token(),
+                "kind": job.kind.label(),
+                "label": job.label.clone(),
+                "status": crate::frontend::jobs::job_status_display(job),
+                "stage": job.stage.clone(),
+                "backend": job.backend.label(),
+                "cancel_capability": job.cancel.label(),
+                "can_cancel": job.cancel.can_cancel(),
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::to_string_pretty(&rows).unwrap_or_else(|_| "[]".to_string())
+}
+
+fn cancel_job_tool(state: &mut AppState, id: &str) -> ToolOutcome {
+    match crate::frontend::jobs::cancel_job_by_token(state, id) {
+        Ok(message) => {
+            state.output_log.push(format!("agent cancel_job> {id}"));
+            state.output_log.push(message.clone());
+            ToolOutcome {
+                content: message,
+                is_error: false,
+            }
+        }
+        Err(error) => {
+            let message = format!("cancel_job failed: {error}");
+            state.output_log.push(message.clone());
+            ToolOutcome {
+                content: message,
+                is_error: true,
+            }
+        }
     }
 }
 
@@ -422,6 +510,34 @@ pub fn inspect(state: &AppState, _query: Option<&str>) -> String {
         }
     );
 
+    let running_jobs = crate::frontend::jobs::list_controlled_jobs(state)
+        .into_iter()
+        .filter(|job| job.status.is_running())
+        .collect::<Vec<_>>();
+    if running_jobs.is_empty() {
+        let _ = writeln!(out, "running jobs: none");
+    } else {
+        let summary = running_jobs
+            .iter()
+            .take(5)
+            .map(|job| {
+                format!(
+                    "{} {} ({})",
+                    job.id.token(),
+                    job.label,
+                    job.stage.as_deref().unwrap_or(job.status.label())
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        let suffix = if running_jobs.len() > 5 {
+            format!("; +{} more", running_jobs.len() - 5)
+        } else {
+            String::new()
+        };
+        let _ = writeln!(out, "running jobs: {summary}{suffix}");
+    }
+
     let _ = writeln!(out, "status: {}", state.message);
     out
 }
@@ -444,247 +560,4 @@ fn element_histogram(structure: &crate::domain::Structure) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::io::llm::types::ToolCall;
-
-    fn call(command: &str) -> ToolCall {
-        ToolCall {
-            id: "t".to_string(),
-            name: "run_command".to_string(),
-            input: json!({ "command": command }),
-        }
-    }
-
-    fn save_script_call() -> ToolCall {
-        ToolCall {
-            id: "s".to_string(),
-            name: "save_script".to_string(),
-            input: json!({ "filename": "wf", "commands": ["open x.pdb"] }),
-        }
-    }
-
-    /// Gate with the default mode (AutoSafe) and an empty allow-set.
-    fn gated(command: &str) -> bool {
-        needs_confirmation(
-            &call(command),
-            ApprovalMode::AutoSafe,
-            &HashSet::new(),
-            &HashSet::new(),
-        )
-    }
-
-    #[test]
-    fn risk_classification_matches_the_grammar() {
-        assert_eq!(
-            risk_of_call(&call("view background white")),
-            RiskLevel::ReadOnly
-        );
-        assert_eq!(
-            risk_of_call(&call("color chain A red")),
-            RiskLevel::ReadOnly
-        );
-        assert_eq!(risk_of_call(&call("open 1abc.pdb")), RiskLevel::ReadOnly);
-        assert_eq!(risk_of_call(&call("hydrogen add")), RiskLevel::ReadOnly);
-        assert_eq!(
-            risk_of_call(&call("qm recommend thermochemistry")),
-            RiskLevel::ReadOnly
-        );
-        assert_eq!(
-            risk_of_call(&call("phosphorylate --protein active --at A:1")),
-            RiskLevel::Mutating
-        );
-        assert_eq!(
-            risk_of_call(&call("save image out.png")),
-            RiskLevel::FileWrite
-        );
-        assert_eq!(risk_of_call(&save_script_call()), RiskLevel::FileWrite);
-        assert_eq!(risk_of_call(&call("md build")), RiskLevel::Expensive);
-        assert_eq!(
-            risk_of_call(&call("qm energy --method r2scan-3c")),
-            RiskLevel::Expensive
-        );
-        assert_eq!(
-            risk_of_call(&call("dock --receptor active --ligand 2")),
-            RiskLevel::Expensive
-        );
-        assert_eq!(
-            risk_of_call(&call("score --receptor active")),
-            RiskLevel::Expensive
-        );
-        assert_eq!(risk_of_call(&call("run setup.sls")), RiskLevel::Destructive);
-        // A bare `*.sls` token runs as a script via the console's pre-clap
-        // shortcut, so it must classify Destructive like an explicit `run`.
-        assert_eq!(risk_of_call(&call("setup.sls")), RiskLevel::Destructive);
-        assert_eq!(
-            risk_of_call(&call("delete chain A")),
-            RiskLevel::Destructive
-        );
-    }
-
-    #[test]
-    fn structure_editing_commands_are_never_read_only() {
-        // The silent-bypass bug: PTM / structure-editing verbs must not auto-run
-        // as if read-only. Each must be Mutating; `delete` Destructive.
-        for command in [
-            "phosphorylate --protein active --at A:84",
-            "acetylate --protein active --at A:120",
-            "methylate --protein active --at A:9",
-            "lipidate --protein active --at A:3",
-            "ubiquitinate --protein active --at A:48",
-            "glycosylate --protein active",
-            "glycan GlcNAc",
-        ] {
-            assert_eq!(
-                risk_of_call(&call(command)),
-                RiskLevel::Mutating,
-                "{command}"
-            );
-            assert!(
-                gated_in(command, ApprovalMode::Manual),
-                "{command} must gate in Manual"
-            );
-        }
-        assert_eq!(
-            risk_of_call(&call("save image out.png")),
-            RiskLevel::FileWrite
-        );
-        assert!(gated_in("save image out.png", ApprovalMode::Manual));
-        assert_eq!(
-            risk_of_call(&call("delete chain A")),
-            RiskLevel::Destructive
-        );
-    }
-
-    fn gated_in(command: &str, mode: ApprovalMode) -> bool {
-        needs_confirmation(&call(command), mode, &HashSet::new(), &HashSet::new())
-    }
-
-    #[test]
-    fn autosafe_runs_edits_but_gates_writes_compute_and_destructive() {
-        assert!(!gated("view background white"));
-        assert!(!gated("phosphorylate --protein active --at A:1"));
-        assert!(gated("save image out.png"));
-        assert!(gated("qm energy"));
-        assert!(gated("delete chain A"));
-        assert!(needs_confirmation(
-            &save_script_call(),
-            ApprovalMode::AutoSafe,
-            &HashSet::new(),
-            &HashSet::new(),
-        ));
-    }
-
-    #[test]
-    fn manual_gates_everything_but_read_only() {
-        assert!(!gated_in("view background white", ApprovalMode::Manual));
-        assert!(gated_in("save image out.png", ApprovalMode::Manual));
-        assert!(gated_in("qm energy", ApprovalMode::Manual));
-        assert!(gated_in("delete chain A", ApprovalMode::Manual));
-    }
-
-    #[test]
-    fn auto_runs_everything_except_destructive() {
-        assert!(!gated_in("qm energy", ApprovalMode::Auto));
-        assert!(!gated_in("save image out.png", ApprovalMode::Auto));
-        assert!(gated_in("delete chain A", ApprovalMode::Auto));
-    }
-
-    #[test]
-    fn destructive_always_confirms_and_allow_set_cannot_bypass_it() {
-        let mut verbs = HashSet::new();
-        verbs.insert("delete".to_string());
-        let mut risks = HashSet::new();
-        risks.insert(RiskLevel::Destructive);
-        for mode in ApprovalMode::all() {
-            if mode == ApprovalMode::Plan {
-                continue; // Plan never executes; the gate is not consulted
-            }
-            for command in ["delete chain A", "run setup.sls", "setup.sls"] {
-                assert!(
-                    needs_confirmation(&call(command), mode, &verbs, &risks),
-                    "{command} must confirm in {mode:?} even with an allow-set"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn allow_set_suppresses_gating_for_verb_and_risk() {
-        // Allowing the `qm` verb auto-runs qm in AutoSafe.
-        let mut verbs = HashSet::new();
-        verbs.insert("qm".to_string());
-        assert!(!needs_confirmation(
-            &call("qm energy"),
-            ApprovalMode::AutoSafe,
-            &verbs,
-            &HashSet::new()
-        ));
-        // Allowing the whole Expensive level auto-runs dock too.
-        let mut risks = HashSet::new();
-        risks.insert(RiskLevel::Expensive);
-        assert!(!needs_confirmation(
-            &call("dock --receptor active"),
-            ApprovalMode::AutoSafe,
-            &HashSet::new(),
-            &risks,
-        ));
-    }
-
-    #[test]
-    fn unparseable_command_is_read_only_so_it_runs_and_self_reports_the_error() {
-        // An invalid command reaches no effect (it errors before dispatch), so
-        // gating it would only nag the user; let it run and fail instead.
-        assert_eq!(risk_of_call(&call("inspect")), RiskLevel::ReadOnly);
-        assert!(!gated("frobnicate the molecule"));
-    }
-
-    #[test]
-    fn perception_tools_are_never_gated() {
-        let inspect_call = ToolCall {
-            id: "t".to_string(),
-            name: "inspect".to_string(),
-            input: json!({}),
-        };
-        let recommend = ToolCall {
-            id: "t".to_string(),
-            name: "recommend_method".to_string(),
-            input: json!({ "task": "thermochemistry" }),
-        };
-        for c in [&inspect_call, &recommend] {
-            assert_eq!(risk_of_call(c), RiskLevel::ReadOnly);
-            assert!(!needs_confirmation(
-                c,
-                ApprovalMode::Manual,
-                &HashSet::new(),
-                &HashSet::new()
-            ));
-        }
-    }
-
-    #[test]
-    fn save_script_writes_and_rejects_paths() {
-        let mut state = AppState::scratch(Default::default(), Vec::new());
-        // A bare name writes a .sls file.
-        let ok = save_script_tool(
-            &mut state,
-            &json!({ "filename": "demo", "commands": ["fetch 4hhb", "color hetero"] }),
-        );
-        assert!(!ok.is_error, "expected success: {}", ok.content);
-        assert!(ok.content.contains("demo.sls"));
-        // A path with directories is rejected.
-        let bad = save_script_tool(
-            &mut state,
-            &json!({ "filename": "../evil", "commands": [] }),
-        );
-        assert!(bad.is_error);
-    }
-
-    #[test]
-    fn clamp_truncates_large_output() {
-        let big = "x".repeat(MAX_RESULT_CHARS + 50);
-        let clamped = clamp_result(&big);
-        assert!(clamped.ends_with("… (truncated)"));
-        assert!(clamped.chars().count() < big.chars().count());
-    }
-}
+mod tests;

--- a/src/frontend/agent/tools/tests.rs
+++ b/src/frontend/agent/tools/tests.rs
@@ -1,0 +1,304 @@
+use super::*;
+use crate::io::llm::types::ToolCall;
+
+fn call(command: &str) -> ToolCall {
+    ToolCall {
+        id: "t".to_string(),
+        name: "run_command".to_string(),
+        input: json!({ "command": command }),
+    }
+}
+
+fn save_script_call() -> ToolCall {
+    ToolCall {
+        id: "s".to_string(),
+        name: "save_script".to_string(),
+        input: json!({ "filename": "wf", "commands": ["open x.pdb"] }),
+    }
+}
+
+fn gated(command: &str) -> bool {
+    needs_confirmation(
+        &call(command),
+        ApprovalMode::AutoSafe,
+        &HashSet::new(),
+        &HashSet::new(),
+    )
+}
+
+#[test]
+fn risk_classification_matches_the_grammar() {
+    assert_eq!(
+        risk_of_call(&call("view background white")),
+        RiskLevel::ReadOnly
+    );
+    assert_eq!(
+        risk_of_call(&call("color chain A red")),
+        RiskLevel::ReadOnly
+    );
+    assert_eq!(risk_of_call(&call("open 1abc.pdb")), RiskLevel::ReadOnly);
+    assert_eq!(risk_of_call(&call("hydrogen add")), RiskLevel::ReadOnly);
+    assert_eq!(
+        risk_of_call(&call("qm recommend thermochemistry")),
+        RiskLevel::ReadOnly
+    );
+    assert_eq!(
+        risk_of_call(&call("phosphorylate --protein active --at A:1")),
+        RiskLevel::Mutating
+    );
+    assert_eq!(
+        risk_of_call(&call("save image out.png")),
+        RiskLevel::FileWrite
+    );
+    assert_eq!(risk_of_call(&save_script_call()), RiskLevel::FileWrite);
+    assert_eq!(risk_of_call(&call("md build")), RiskLevel::Expensive);
+    assert_eq!(
+        risk_of_call(&call("qm energy --method r2scan-3c")),
+        RiskLevel::Expensive
+    );
+    assert_eq!(
+        risk_of_call(&call("dock --receptor active --ligand 2")),
+        RiskLevel::Expensive
+    );
+    assert_eq!(
+        risk_of_call(&call("score --receptor active")),
+        RiskLevel::Expensive
+    );
+    assert_eq!(risk_of_call(&call("run setup.sls")), RiskLevel::Destructive);
+    assert_eq!(risk_of_call(&call("setup.sls")), RiskLevel::Destructive);
+    assert_eq!(
+        risk_of_call(&call("delete chain A")),
+        RiskLevel::Destructive
+    );
+}
+
+#[test]
+fn structure_editing_commands_are_never_read_only() {
+    for command in [
+        "phosphorylate --protein active --at A:84",
+        "acetylate --protein active --at A:120",
+        "methylate --protein active --at A:9",
+        "lipidate --protein active --at A:3",
+        "ubiquitinate --protein active --at A:48",
+        "glycosylate --protein active",
+        "glycan GlcNAc",
+    ] {
+        assert_eq!(
+            risk_of_call(&call(command)),
+            RiskLevel::Mutating,
+            "{command}"
+        );
+        assert!(
+            gated_in(command, ApprovalMode::Manual),
+            "{command} must gate in Manual"
+        );
+    }
+    assert_eq!(
+        risk_of_call(&call("save image out.png")),
+        RiskLevel::FileWrite
+    );
+    assert!(gated_in("save image out.png", ApprovalMode::Manual));
+    assert_eq!(
+        risk_of_call(&call("delete chain A")),
+        RiskLevel::Destructive
+    );
+}
+
+fn gated_in(command: &str, mode: ApprovalMode) -> bool {
+    needs_confirmation(&call(command), mode, &HashSet::new(), &HashSet::new())
+}
+
+#[test]
+fn autosafe_runs_edits_but_gates_writes_compute_and_destructive() {
+    assert!(!gated("view background white"));
+    assert!(!gated("phosphorylate --protein active --at A:1"));
+    assert!(gated("save image out.png"));
+    assert!(gated("qm energy"));
+    assert!(gated("delete chain A"));
+    assert!(needs_confirmation(
+        &save_script_call(),
+        ApprovalMode::AutoSafe,
+        &HashSet::new(),
+        &HashSet::new(),
+    ));
+}
+
+#[test]
+fn manual_gates_everything_but_read_only() {
+    assert!(!gated_in("view background white", ApprovalMode::Manual));
+    assert!(gated_in("save image out.png", ApprovalMode::Manual));
+    assert!(gated_in("qm energy", ApprovalMode::Manual));
+    assert!(gated_in("delete chain A", ApprovalMode::Manual));
+}
+
+#[test]
+fn auto_runs_everything_except_destructive() {
+    assert!(!gated_in("qm energy", ApprovalMode::Auto));
+    assert!(!gated_in("save image out.png", ApprovalMode::Auto));
+    assert!(gated_in("delete chain A", ApprovalMode::Auto));
+}
+
+#[test]
+fn destructive_always_confirms_and_allow_set_cannot_bypass_it() {
+    let mut verbs = HashSet::new();
+    verbs.insert("delete".to_string());
+    let mut risks = HashSet::new();
+    risks.insert(RiskLevel::Destructive);
+    for mode in ApprovalMode::all() {
+        if mode == ApprovalMode::Plan {
+            continue;
+        }
+        for command in ["delete chain A", "run setup.sls", "setup.sls"] {
+            assert!(
+                needs_confirmation(&call(command), mode, &verbs, &risks),
+                "{command} must confirm in {mode:?} even with an allow-set"
+            );
+        }
+    }
+}
+
+#[test]
+fn allow_set_suppresses_gating_for_verb_and_risk() {
+    let mut verbs = HashSet::new();
+    verbs.insert("qm".to_string());
+    assert!(!needs_confirmation(
+        &call("qm energy"),
+        ApprovalMode::AutoSafe,
+        &verbs,
+        &HashSet::new()
+    ));
+
+    let mut risks = HashSet::new();
+    risks.insert(RiskLevel::Expensive);
+    assert!(!needs_confirmation(
+        &call("dock --receptor active"),
+        ApprovalMode::AutoSafe,
+        &HashSet::new(),
+        &risks,
+    ));
+}
+
+#[test]
+fn unparseable_command_is_read_only_so_it_runs_and_self_reports_the_error() {
+    assert_eq!(risk_of_call(&call("inspect")), RiskLevel::ReadOnly);
+    assert!(!gated("frobnicate the molecule"));
+}
+
+#[test]
+fn perception_tools_are_never_gated() {
+    let inspect_call = ToolCall {
+        id: "t".to_string(),
+        name: "inspect".to_string(),
+        input: json!({}),
+    };
+    let recommend = ToolCall {
+        id: "t".to_string(),
+        name: "recommend_method".to_string(),
+        input: json!({ "task": "thermochemistry" }),
+    };
+    for c in [&inspect_call, &recommend] {
+        assert_eq!(risk_of_call(c), RiskLevel::ReadOnly);
+        assert!(!needs_confirmation(
+            c,
+            ApprovalMode::Manual,
+            &HashSet::new(),
+            &HashSet::new()
+        ));
+    }
+}
+
+#[test]
+fn save_script_writes_and_rejects_paths() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    let ok = save_script_tool(
+        &mut state,
+        &json!({ "filename": "demo", "commands": ["fetch 4hhb", "color hetero"] }),
+    );
+    assert!(!ok.is_error, "expected success: {}", ok.content);
+    assert!(ok.content.contains("demo.sls"));
+
+    let bad = save_script_tool(
+        &mut state,
+        &json!({ "filename": "../evil", "commands": [] }),
+    );
+    assert!(bad.is_error);
+}
+
+#[test]
+fn list_jobs_and_cancel_job_control_assistant_qm_job() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    let controller = crate::backend::tasks::task_controller_by_id("qm-optimize")
+        .copied()
+        .unwrap();
+    let task_run_id = state.tasks.create_task_run(controller);
+    state
+        .tasks
+        .mark_status(task_run_id, crate::backend::tasks::TaskStatus::Running);
+    let (_tx, rx) = std::sync::mpsc::channel();
+    let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    state
+        .jobs
+        .agent_jobs
+        .push(crate::frontend::jobs::TrackedAgentJob {
+            id: 7,
+            conversation: state.ui.agent.active_conversation,
+            label: "qm optimize".to_string(),
+            task_run_id,
+            job: crate::frontend::jobs::AgentHeavyJob::Qm(crate::frontend::jobs::RunningQmJob {
+                cancel: crate::wire::JobCancelHandle::from_flag(std::sync::Arc::clone(&cancel)),
+                receiver: rx,
+                latest_stage: Some("SCF".to_string()),
+                cancel_requested: false,
+            }),
+        });
+
+    let list = execute_tool(
+        &mut state,
+        &ToolCall {
+            id: "list".into(),
+            name: "list_jobs".into(),
+            input: json!({}),
+        },
+    );
+    assert!(!list.is_error, "{}", list.content);
+    assert!(
+        list.content.contains("\"id\": \"agent:7\""),
+        "{}",
+        list.content
+    );
+    assert!(
+        list.content.contains("\"label\": \"qm optimize\""),
+        "{}",
+        list.content
+    );
+
+    let cancel_out = execute_tool(
+        &mut state,
+        &ToolCall {
+            id: "cancel".into(),
+            name: "cancel_job".into(),
+            input: json!({ "id": "agent:7" }),
+        },
+    );
+
+    assert!(!cancel_out.is_error, "{}", cancel_out.content);
+    assert!(
+        cancel_out.content.contains("Cancel requested"),
+        "{}",
+        cancel_out.content
+    );
+    assert!(cancel.load(std::sync::atomic::Ordering::Relaxed));
+    assert_eq!(state.jobs.agent_jobs.len(), 1);
+    assert_eq!(
+        state.tasks.task_run(task_run_id).unwrap().status,
+        crate::backend::tasks::TaskStatus::Cancelling
+    );
+}
+
+#[test]
+fn clamp_truncates_large_output() {
+    let big = "x".repeat(MAX_RESULT_CHARS + 50);
+    let clamped = clamp_result(&big);
+    assert!(clamped.ends_with("(truncated)"));
+    assert!(clamped.chars().count() < big.chars().count());
+}

--- a/src/frontend/console.rs
+++ b/src/frontend/console.rs
@@ -283,12 +283,21 @@ pub fn command_catalog() -> String {
         "                              (--product <entry> [--neb] | --scan-bond i,j --scan-from <v> --scan-to <v>)",
         "  qm recommend <task>         Print the recommended QM level of theory (general|barriers|nci|",
         "                              thermochemistry). Read-only, not gated — consult it before choosing.",
+        "  qm status                   Convenience view of running QM jobs.",
+        "  qm cancel                   Cancel the only running QM job; if multiple match, use jobs cancel <id>.",
         "  qm periodic [--functional pade] [--basis SZV-GTH] [--kmesh 2x2x2] [--cutoff 280] (needs a cell)",
         "  dock --receptor <entry> --ligand <entry> [--center x,y,z] [--size x,y,z] [--exhaustiveness 8] [--modes 9] [--seed 0]",
         "  score --receptor <entry> --ligand <entry> [--center x,y,z] [--size x,y,z]   (single-point pose score)",
         "",
+        "Task control:",
+        "  jobs                        List running and tracked local, assistant, and remote jobs.",
+        "  jobs status                 Same as `jobs`.",
+        "  jobs cancel <id>            Request cancellation through the unified job control plane.",
+        "",
         "Tips: render commands target the active entry unless given `--global`. Call `inspect` \
-         first when you are unsure what is loaded. Commands are risk-classified; whether one \
+         first when you are unsure what is loaded. Assistant task control should use \
+         `list_jobs` and `cancel_job`, not guessed cancel/stop/kill/abort console commands. \
+         Commands are risk-classified; whether one \
          needs the user's approval depends on their approval mode (Settings ▸ Assistant), and \
          destructive commands (`delete`, running a script) always ask.",
     ]

--- a/src/frontend/console/grammar.rs
+++ b/src/frontend/console/grammar.rs
@@ -157,6 +157,13 @@ pub(crate) enum Command {
         args: Vec<String>,
     },
 
+    /// List or cancel background jobs.
+    #[command(visible_alias = "job")]
+    Jobs {
+        #[command(subcommand)]
+        action: Option<JobsAction>,
+    },
+
     /// Dock a ligand into a receptor (Vina).
     Dock(DockArgs),
 
@@ -424,6 +431,14 @@ pub(crate) enum SaveTarget {
     View { path: PathBuf },
 }
 
+#[derive(Debug, Subcommand)]
+pub(crate) enum JobsAction {
+    /// List running and tracked jobs.
+    Status,
+    /// Request cancellation for a job id shown by `jobs status`.
+    Cancel { id: String },
+}
+
 /// How consequential a command is — the input to the assistant's approval gate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum RiskLevel {
@@ -472,16 +487,17 @@ impl Command {
             | Command::Show(_)
             | Command::Representation(_)
             | Command::Hydrogen { .. }
+            | Command::Jobs {
+                action: None | Some(JobsAction::Status),
+            }
             | Command::Help => ReadOnly,
             // `qm recommend` only prints the level-of-theory table (read-only);
             // every other `qm` sub-verb launches a calculation.
-            Command::Qm { args } => {
-                if args.first().map(String::as_str) == Some("recommend") {
-                    ReadOnly
-                } else {
-                    Expensive
-                }
-            }
+            Command::Qm { args } => match args.first().map(String::as_str) {
+                Some("recommend" | "status") => ReadOnly,
+                Some("cancel") => Destructive,
+                _ => Expensive,
+            },
             Command::Glycan(_)
             | Command::Glycosylate(_)
             | Command::Phosphorylate(_)
@@ -496,7 +512,11 @@ impl Command {
             | Command::Score(_) => Expensive,
             // `Source` runs a script's lines straight through the console with no
             // per-line gate, so it can `delete` — it must clear the floor itself.
-            Command::Delete { .. } | Command::Source { .. } => Destructive,
+            Command::Delete { .. }
+            | Command::Source { .. }
+            | Command::Jobs {
+                action: Some(JobsAction::Cancel { .. }),
+            } => Destructive,
         }
     }
 
@@ -534,6 +554,10 @@ impl Command {
             Command::Md { args } => md_commands::md_command(state, &args),
             Command::Disorder { args } => disorder_commands::disorder_command(state, &args),
             Command::Qm { args } => qm_commands::qm_command(state, &args),
+            Command::Jobs { action } => match action.unwrap_or(JobsAction::Status) {
+                JobsAction::Status => Ok(crate::frontend::jobs::format_jobs_status(state)),
+                JobsAction::Cancel { id } => crate::frontend::jobs::cancel_job_by_token(state, &id),
+            },
             Command::Dock(args) => docking_commands::dock_command(state, args),
             Command::Score(args) => docking_commands::score_command(state, args),
             Command::Glycan(args) => glycan_commands::glycan_command(state, args),

--- a/src/frontend/dispatcher/builders.rs
+++ b/src/frontend/dispatcher/builders.rs
@@ -221,6 +221,14 @@ pub(crate) fn start_pending_optimization(state: &mut AppState) {
 
 pub(crate) fn cancel_pending_optimization_request(state: &mut AppState) {
     bind_active_panel_task(state, TaskPanelKind::OptimizationPrompt);
+    if state.jobs.optimization_running() {
+        let _ = crate::frontend::jobs::cancel_controlled_job(
+            state,
+            &crate::frontend::jobs::JobControlId::Local(
+                crate::frontend::jobs::LocalJobSlot::Optimizer,
+            ),
+        );
+    }
     state.ui.pending_optimization = None;
     state.set_message("forcefield optimization canceled".to_string());
     complete_active_task(state, TaskKind::OptimizeGeometry, TaskStatus::Failed);

--- a/src/frontend/dispatcher/builders/qm.rs
+++ b/src/frontend/dispatcher/builders/qm.rs
@@ -187,6 +187,16 @@ fn start_remote_qm(
 
 pub(crate) fn cancel_pending_qm_request(state: &mut AppState) {
     bind_active_panel_task(state, TaskPanelKind::QmPrompt);
+    if state.jobs.qm_running() {
+        let _ = crate::frontend::jobs::cancel_controlled_job(
+            state,
+            &crate::frontend::jobs::JobControlId::Local(crate::frontend::jobs::LocalJobSlot::Qm),
+        );
+        state.ui.pending_qm = None;
+        state.set_message("QM calculation stopping".to_string());
+        close_active_task_panel(state);
+        return;
+    }
     state.ui.pending_qm = None;
     state.set_message("QM calculation canceled".to_string());
     complete_active_qm_task(state, TaskStatus::Failed);

--- a/src/frontend/dispatcher/disorder.rs
+++ b/src/frontend/dispatcher/disorder.rs
@@ -72,7 +72,12 @@ pub(crate) fn start_pending_disorder(state: &mut AppState) {
 pub(crate) fn cancel_pending_disorder_request(state: &mut AppState) {
     bind_active_panel_task(state, TaskPanelKind::DisorderedSystemPrompt);
     if state.jobs.disorder_running() {
-        state.jobs.cancel_disorder();
+        let _ = crate::frontend::jobs::cancel_controlled_job(
+            state,
+            &crate::frontend::jobs::JobControlId::Local(
+                crate::frontend::jobs::LocalJobSlot::Disorder,
+            ),
+        );
     }
     state.ui.pending_disorder = None;
     state.set_message("Packing canceled".to_string());

--- a/src/frontend/dispatcher/docking.rs
+++ b/src/frontend/dispatcher/docking.rs
@@ -96,6 +96,14 @@ fn entry_structure(state: &mut AppState, entry_id: u64) -> Option<Structure> {
 
 pub(crate) fn cancel_pending_docking_request(state: &mut AppState) {
     bind_active_panel_task(state, TaskPanelKind::DockingPrompt);
+    if state.jobs.docking_running() {
+        let _ = crate::frontend::jobs::cancel_controlled_job(
+            state,
+            &crate::frontend::jobs::JobControlId::Local(
+                crate::frontend::jobs::LocalJobSlot::Docking,
+            ),
+        );
+    }
     state.ui.pending_docking = None;
     state.set_message("docking canceled".to_string());
     complete_active_task(state, TaskKind::RunDocking, TaskStatus::Failed);

--- a/src/frontend/dispatcher/jobs/compute.rs
+++ b/src/frontend/dispatcher/jobs/compute.rs
@@ -213,21 +213,19 @@ pub(crate) fn poll_optimization_job(state: &mut AppState, ctx: &egui::Context) {
 }
 
 pub(crate) fn poll_qm_job(state: &mut AppState, ctx: &egui::Context) {
-    let Some(running) = state.jobs.take_qm() else {
+    let Some(mut running) = state.jobs.take_qm() else {
         return;
     };
     let task_run_id = state.active_task_run;
     let fingerprint_before = state.entries_fingerprint();
 
     if ctx.input(|input| input.key_pressed(egui::Key::Escape)) {
-        running
-            .cancel
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-        // hartree runs the calculation in one opaque call, so a cancel only takes
-        // effect at the next stage boundary; the in-flight step runs to the end.
-        state.set_message(
-            "QM calculation stopping (the current step runs to completion)".to_string(),
-        );
+        running.cancel_requested = true;
+        running.cancel.cancel();
+        if let Some(task_run_id) = task_run_id {
+            mark_task_status(state, task_run_id, TaskStatus::Cancelling);
+        }
+        state.set_message("QM calculation stopping".to_string());
     }
 
     let mut finished = false;
@@ -236,8 +234,15 @@ pub(crate) fn poll_qm_job(state: &mut AppState, ctx: &egui::Context) {
         match message {
             QmWorkerMessage::Progress { stage } => {
                 state.set_message(format!("QM: {stage}; press Esc to stop"));
+                running.latest_stage = Some(stage);
             }
             QmWorkerMessage::Finished(outcome) => {
+                if running.cancel_requested {
+                    state.set_message("QM calculation cancelled".to_string());
+                    complete_active_qm_task(state, TaskStatus::Cancelled);
+                    finished = true;
+                    continue;
+                }
                 let outcome = *outcome;
                 for line in outcome.summary.lines() {
                     state.output_log.push(line.to_string());
@@ -271,8 +276,13 @@ pub(crate) fn poll_qm_job(state: &mut AppState, ctx: &egui::Context) {
                 finished = true;
             }
             QmWorkerMessage::Failed(error) => {
-                state.set_message(format!("QM calculation failed: {error}"));
-                complete_active_qm_task(state, TaskStatus::Failed);
+                if running.cancel_requested {
+                    state.set_message("QM calculation cancelled".to_string());
+                    complete_active_qm_task(state, TaskStatus::Cancelled);
+                } else {
+                    state.set_message(format!("QM calculation failed: {error}"));
+                    complete_active_qm_task(state, TaskStatus::Failed);
+                }
                 finished = true;
             }
         }

--- a/src/frontend/dispatcher/jobs/tests.rs
+++ b/src/frontend/dispatcher/jobs/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::frontend::gpu_monitor::GpuSample;
-use crate::frontend::jobs::{Metrics, RunningMetricsSampler};
+use crate::frontend::jobs::{Metrics, QmWorkerMessage, RunningMetricsSampler, RunningQmJob};
 
 #[test]
 fn poll_remote_gpu_monitor_drains_sample_into_state() {
@@ -125,4 +125,33 @@ fn poll_metrics_drains_latest_into_state() {
             .and_then(|h| h.back().copied()),
         Some(Some(50.0))
     );
+}
+
+#[test]
+fn esc_still_requests_qm_cancel_with_stage_boundary_message() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    let (_tx, rx) = std::sync::mpsc::channel::<QmWorkerMessage>();
+    let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    state.jobs.qm = Some(RunningQmJob {
+        cancel: crate::wire::JobCancelHandle::from_flag(std::sync::Arc::clone(&cancel)),
+        receiver: rx,
+        latest_stage: Some("SCF".into()),
+        cancel_requested: false,
+    });
+    let ctx = egui::Context::default();
+    ctx.input_mut(|input| {
+        input.events.push(egui::Event::Key {
+            key: egui::Key::Escape,
+            physical_key: Some(egui::Key::Escape),
+            pressed: true,
+            repeat: false,
+            modifiers: egui::Modifiers::NONE,
+        });
+    });
+
+    poll_qm_job(&mut state, &ctx);
+
+    assert!(cancel.load(std::sync::atomic::Ordering::Relaxed));
+    assert_eq!(state.message, "QM calculation stopping");
+    assert!(state.jobs.qm.is_some());
 }

--- a/src/frontend/dispatcher/mod.rs
+++ b/src/frontend/dispatcher/mod.rs
@@ -322,6 +322,7 @@ pub fn dispatch(state: &mut AppState, action: AppAction, ctx: &egui::Context) {
         }
         AppAction::FetchRemoteHardware(id) => fetch_remote_hardware(state, id),
         AppAction::RefreshRemoteJobs => refresh_remote_jobs(state),
+        AppAction::CancelControlledJob(id) => cancel_controlled_job_action(state, &id),
         AppAction::RemoveRemoteScratch(run_uuid) => remove_remote_job_scratch(state, &run_uuid),
         AppAction::SetMonitorSource(src) => set_monitor_source(state, src),
         AppAction::RunConsoleCommand(command) => run_console_command(state, &command),
@@ -355,7 +356,6 @@ pub fn dispatch(state: &mut AppState, action: AppAction, ctx: &egui::Context) {
         AppAction::RemoveQueuedAgentInput(index) => {
             crate::frontend::agent::remove_queued_agent_input(state, index)
         }
-        AppAction::CancelAgentJob(id) => crate::frontend::agent::cancel_agent_job(state, id),
         AppAction::SwitchProviderModel { provider, model } => {
             crate::frontend::agent::switch_provider_model(state, &provider, &model)
         }
@@ -436,6 +436,19 @@ const AUTOSAVE_DEBOUNCE_SECS: f64 = 0.5;
 
 fn toggle_atom_labels(state: &mut AppState) {
     state.ui.viewport.show_atom_labels = !state.ui.viewport.show_atom_labels;
+}
+
+fn cancel_controlled_job_action(state: &mut AppState, id: &crate::frontend::jobs::JobControlId) {
+    let job = crate::frontend::jobs::list_controlled_jobs(state)
+        .into_iter()
+        .find(|job| job.id == *id);
+    match crate::frontend::jobs::cancel_controlled_job(state, id) {
+        Ok(outcome) => state.set_message(crate::frontend::jobs::format_cancel_outcome_for_job(
+            &outcome,
+            job.as_ref(),
+        )),
+        Err(error) => state.set_message(format!("Could not cancel job: {error}")),
+    }
 }
 
 pub(crate) fn run_console_command(state: &mut AppState, command: &str) {

--- a/src/frontend/dispatcher/simulation.rs
+++ b/src/frontend/dispatcher/simulation.rs
@@ -151,6 +151,14 @@ pub(crate) fn start_pending_md_run(state: &mut AppState) {
 
 pub(crate) fn cancel_pending_md_run_request(state: &mut AppState) {
     bind_active_panel_task(state, TaskPanelKind::MdRunPrompt);
+    if state.jobs.engine_running() {
+        let _ = crate::frontend::jobs::cancel_controlled_job(
+            state,
+            &crate::frontend::jobs::JobControlId::Local(
+                crate::frontend::jobs::LocalJobSlot::Engine,
+            ),
+        );
+    }
     state.ui.pending_md_run = None;
     state.set_message("MD run canceled".to_string());
     complete_active_task(state, TaskKind::RunMd, TaskStatus::Failed);

--- a/src/frontend/jobs.rs
+++ b/src/frontend/jobs.rs
@@ -1,4 +1,5 @@
 mod agent;
+mod control;
 mod disorder;
 mod docking;
 mod engine;
@@ -10,6 +11,7 @@ mod remote;
 mod update;
 
 pub(crate) use agent::*;
+pub(crate) use control::*;
 pub(crate) use disorder::*;
 pub(crate) use docking::*;
 pub(crate) use engine::*;

--- a/src/frontend/jobs/agent.rs
+++ b/src/frontend/jobs/agent.rs
@@ -38,7 +38,7 @@ impl AgentHeavyJob {
     /// Signal the worker to stop at its next cancellation checkpoint.
     pub fn cancel(&self) {
         match self {
-            AgentHeavyJob::Qm(job) => job.cancel.store(true, Ordering::Relaxed),
+            AgentHeavyJob::Qm(job) => job.cancel.cancel(),
             AgentHeavyJob::Engine(job) => job.cancel.store(true, Ordering::Relaxed),
             AgentHeavyJob::Docking(job) => job.cancel.store(true, Ordering::Relaxed),
         }

--- a/src/frontend/jobs/control.rs
+++ b/src/frontend/jobs/control.rs
@@ -1,0 +1,744 @@
+use std::sync::atomic::Ordering;
+
+use crate::backend::storage::jobs as registry;
+use crate::backend::tasks::TaskStatus;
+use crate::frontend::state::AppState;
+
+use super::agent::AgentHeavyJob;
+use super::manager::JobManager;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum JobControlId {
+    Local(LocalJobSlot),
+    Agent(u64),
+    Remote(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LocalJobSlot {
+    Optimizer,
+    Disorder,
+    Qm,
+    Docking,
+    Engine,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JobBackend {
+    LocalLive,
+    AgentLive,
+    RemoteRegistry,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JobKind {
+    Optimizer,
+    Disorder,
+    Qm,
+    Docking,
+    Engine,
+    AssistantQm,
+    AssistantDocking,
+    AssistantEngine,
+    RemoteEngine,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JobStatus {
+    Queued,
+    Running,
+    Cancelling,
+    Done,
+    Failed,
+    Lost,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancelCapability {
+    Cooperative,
+    RemoteLauncher,
+    None,
+}
+
+impl JobControlId {
+    pub fn token(&self) -> String {
+        match self {
+            Self::Local(slot) => format!("local:{}", slot.token()),
+            Self::Agent(id) => format!("agent:{id}"),
+            Self::Remote(run_uuid) => format!("remote:{run_uuid}"),
+        }
+    }
+}
+
+impl LocalJobSlot {
+    pub fn token(self) -> &'static str {
+        match self {
+            Self::Optimizer => "optimizer",
+            Self::Disorder => "disorder",
+            Self::Qm => "qm",
+            Self::Docking => "docking",
+            Self::Engine => "engine",
+        }
+    }
+}
+
+impl JobBackend {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::LocalLive => "local",
+            Self::AgentLive => "assistant",
+            Self::RemoteRegistry => "remote",
+        }
+    }
+}
+
+impl JobKind {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Optimizer => "optimizer",
+            Self::Disorder => "disorder",
+            Self::Qm => "qm",
+            Self::Docking => "docking",
+            Self::Engine => "engine",
+            Self::AssistantQm => "assistant-qm",
+            Self::AssistantDocking => "assistant-docking",
+            Self::AssistantEngine => "assistant-engine",
+            Self::RemoteEngine => "remote-engine",
+        }
+    }
+
+    pub fn is_qm(&self) -> bool {
+        matches!(self, Self::Qm | Self::AssistantQm)
+    }
+}
+
+impl JobStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Cancelling => "cancelling",
+            Self::Done => "done",
+            Self::Failed => "failed",
+            Self::Lost => "lost",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub fn is_running(self) -> bool {
+        matches!(self, Self::Queued | Self::Running | Self::Cancelling)
+    }
+}
+
+impl CancelCapability {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Cooperative => "cooperative",
+            Self::RemoteLauncher => "remote-launcher",
+            Self::None => "none",
+        }
+    }
+
+    pub fn can_cancel(self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveJobSnapshot {
+    pub id: JobControlId,
+    pub backend: JobBackend,
+    pub kind: JobKind,
+    pub status: JobStatus,
+    pub cancel: CancelCapability,
+    pub label: String,
+    pub engine_id: Option<String>,
+    pub job_kind: Option<String>,
+    pub stage: Option<String>,
+    pub task_run_id: Option<u64>,
+    pub run_uuid: Option<String>,
+    pub host_label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CancelOutcome {
+    Requested {
+        id: JobControlId,
+        task_run_id: Option<u64>,
+    },
+    RequestFailed {
+        id: JobControlId,
+        reason: String,
+    },
+    NotFound {
+        id: JobControlId,
+    },
+    NotCancellable {
+        id: JobControlId,
+        reason: String,
+    },
+}
+
+impl CancelOutcome {
+    pub fn task_run_id(&self) -> Option<u64> {
+        match self {
+            Self::Requested { task_run_id, .. } => *task_run_id,
+            Self::RequestFailed { .. } | Self::NotFound { .. } | Self::NotCancellable { .. } => {
+                None
+            }
+        }
+    }
+}
+
+impl JobManager {
+    pub fn list_live_snapshots(&self, active_task_run: Option<u64>) -> Vec<LiveJobSnapshot> {
+        let mut jobs = Vec::new();
+        if let Some(running) = self.optimizer.as_ref() {
+            jobs.push(local_snapshot(
+                LocalJobSlot::Optimizer,
+                JobKind::Optimizer,
+                "forcefield optimization",
+                active_task_run,
+                running
+                    .latest_report
+                    .map(|report| format!("step {}", report.steps)),
+            ));
+        }
+        if let Some(running) = self.disorder.as_ref() {
+            jobs.push(local_snapshot(
+                LocalJobSlot::Disorder,
+                JobKind::Disorder,
+                "build disordered system",
+                active_task_run,
+                running.latest_report.as_ref().map(|report| {
+                    format!(
+                        "{} / {} placed",
+                        report.total_placed(),
+                        report.total_requested()
+                    )
+                }),
+            ));
+        }
+        if let Some(running) = self.qm.as_ref() {
+            let mut snapshot = local_snapshot(
+                LocalJobSlot::Qm,
+                JobKind::Qm,
+                "QM calculation",
+                active_task_run,
+                running.latest_stage.clone(),
+            );
+            if running.cancel_requested {
+                snapshot.status = JobStatus::Cancelling;
+                snapshot.cancel = CancelCapability::None;
+            }
+            jobs.push(snapshot);
+        }
+        if self.docking.is_some() {
+            jobs.push(local_snapshot(
+                LocalJobSlot::Docking,
+                JobKind::Docking,
+                "molecular docking",
+                active_task_run,
+                None,
+            ));
+        }
+        if let Some(running) = self.engine.as_ref() {
+            let mut snapshot = local_snapshot(
+                LocalJobSlot::Engine,
+                JobKind::Engine,
+                format!("{} {}", running.engine, running.job_kind),
+                active_task_run,
+                running.latest_stage.clone(),
+            );
+            snapshot.engine_id = Some(running.engine.to_string());
+            snapshot.job_kind = Some(running.job_kind.to_string());
+            jobs.push(snapshot);
+        }
+        for tracked in &self.agent_jobs {
+            jobs.push(agent_snapshot(tracked));
+        }
+        jobs
+    }
+
+    pub fn cancel_controlled_job(&mut self, id: &JobControlId) -> anyhow::Result<CancelOutcome> {
+        Ok(match id {
+            JobControlId::Local(slot) => {
+                if self.cancel_local_slot(*slot) {
+                    CancelOutcome::Requested {
+                        id: id.clone(),
+                        task_run_id: None,
+                    }
+                } else {
+                    CancelOutcome::NotFound { id: id.clone() }
+                }
+            }
+            JobControlId::Agent(agent_id) => match self.cancel_agent_slot(*agent_id) {
+                Some(task_run_id) => CancelOutcome::Requested {
+                    id: id.clone(),
+                    task_run_id: Some(task_run_id),
+                },
+                None => CancelOutcome::NotFound { id: id.clone() },
+            },
+            JobControlId::Remote(_) => CancelOutcome::NotCancellable {
+                id: id.clone(),
+                reason: "remote jobs require registry and host context".to_string(),
+            },
+        })
+    }
+
+    fn cancel_local_slot(&mut self, slot: LocalJobSlot) -> bool {
+        match slot {
+            LocalJobSlot::Optimizer => self
+                .optimizer
+                .as_ref()
+                .map(|running| running.cancel.store(true, Ordering::Relaxed)),
+            LocalJobSlot::Disorder => self
+                .disorder
+                .as_ref()
+                .map(|running| running.cancel.store(true, Ordering::Relaxed)),
+            LocalJobSlot::Qm => self.qm.as_mut().map(|running| {
+                running.cancel_requested = true;
+                running.cancel.cancel();
+            }),
+            LocalJobSlot::Docking => self
+                .docking
+                .as_ref()
+                .map(|running| running.cancel.store(true, Ordering::Relaxed)),
+            LocalJobSlot::Engine => self
+                .engine
+                .as_ref()
+                .map(|running| running.cancel.store(true, Ordering::Relaxed)),
+        }
+        .is_some()
+    }
+
+    fn cancel_agent_slot(&mut self, id: u64) -> Option<u64> {
+        let tracked = self.agent_jobs.iter_mut().find(|job| job.id == id)?;
+        tracked.job.cancel();
+        tracked.task_cancelling();
+        Some(tracked.task_run_id)
+    }
+}
+
+trait TrackedAgentJobCancel {
+    fn task_cancelling(&mut self);
+}
+
+impl TrackedAgentJobCancel for super::agent::TrackedAgentJob {
+    fn task_cancelling(&mut self) {
+        if let AgentHeavyJob::Qm(job) = &mut self.job {
+            job.cancel_requested = true;
+        }
+    }
+}
+
+pub fn list_controlled_jobs(state: &AppState) -> Vec<LiveJobSnapshot> {
+    let mut jobs = state.jobs.list_live_snapshots(state.active_task_run);
+    jobs.extend(list_remote_snapshots(state));
+    jobs
+}
+
+pub fn cancel_controlled_job(
+    state: &mut AppState,
+    id: &JobControlId,
+) -> anyhow::Result<CancelOutcome> {
+    match id {
+        JobControlId::Remote(run_uuid) => cancel_remote_controlled_job(state, run_uuid),
+        JobControlId::Local(_) | JobControlId::Agent(_) => {
+            let active_task_run = state.active_task_run;
+            let outcome = state.jobs.cancel_controlled_job(id)?;
+            if let Some(task_run_id) = outcome.task_run_id()
+                && task_run_id != 0
+            {
+                mark_task_cancelling(state, task_run_id);
+            }
+            if matches!(id, JobControlId::Local(_))
+                && matches!(outcome, CancelOutcome::Requested { .. })
+                && let Some(task_run_id) = active_task_run
+            {
+                mark_task_cancelling(state, task_run_id);
+                return Ok(CancelOutcome::Requested {
+                    id: id.clone(),
+                    task_run_id: Some(task_run_id),
+                });
+            }
+            Ok(outcome)
+        }
+    }
+}
+
+pub fn format_jobs_status(state: &AppState) -> String {
+    let jobs = list_controlled_jobs(state);
+    if jobs.is_empty() {
+        return "No running or tracked jobs.".to_string();
+    }
+    format_job_table(&jobs)
+}
+
+pub fn cancel_job_by_token(state: &mut AppState, token: &str) -> anyhow::Result<String> {
+    let jobs = list_controlled_jobs(state);
+    let id = parse_job_control_id(token, &jobs)?;
+    let job = jobs.iter().find(|job| job.id == id).cloned();
+    let outcome = cancel_controlled_job(state, &id)?;
+    Ok(format_cancel_outcome_for_job(&outcome, job.as_ref()))
+}
+
+pub fn qm_jobs_status(state: &AppState) -> String {
+    let jobs = running_qm_jobs(state);
+    if jobs.is_empty() {
+        return "No running QM jobs.".to_string();
+    }
+    format_job_table(&jobs)
+}
+
+pub fn cancel_qm_job_alias(state: &mut AppState) -> anyhow::Result<String> {
+    let jobs = running_qm_jobs(state);
+    match jobs.as_slice() {
+        [] => Ok("No running QM job to cancel.".to_string()),
+        [job] => {
+            let id = job.id.clone();
+            let job = job.clone();
+            let outcome = cancel_controlled_job(state, &id)?;
+            Ok(format_cancel_outcome_for_job(&outcome, Some(&job)))
+        }
+        _ => {
+            let ids = jobs
+                .iter()
+                .map(|job| job.id.token())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Ok(format!(
+                "Multiple QM jobs are running ({ids}); use `jobs cancel <id>`."
+            ))
+        }
+    }
+}
+
+pub fn format_job_table(jobs: &[LiveJobSnapshot]) -> String {
+    let mut out = String::from("id\tkind\tlabel\tstatus\tstage\tbackend\tcancel\n");
+    for job in jobs {
+        out.push_str(&format_job_row(job));
+        out.push('\n');
+    }
+    out.trim_end().to_string()
+}
+
+pub fn format_job_row(job: &LiveJobSnapshot) -> String {
+    format!(
+        "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+        job.id.token(),
+        job.kind.label(),
+        job.label,
+        job_status_display(job),
+        job.stage.as_deref().unwrap_or("-"),
+        job.backend.label(),
+        job.cancel.label(),
+    )
+}
+
+pub fn format_cancel_outcome_for_job(
+    outcome: &CancelOutcome,
+    job: Option<&LiveJobSnapshot>,
+) -> String {
+    match outcome {
+        CancelOutcome::Requested { id, .. } => match job {
+            Some(job) if job_is_qm(job) => format!(
+                "Cancel requested for {}. The current stage may finish before stopping.",
+                id.token()
+            ),
+            _ => format!("Cancel requested for {}.", id.token()),
+        },
+        CancelOutcome::RequestFailed { id, reason } => {
+            format!("Could not cancel {}: {reason}", id.token())
+        }
+        CancelOutcome::NotFound { id } => format!("Job not found: {}", id.token()),
+        CancelOutcome::NotCancellable { id, reason } => {
+            format!("Job {} is not cancellable: {reason}", id.token())
+        }
+    }
+}
+
+pub fn job_status_display(job: &LiveJobSnapshot) -> String {
+    if job.backend == JobBackend::RemoteRegistry {
+        format!("last-known:{}", job.status.label())
+    } else {
+        job.status.label().to_string()
+    }
+}
+
+fn job_is_qm(job: &LiveJobSnapshot) -> bool {
+    job.kind.is_qm()
+        || job
+            .job_kind
+            .as_deref()
+            .is_some_and(|kind| kind.starts_with("qm-"))
+}
+
+pub fn parse_job_control_id(token: &str, jobs: &[LiveJobSnapshot]) -> anyhow::Result<JobControlId> {
+    let token = token.trim();
+    if token.is_empty() {
+        anyhow::bail!("job id is empty");
+    }
+    let token_lower = token.to_ascii_lowercase();
+    for job in jobs {
+        if job.id.token().eq_ignore_ascii_case(token) {
+            return Ok(job.id.clone());
+        }
+        if matches!(job.id, JobControlId::Remote(_))
+            && job.run_uuid.as_deref().is_some_and(|uuid| uuid == token)
+        {
+            return Ok(job.id.clone());
+        }
+    }
+    if let Some(rest) = token_lower.strip_prefix("agent:")
+        && let Ok(id) = rest.parse::<u64>()
+    {
+        return Ok(JobControlId::Agent(id));
+    }
+    if let Some(rest) = token_lower.strip_prefix("remote:") {
+        let Some(job) = jobs.iter().find(|job| {
+            matches!(job.id, JobControlId::Remote(_))
+                && job.run_uuid.as_deref().is_some_and(|uuid| uuid == rest)
+        }) else {
+            return Ok(JobControlId::Remote(token["remote:".len()..].to_string()));
+        };
+        return Ok(job.id.clone());
+    }
+    let local = token_lower
+        .strip_prefix("local:")
+        .unwrap_or(token_lower.as_str());
+    match local {
+        "optimizer" | "optimization" | "opt" => Ok(JobControlId::Local(LocalJobSlot::Optimizer)),
+        "disorder" | "pack" => Ok(JobControlId::Local(LocalJobSlot::Disorder)),
+        "qm" => Ok(JobControlId::Local(LocalJobSlot::Qm)),
+        "docking" | "dock" => Ok(JobControlId::Local(LocalJobSlot::Docking)),
+        "engine" | "md" | "gromacs" => Ok(JobControlId::Local(LocalJobSlot::Engine)),
+        _ => anyhow::bail!("unknown job id `{token}`; run `jobs status` to list jobs"),
+    }
+}
+
+fn running_qm_jobs(state: &AppState) -> Vec<LiveJobSnapshot> {
+    list_controlled_jobs(state)
+        .into_iter()
+        .filter(|job| {
+            job.status.is_running()
+                && (job.kind.is_qm()
+                    || job
+                        .job_kind
+                        .as_deref()
+                        .is_some_and(|kind| kind.starts_with("qm-")))
+        })
+        .collect()
+}
+
+pub fn remote_job_snapshot(row: &registry::RemoteJob) -> LiveJobSnapshot {
+    LiveJobSnapshot {
+        id: JobControlId::Remote(row.run_uuid.clone()),
+        backend: JobBackend::RemoteRegistry,
+        kind: JobKind::RemoteEngine,
+        status: remote_status(row.status),
+        cancel: if row.status.is_terminal() {
+            CancelCapability::None
+        } else {
+            CancelCapability::RemoteLauncher
+        },
+        label: format!("remote {} on {}", row.job_kind, row.host_label),
+        engine_id: Some(row.engine_id.clone()),
+        job_kind: Some(row.job_kind.clone()),
+        stage: None,
+        task_run_id: None,
+        run_uuid: Some(row.run_uuid.clone()),
+        host_label: Some(row.host_label.clone()),
+    }
+}
+
+pub fn record_remote_cancel_success(
+    conn: &rusqlite::Connection,
+    run_uuid: &str,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    registry::record_poll(
+        conn,
+        run_uuid,
+        registry::RemoteJobStatus::Cancelled,
+        None,
+        now_ms,
+    )
+}
+
+fn list_remote_snapshots(state: &AppState) -> Vec<LiveJobSnapshot> {
+    let rows = (|| -> anyhow::Result<Vec<registry::RemoteJob>> {
+        let conn = registry::open()?;
+        match state.workspace.project() {
+            Some(project) => registry::list_for_project(&conn, &project.root.to_string_lossy()),
+            None => registry::list_non_terminal(&conn),
+        }
+    })()
+    .unwrap_or_default();
+    rows.iter().map(remote_job_snapshot).collect()
+}
+
+fn cancel_remote_controlled_job(
+    state: &mut AppState,
+    run_uuid: &str,
+) -> anyhow::Result<CancelOutcome> {
+    let conn = registry::open()?;
+    let Some(row) = registry::get(&conn, run_uuid)? else {
+        return Ok(CancelOutcome::NotFound {
+            id: JobControlId::Remote(run_uuid.to_string()),
+        });
+    };
+    if row.status.is_terminal() {
+        return Ok(CancelOutcome::NotCancellable {
+            id: JobControlId::Remote(run_uuid.to_string()),
+            reason: format!("remote job is already {}", row.status.token()),
+        });
+    }
+    let id = JobControlId::Remote(row.run_uuid.clone());
+    let Some(host) = state.config.remote_hosts.get(&row.host_id).cloned() else {
+        return Ok(CancelOutcome::NotCancellable {
+            id,
+            reason: format!("remote host {} is no longer configured", row.host_id),
+        });
+    };
+    let Some(launcher) = launcher_from_token(&row.scheduler) else {
+        return Ok(CancelOutcome::NotCancellable {
+            id,
+            reason: format!("unknown remote scheduler {}", row.scheduler),
+        });
+    };
+    let target = crate::engines::remote::RemoteTarget::for_run(&host, &row.run_uuid);
+    let handle = crate::engines::remote::launcher::LaunchHandle(row.launch_handle.clone());
+    if let Err(error) = launcher.cancel(&target, &handle) {
+        return Ok(CancelOutcome::RequestFailed {
+            id,
+            reason: error.to_string(),
+        });
+    }
+    record_remote_cancel_success(&conn, &row.run_uuid, registry::now_ms())?;
+    sync_remote_job_ui_row(state, &row.run_uuid, registry::RemoteJobStatus::Cancelled);
+    let task_run_id = state
+        .tasks
+        .task_run_by_uuid(&row.run_uuid)
+        .map(|task| task.id);
+    if let Some(task_run_id) = task_run_id {
+        mark_task_cancelled(state, task_run_id);
+    }
+    Ok(CancelOutcome::Requested {
+        id: JobControlId::Remote(row.run_uuid),
+        task_run_id,
+    })
+}
+
+fn launcher_from_token(token: &str) -> Option<crate::engines::remote::launcher::Launcher> {
+    match token {
+        "direct" => Some(crate::engines::remote::launcher::Launcher::Direct),
+        _ => None,
+    }
+}
+
+fn mark_task_cancelled(state: &mut AppState, task_run_id: u64) {
+    if let Err(error) =
+        crate::frontend::task_executor::mark_task_status(state, task_run_id, TaskStatus::Cancelled)
+    {
+        state.set_message(format!("failed to update task status: {error}"));
+    }
+}
+
+fn mark_task_cancelling(state: &mut AppState, task_run_id: u64) {
+    if let Err(error) =
+        crate::frontend::task_executor::mark_task_status(state, task_run_id, TaskStatus::Cancelling)
+    {
+        state.set_message(format!("failed to update task status: {error}"));
+    }
+}
+
+fn sync_remote_job_ui_row(state: &mut AppState, run_uuid: &str, status: registry::RemoteJobStatus) {
+    if let Some(row) = state
+        .ui
+        .remote_jobs
+        .iter_mut()
+        .find(|row| row.run_uuid == run_uuid)
+    {
+        row.status = status;
+        row.last_polled_at_ms = Some(registry::now_ms());
+        row.exit_code = None;
+    }
+}
+
+fn remote_status(status: registry::RemoteJobStatus) -> JobStatus {
+    match status {
+        registry::RemoteJobStatus::Queued => JobStatus::Queued,
+        registry::RemoteJobStatus::Running => JobStatus::Running,
+        registry::RemoteJobStatus::Done => JobStatus::Done,
+        registry::RemoteJobStatus::Failed => JobStatus::Failed,
+        registry::RemoteJobStatus::Lost => JobStatus::Lost,
+        registry::RemoteJobStatus::Cancelled => JobStatus::Cancelled,
+    }
+}
+
+fn local_snapshot(
+    slot: LocalJobSlot,
+    kind: JobKind,
+    label: impl Into<String>,
+    task_run_id: Option<u64>,
+    stage: Option<String>,
+) -> LiveJobSnapshot {
+    LiveJobSnapshot {
+        id: JobControlId::Local(slot),
+        backend: JobBackend::LocalLive,
+        kind,
+        status: JobStatus::Running,
+        cancel: CancelCapability::Cooperative,
+        label: label.into(),
+        engine_id: None,
+        job_kind: None,
+        stage,
+        task_run_id,
+        run_uuid: None,
+        host_label: None,
+    }
+}
+
+fn agent_snapshot(tracked: &super::agent::TrackedAgentJob) -> LiveJobSnapshot {
+    let (kind, stage, engine_id, job_kind, cancel_requested) = match &tracked.job {
+        AgentHeavyJob::Qm(job) => (
+            JobKind::AssistantQm,
+            job.latest_stage.clone(),
+            None,
+            None,
+            job.cancel_requested,
+        ),
+        AgentHeavyJob::Docking(_) => (JobKind::AssistantDocking, None, None, None, false),
+        AgentHeavyJob::Engine(job) => (
+            JobKind::AssistantEngine,
+            job.latest_stage.clone(),
+            Some(job.engine.to_string()),
+            Some(job.job_kind.to_string()),
+            false,
+        ),
+    };
+    LiveJobSnapshot {
+        id: JobControlId::Agent(tracked.id),
+        backend: JobBackend::AgentLive,
+        kind,
+        status: if cancel_requested {
+            JobStatus::Cancelling
+        } else {
+            JobStatus::Running
+        },
+        cancel: if cancel_requested {
+            CancelCapability::None
+        } else {
+            CancelCapability::Cooperative
+        },
+        label: tracked.label.clone(),
+        engine_id,
+        job_kind,
+        stage,
+        task_run_id: Some(tracked.task_run_id),
+        run_uuid: None,
+        host_label: None,
+    }
+}

--- a/src/frontend/jobs/manager.rs
+++ b/src/frontend/jobs/manager.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::Ordering;
-
 use crate::frontend::remote_jobs::{RunningRemoteJobsRefresh, RunningRemoteSubmit};
 
 use super::agent::{RunningAgentTurn, TrackedAgentJob};
@@ -75,12 +73,6 @@ impl JobManager {
         self.optimizer = Some(optimizer);
     }
 
-    pub fn cancel_optimization(&mut self) {
-        if let Some(running) = self.optimizer.take() {
-            running.cancel.store(true, Ordering::Relaxed);
-        }
-    }
-
     pub fn disorder_running(&self) -> bool {
         self.disorder.is_some()
     }
@@ -91,12 +83,6 @@ impl JobManager {
 
     pub fn set_disorder(&mut self, disorder: RunningDisorderJob) {
         self.disorder = Some(disorder);
-    }
-
-    pub fn cancel_disorder(&mut self) {
-        if let Some(running) = self.disorder.take() {
-            running.cancel.store(true, Ordering::Relaxed);
-        }
     }
 
     pub fn qm_running(&self) -> bool {
@@ -111,12 +97,6 @@ impl JobManager {
         self.qm = Some(qm);
     }
 
-    pub fn cancel_qm(&mut self) {
-        if let Some(running) = self.qm.take() {
-            running.cancel.store(true, Ordering::Relaxed);
-        }
-    }
-
     pub fn docking_running(&self) -> bool {
         self.docking.is_some()
     }
@@ -129,12 +109,6 @@ impl JobManager {
         self.docking = Some(docking);
     }
 
-    pub fn cancel_docking(&mut self) {
-        if let Some(running) = self.docking.take() {
-            running.cancel.store(true, Ordering::Relaxed);
-        }
-    }
-
     pub fn engine_running(&self) -> bool {
         self.engine.is_some()
     }
@@ -145,11 +119,5 @@ impl JobManager {
 
     pub fn set_engine(&mut self, engine: RunningEngineJob) {
         self.engine = Some(engine);
-    }
-
-    pub fn cancel_engine(&mut self) {
-        if let Some(running) = self.engine.take() {
-            running.cancel.store(true, Ordering::Relaxed);
-        }
     }
 }

--- a/src/frontend/jobs/qm.rs
+++ b/src/frontend/jobs/qm.rs
@@ -1,12 +1,16 @@
-use std::sync::{Arc, atomic::AtomicBool, mpsc::Receiver};
+use std::sync::mpsc::Receiver;
 
 use crate::engines::qm::{QmJob, QmOutcome};
-use crate::wire::{Engine, EngineOutcome, EngineRequest, Executor, JobUpdate, run_job};
+use crate::wire::{
+    Engine, EngineOutcome, EngineRequest, Executor, JobCancelHandle, JobUpdate, run_job,
+};
 
 /// A background quantum-chemistry (hartree) job the UI is polling.
 pub struct RunningQmJob {
-    pub cancel: Arc<AtomicBool>,
+    pub cancel: JobCancelHandle,
     pub receiver: Receiver<QmWorkerMessage>,
+    pub latest_stage: Option<String>,
+    pub cancel_requested: bool,
 }
 
 pub enum QmWorkerMessage {
@@ -20,15 +24,19 @@ pub enum QmWorkerMessage {
 /// then a `Finished` outcome or `Failed` error. Caller stores the handle in
 /// [`JobManager`].
 pub fn spawn_qm_job(job: QmJob, threads: Option<usize>) -> RunningQmJob {
+    let executor = if cfg!(test) {
+        Executor::InProcess
+    } else {
+        Executor::LocalSubprocess
+    };
     let running = run_job(
         EngineRequest::with_cores(Engine::Qm(job), threads),
-        Executor::InProcess,
+        executor,
     );
-    // The QM job rides the shared run handle; adapt its updates to the message the
-    // task UI already polls. An in-process job cancels through the shared flag.
-    let cancel = running
-        .cancel_flag()
-        .expect("an in-process job cancels via the cooperative flag");
+    // Production runs QM in a subprocess so Cancel can kill an opaque hartree
+    // calculation without requiring in-process preemption hooks. Tests keep the
+    // in-process path because Rust's test harness is not the self-exec worker.
+    let cancel = running.cancel_handle();
     let (sender, receiver) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         while let Ok(update) = running.updates().recv() {
@@ -48,5 +56,10 @@ pub fn spawn_qm_job(job: QmJob, threads: Option<usize>) -> RunningQmJob {
         }
     });
 
-    RunningQmJob { cancel, receiver }
+    RunningQmJob {
+        cancel,
+        receiver,
+        latest_stage: None,
+        cancel_requested: false,
+    }
 }

--- a/src/frontend/jobs/tests.rs
+++ b/src/frontend/jobs/tests.rs
@@ -1,6 +1,11 @@
 use super::*;
 use serde_json::json;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
+
+fn qm_cancel(flag: std::sync::Arc<std::sync::atomic::AtomicBool>) -> crate::wire::JobCancelHandle {
+    crate::wire::JobCancelHandle::from_flag(flag)
+}
 
 #[test]
 fn apply_metrics_sampler_starts_and_stops() {
@@ -139,4 +144,415 @@ fn interpret_models_response_json_error_reports_message() {
     .unwrap_err();
     assert!(err.contains("401"), "got: {err}");
     assert!(err.contains("API key is required"), "got: {err}");
+}
+
+#[test]
+fn local_job_snapshots_enumerate_live_slots() {
+    let mut jobs = JobManager::default();
+    let (_qm_tx, qm_rx) = std::sync::mpsc::channel();
+    jobs.qm = Some(RunningQmJob {
+        cancel: qm_cancel(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+            false,
+        ))),
+        receiver: qm_rx,
+        latest_stage: Some("SCF".to_string()),
+        cancel_requested: false,
+    });
+    let (_engine_tx, engine_rx) = std::sync::mpsc::channel();
+    jobs.engine = Some(RunningEngineJob {
+        engine: "gromacs",
+        job_kind: "run-md",
+        cancel: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        receiver: engine_rx,
+        latest_stage: Some("nvt".to_string()),
+        log_tail: Vec::new(),
+    });
+
+    let snapshots = jobs.list_live_snapshots(Some(42));
+
+    assert_eq!(snapshots.len(), 2);
+    assert!(snapshots.iter().any(|snapshot| {
+        snapshot.id == JobControlId::Local(LocalJobSlot::Qm)
+            && snapshot.kind == JobKind::Qm
+            && snapshot.stage.as_deref() == Some("SCF")
+            && snapshot.task_run_id == Some(42)
+    }));
+    assert!(snapshots.iter().any(|snapshot| {
+        snapshot.id == JobControlId::Local(LocalJobSlot::Engine)
+            && snapshot.engine_id.as_deref() == Some("gromacs")
+            && snapshot.job_kind.as_deref() == Some("run-md")
+            && snapshot.stage.as_deref() == Some("nvt")
+    }));
+}
+
+#[test]
+fn agent_job_cancel_routes_through_control_plane() {
+    let mut state = crate::frontend::state::AppState::scratch(Default::default(), Vec::new());
+    let controller = crate::backend::tasks::task_controller_by_id("qm-energy")
+        .copied()
+        .unwrap();
+    let task_run_id = state.tasks.create_task_run(controller);
+    state
+        .tasks
+        .mark_status(task_run_id, crate::backend::tasks::TaskStatus::Running);
+    let (_tx, rx) = std::sync::mpsc::channel();
+    let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    state.jobs.agent_jobs.push(TrackedAgentJob {
+        id: 7,
+        conversation: state.ui.agent.active_conversation,
+        label: "qm energy".to_string(),
+        task_run_id,
+        job: AgentHeavyJob::Qm(RunningQmJob {
+            cancel: qm_cancel(std::sync::Arc::clone(&cancel)),
+            receiver: rx,
+            latest_stage: None,
+            cancel_requested: false,
+        }),
+    });
+
+    let outcome = cancel_controlled_job(&mut state, &JobControlId::Agent(7)).unwrap();
+
+    assert!(matches!(
+        outcome,
+        CancelOutcome::Requested {
+            id: JobControlId::Agent(7),
+            task_run_id: Some(id),
+        } if id == task_run_id
+    ));
+    assert!(cancel.load(Ordering::Relaxed));
+    assert_eq!(state.jobs.agent_jobs.len(), 1);
+    assert_eq!(
+        state.tasks.task_run(task_run_id).unwrap().status,
+        crate::backend::tasks::TaskStatus::Cancelling
+    );
+}
+
+#[test]
+fn cancel_transient_jobs_routes_local_slots_through_control_plane() {
+    let mut state = crate::frontend::state::AppState::scratch(Default::default(), Vec::new());
+    let controller = crate::backend::tasks::task_controller_by_id("qm-energy")
+        .copied()
+        .unwrap();
+    let task_run_id = state.tasks.create_task_run(controller);
+    state.active_task_run = Some(task_run_id);
+    state
+        .tasks
+        .mark_status(task_run_id, crate::backend::tasks::TaskStatus::Running);
+    let (_tx, rx) = std::sync::mpsc::channel();
+    let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    state.jobs.qm = Some(RunningQmJob {
+        cancel: qm_cancel(std::sync::Arc::clone(&cancel)),
+        receiver: rx,
+        latest_stage: None,
+        cancel_requested: false,
+    });
+
+    state.cancel_transient_jobs();
+
+    assert!(cancel.load(Ordering::Relaxed));
+    assert!(state.jobs.qm.is_some());
+    assert_eq!(
+        state.tasks.task_run(task_run_id).unwrap().status,
+        crate::backend::tasks::TaskStatus::Cancelling
+    );
+    assert_eq!(state.active_task_run, Some(task_run_id));
+}
+
+#[test]
+fn agent_job_snapshots_include_latest_stage() {
+    let mut jobs = JobManager::default();
+    let (_tx, rx) = std::sync::mpsc::channel();
+    jobs.agent_jobs.push(TrackedAgentJob {
+        id: 9,
+        conversation: crate::frontend::agent::AssistantConversationId::new(1),
+        label: "qm energy".to_string(),
+        task_run_id: 44,
+        job: AgentHeavyJob::Qm(RunningQmJob {
+            cancel: qm_cancel(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+                false,
+            ))),
+            receiver: rx,
+            latest_stage: Some("SCF".to_string()),
+            cancel_requested: false,
+        }),
+    });
+
+    let snapshots = jobs.list_live_snapshots(None);
+
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].id, JobControlId::Agent(9));
+    assert_eq!(snapshots[0].kind, JobKind::AssistantQm);
+    assert_eq!(snapshots[0].stage.as_deref(), Some("SCF"));
+    assert_eq!(snapshots[0].task_run_id, Some(44));
+}
+
+#[test]
+fn remote_job_snapshot_maps_last_known_registry_state() {
+    let row = remote_row(
+        "run-1",
+        crate::backend::storage::jobs::RemoteJobStatus::Running,
+    );
+
+    let snapshot = remote_job_snapshot(&row);
+
+    assert_eq!(snapshot.id, JobControlId::Remote("run-1".to_string()));
+    assert_eq!(snapshot.backend, JobBackend::RemoteRegistry);
+    assert_eq!(snapshot.kind, JobKind::RemoteEngine);
+    assert_eq!(snapshot.status, JobStatus::Running);
+    assert_eq!(snapshot.cancel, CancelCapability::RemoteLauncher);
+    assert_eq!(snapshot.engine_id.as_deref(), Some("hartree"));
+    assert_eq!(snapshot.job_kind.as_deref(), Some("qm-energy"));
+    assert_eq!(snapshot.host_label.as_deref(), Some("Cluster"));
+}
+
+#[test]
+fn remote_cancel_success_updates_registry_status_without_ssh() {
+    let path = std::env::temp_dir().join(format!(
+        "silicolab-control-cancel-{}.db",
+        uuid::Uuid::new_v4().simple()
+    ));
+    let _ = std::fs::remove_file(&path);
+    let conn = crate::backend::storage::jobs::open_at(&path).unwrap();
+    crate::backend::storage::jobs::upsert(
+        &conn,
+        &remote_row(
+            "run-2",
+            crate::backend::storage::jobs::RemoteJobStatus::Running,
+        ),
+    )
+    .unwrap();
+
+    record_remote_cancel_success(&conn, "run-2", 1234).unwrap();
+
+    let row = crate::backend::storage::jobs::get(&conn, "run-2")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        row.status,
+        crate::backend::storage::jobs::RemoteJobStatus::Cancelled
+    );
+    assert_eq!(row.last_polled_at_ms, Some(1234));
+    assert_eq!(row.exit_code, None);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn qm_cancel_alias_refuses_multiple_qm_jobs_without_cancelling_any() {
+    let mut state = crate::frontend::state::AppState::scratch(Default::default(), Vec::new());
+    let local_cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (_local_tx, local_rx) = std::sync::mpsc::channel();
+    state.jobs.qm = Some(RunningQmJob {
+        cancel: qm_cancel(std::sync::Arc::clone(&local_cancel)),
+        receiver: local_rx,
+        latest_stage: Some("local".into()),
+        cancel_requested: false,
+    });
+
+    let agent_cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (_agent_tx, agent_rx) = std::sync::mpsc::channel();
+    let controller = crate::backend::tasks::task_controller_by_id("qm-optimize")
+        .copied()
+        .unwrap();
+    let task_run_id = state.tasks.create_task_run(controller);
+    state.jobs.agent_jobs.push(TrackedAgentJob {
+        id: 12,
+        conversation: state.ui.agent.active_conversation,
+        label: "qm optimize".to_string(),
+        task_run_id,
+        job: AgentHeavyJob::Qm(RunningQmJob {
+            cancel: qm_cancel(std::sync::Arc::clone(&agent_cancel)),
+            receiver: agent_rx,
+            latest_stage: Some("agent".into()),
+            cancel_requested: false,
+        }),
+    });
+
+    let message = cancel_qm_job_alias(&mut state).unwrap();
+
+    assert!(
+        message.contains("Multiple QM jobs are running"),
+        "{message}"
+    );
+    assert!(message.contains("local:qm"), "{message}");
+    assert!(message.contains("agent:12"), "{message}");
+    assert!(!local_cancel.load(Ordering::Relaxed));
+    assert!(!agent_cancel.load(Ordering::Relaxed));
+    assert!(state.jobs.qm.is_some());
+    assert_eq!(state.jobs.agent_jobs.len(), 1);
+}
+
+#[test]
+fn jobs_status_shows_agent_job_and_remote_status_as_last_known() {
+    let mut state = crate::frontend::state::AppState::scratch(Default::default(), Vec::new());
+    let (_tx, rx) = std::sync::mpsc::channel();
+    let controller = crate::backend::tasks::task_controller_by_id("qm-optimize")
+        .copied()
+        .unwrap();
+    let task_run_id = state.tasks.create_task_run(controller);
+    state.jobs.agent_jobs.push(TrackedAgentJob {
+        id: 7,
+        conversation: state.ui.agent.active_conversation,
+        label: "qm optimize".to_string(),
+        task_run_id,
+        job: AgentHeavyJob::Qm(RunningQmJob {
+            cancel: qm_cancel(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+                false,
+            ))),
+            receiver: rx,
+            latest_stage: Some("SCF".into()),
+            cancel_requested: false,
+        }),
+    });
+
+    let status = crate::frontend::console::execute_console_line(&mut state, "jobs status").unwrap();
+    assert!(status.contains("agent:7"), "{status}");
+    assert!(status.contains("qm optimize"), "{status}");
+
+    let remote = remote_job_snapshot(&remote_row(
+        "run-3",
+        crate::backend::storage::jobs::RemoteJobStatus::Running,
+    ));
+    assert!(
+        format_job_row(&remote).contains("last-known:running"),
+        "{}",
+        format_job_row(&remote)
+    );
+}
+
+#[test]
+fn jobs_cancel_and_control_plane_cancel_have_matching_qm_message_and_effect() {
+    fn state_with_agent_qm() -> (
+        crate::frontend::state::AppState,
+        std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) {
+        let mut state = crate::frontend::state::AppState::scratch(Default::default(), Vec::new());
+        let (_tx, rx) = std::sync::mpsc::channel();
+        let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let controller = crate::backend::tasks::task_controller_by_id("qm-optimize")
+            .copied()
+            .unwrap();
+        let task_run_id = state.tasks.create_task_run(controller);
+        state.jobs.agent_jobs.push(TrackedAgentJob {
+            id: 7,
+            conversation: state.ui.agent.active_conversation,
+            label: "qm optimize".to_string(),
+            task_run_id,
+            job: AgentHeavyJob::Qm(RunningQmJob {
+                cancel: qm_cancel(std::sync::Arc::clone(&cancel)),
+                receiver: rx,
+                latest_stage: None,
+                cancel_requested: false,
+            }),
+        });
+        (state, cancel)
+    }
+
+    let (mut console_state, console_cancel) = state_with_agent_qm();
+    let console =
+        crate::frontend::console::execute_console_line(&mut console_state, "jobs cancel agent:7")
+            .unwrap();
+
+    let (mut direct_state, direct_cancel) = state_with_agent_qm();
+    let jobs = list_controlled_jobs(&direct_state);
+    let job = jobs.iter().find(|job| job.id.token() == "agent:7").cloned();
+    let outcome = cancel_controlled_job(&mut direct_state, &JobControlId::Agent(7)).unwrap();
+    let direct = format_cancel_outcome_for_job(&outcome, job.as_ref());
+
+    assert_eq!(console, direct);
+    assert!(console.contains("current stage may finish before stopping"));
+    assert!(console_cancel.load(Ordering::Relaxed));
+    assert!(direct_cancel.load(Ordering::Relaxed));
+    assert_eq!(console_state.jobs.agent_jobs.len(), 1);
+    assert_eq!(direct_state.jobs.agent_jobs.len(), 1);
+}
+
+#[test]
+fn task_monitor_action_and_assistant_cancel_have_same_agent_job_effect() {
+    fn state_with_agent_qm() -> (
+        crate::frontend::state::AppState,
+        std::sync::Arc<std::sync::atomic::AtomicBool>,
+        u64,
+    ) {
+        let mut state = crate::frontend::state::AppState::scratch(Default::default(), Vec::new());
+        let (_tx, rx) = std::sync::mpsc::channel();
+        let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let controller = crate::backend::tasks::task_controller_by_id("qm-optimize")
+            .copied()
+            .unwrap();
+        let task_run_id = state.tasks.create_task_run(controller);
+        state
+            .tasks
+            .mark_status(task_run_id, crate::backend::tasks::TaskStatus::Running);
+        state.jobs.agent_jobs.push(TrackedAgentJob {
+            id: 7,
+            conversation: state.ui.agent.active_conversation,
+            label: "qm optimize".to_string(),
+            task_run_id,
+            job: AgentHeavyJob::Qm(RunningQmJob {
+                cancel: qm_cancel(std::sync::Arc::clone(&cancel)),
+                receiver: rx,
+                latest_stage: None,
+                cancel_requested: false,
+            }),
+        });
+        (state, cancel, task_run_id)
+    }
+
+    let ctx = eframe::egui::Context::default();
+    let (mut monitor_state, monitor_cancel, monitor_task) = state_with_agent_qm();
+    crate::frontend::dispatcher::dispatch(
+        &mut monitor_state,
+        crate::frontend::actions::AppAction::CancelControlledJob(JobControlId::Agent(7)),
+        &ctx,
+    );
+
+    let (mut assistant_state, assistant_cancel, assistant_task) = state_with_agent_qm();
+    let outcome = crate::frontend::agent::tools::execute_tool(
+        &mut assistant_state,
+        &crate::io::llm::types::ToolCall {
+            id: "cancel".into(),
+            name: "cancel_job".into(),
+            input: serde_json::json!({ "id": "agent:7" }),
+        },
+    );
+
+    assert!(monitor_cancel.load(Ordering::Relaxed));
+    assert!(assistant_cancel.load(Ordering::Relaxed));
+    assert_eq!(monitor_state.jobs.agent_jobs.len(), 1);
+    assert_eq!(assistant_state.jobs.agent_jobs.len(), 1);
+    assert_eq!(
+        monitor_state.tasks.task_run(monitor_task).unwrap().status,
+        crate::backend::tasks::TaskStatus::Cancelling
+    );
+    assert_eq!(
+        assistant_state
+            .tasks
+            .task_run(assistant_task)
+            .unwrap()
+            .status,
+        crate::backend::tasks::TaskStatus::Cancelling
+    );
+    assert_eq!(monitor_state.message, outcome.content);
+}
+
+fn remote_row(
+    run_uuid: &str,
+    status: crate::backend::storage::jobs::RemoteJobStatus,
+) -> crate::backend::storage::jobs::RemoteJob {
+    crate::backend::storage::jobs::RemoteJob {
+        run_uuid: run_uuid.to_string(),
+        host_id: "hpc".to_string(),
+        host_label: "Cluster".to_string(),
+        remote_dir: format!("~/.silicolab/runs/{run_uuid}"),
+        scheduler: "direct".to_string(),
+        launch_handle: "12345".to_string(),
+        engine_id: "hartree".to_string(),
+        job_kind: "qm-energy".to_string(),
+        project_root: Some("/work/proj".to_string()),
+        local_run_dir: "/tmp/run".to_string(),
+        status,
+        submitted_at_ms: 1000,
+        last_polled_at_ms: None,
+        exit_code: None,
+    }
 }

--- a/src/frontend/qm_commands.rs
+++ b/src/frontend/qm_commands.rs
@@ -58,6 +58,12 @@ pub fn qm_command(state: &mut AppState, args: &[String]) -> Result<String> {
     if sub == "recommend" {
         return qm_recommend(&args[1..]);
     }
+    if sub == "status" {
+        return Ok(crate::frontend::jobs::qm_jobs_status(state));
+    }
+    if sub == "cancel" {
+        return crate::frontend::jobs::cancel_qm_job_alias(state);
+    }
     // `qm periodic` runs a periodic (crystalline) single point on the active
     // unit cell — a distinct option set from the molecular subcommands.
     if sub == "periodic" {
@@ -71,7 +77,7 @@ pub fn qm_command(state: &mut AppState, args: &[String]) -> Result<String> {
         other => {
             bail!(
                 "unknown qm subcommand `{other}` \
-                 (expected energy, optimize, freq, ts, periodic, or recommend)"
+                 (expected energy, optimize, freq, ts, periodic, recommend, status, or cancel)"
             )
         }
     };

--- a/src/frontend/state/app.rs
+++ b/src/frontend/state/app.rs
@@ -502,11 +502,16 @@ impl AppState {
     }
 
     pub fn cancel_transient_jobs(&mut self) {
-        self.jobs.cancel_optimization();
-        self.jobs.cancel_disorder();
-        self.jobs.cancel_qm();
-        self.jobs.cancel_docking();
-        self.jobs.cancel_engine();
+        use crate::frontend::jobs::{JobControlId, LocalJobSlot, cancel_controlled_job};
+        for slot in [
+            LocalJobSlot::Optimizer,
+            LocalJobSlot::Disorder,
+            LocalJobSlot::Qm,
+            LocalJobSlot::Docking,
+            LocalJobSlot::Engine,
+        ] {
+            let _ = cancel_controlled_job(self, &JobControlId::Local(slot));
+        }
     }
 
     pub fn reset_layout_keep_view(&mut self) {

--- a/src/frontend/ui/panel_bodies/assistant.rs
+++ b/src/frontend/ui/panel_bodies/assistant.rs
@@ -48,14 +48,23 @@ pub(crate) fn render_assistant_panel(
         .iter()
         .map(|item| item.preview().to_string())
         .collect();
-    // Background jobs running for the active conversation. Tagged jobs from other
-    // conversations stay hidden.
-    let running_jobs: Vec<(u64, String, u64)> = state
+    // Background jobs running for the active conversation. Build this from the
+    // unified snapshot, then filter by the conversation-owned agent ids.
+    let active_agent_ids: std::collections::HashSet<u64> = state
         .jobs
         .agent_jobs
         .iter()
         .filter(|job| job.conversation == active_id)
-        .map(|job| (job.id, job.label.clone(), job.task_run_id))
+        .map(|job| job.id)
+        .collect();
+    let running_jobs: Vec<crate::frontend::jobs::LiveJobSnapshot> = state
+        .jobs
+        .list_live_snapshots(state.active_task_run)
+        .into_iter()
+        .filter(|job| match job.id {
+            crate::frontend::jobs::JobControlId::Agent(id) => active_agent_ids.contains(&id),
+            _ => false,
+        })
         .collect();
 
     let panel_rect = ui.available_rect_before_wrap();

--- a/src/frontend/ui/panel_bodies/assistant_composer.rs
+++ b/src/frontend/ui/panel_bodies/assistant_composer.rs
@@ -15,7 +15,7 @@ const MAX_QUEUED_SHOWN: usize = 4;
 
 /// Reserved height for the running-jobs strip (0 when there are none). Shared with
 /// the panel so the transcript above can be sized before this strip is drawn.
-pub(crate) fn running_strip_height(running_jobs: &[(u64, String, u64)]) -> f32 {
+pub(crate) fn running_strip_height(running_jobs: &[crate::frontend::jobs::LiveJobSnapshot]) -> f32 {
     if running_jobs.is_empty() {
         0.0
     } else {
@@ -47,7 +47,7 @@ pub(crate) fn render_assistant_composer(
     ui: &mut egui::Ui,
     actions: &mut Vec<AppAction>,
     pal: &Palette,
-    running_jobs: &[(u64, String, u64)],
+    running_jobs: &[crate::frontend::jobs::LiveJobSnapshot],
     queued: &[String],
 ) {
     let busy = state.ui.agent.is_busy();
@@ -60,23 +60,25 @@ pub(crate) fn render_assistant_composer(
     if !running_jobs.is_empty() {
         assistant_inset_row(ui, running_height, |ui| {
             ui.spacing_mut().item_spacing.y = 2.0;
-            for (id, label, task_run_id) in running_jobs.iter().take(MAX_QUEUED_SHOWN) {
+            for job in running_jobs.iter().take(MAX_QUEUED_SHOWN) {
                 ui.horizontal(|ui| {
                     if assistant_remove_button(ui, "Cancel job") {
-                        actions.push(AppAction::CancelAgentJob(*id));
+                        actions.push(AppAction::CancelControlledJob(job.id.clone()));
                     }
                     ui.add(egui::Spinner::new().size(12.0));
                     let label_resp = ui.add(
                         egui::Label::new(
-                            RichText::new(format!("#{id}  {label}"))
+                            RichText::new(format!("{}  {}", job.id.token(), job.label))
                                 .small()
                                 .color(pal.text_primary),
                         )
                         .truncate()
                         .sense(egui::Sense::click()),
                     );
-                    if label_resp.on_hover_text("Open in Task Monitor").clicked() {
-                        actions.push(AppAction::OpenTaskPanel(*task_run_id));
+                    if label_resp.on_hover_text("Open in Task Monitor").clicked()
+                        && let Some(task_run_id) = job.task_run_id
+                    {
+                        actions.push(AppAction::OpenTaskPanel(task_run_id));
                     }
                 });
             }

--- a/src/frontend/ui/panel_bodies/task_monitor.rs
+++ b/src/frontend/ui/panel_bodies/task_monitor.rs
@@ -39,8 +39,10 @@ fn task_status_badge(pal: &crate::frontend::theme::Palette, status: TaskStatus) 
         TaskStatus::Ready => pal.status_blue,
         TaskStatus::WaitingInput => pal.status_amber,
         TaskStatus::Running => pal.status_green,
+        TaskStatus::Cancelling => pal.status_amber,
         TaskStatus::Completed => pal.status_green,
         TaskStatus::Failed => pal.status_red,
+        TaskStatus::Cancelled => pal.status_amber,
     };
 
     RichText::new(status.label()).strong().color(color)
@@ -80,7 +82,7 @@ pub(crate) fn render_task_monitor_panel(
     render_active_task_summary(state, ui);
     ui.add_space(8.0);
 
-    render_remote_jobs(state, ui, actions);
+    render_controlled_jobs(state, ui, actions);
 
     if state.tasks.tasks.is_empty() {
         ui.label("No task run yet.");
@@ -220,37 +222,47 @@ pub(crate) fn render_task_monitor_panel(
         });
 }
 
-fn remote_status_badge(
+fn job_status_badge(
     pal: &crate::frontend::theme::Palette,
-    status: crate::backend::storage::jobs::RemoteJobStatus,
-    exit_code: Option<i64>,
+    status: crate::frontend::jobs::JobStatus,
+    remote: bool,
 ) -> RichText {
-    use crate::backend::storage::jobs::RemoteJobStatus;
-    let (label, color) = match status {
-        RemoteJobStatus::Queued => ("Queued", pal.status_blue),
-        RemoteJobStatus::Running => ("Running", pal.status_green),
-        RemoteJobStatus::Done => ("Done", pal.status_green),
-        RemoteJobStatus::Failed => ("Failed", pal.status_red),
-        RemoteJobStatus::Lost => ("Lost", pal.status_amber),
+    let color = match status {
+        crate::frontend::jobs::JobStatus::Queued => pal.status_blue,
+        crate::frontend::jobs::JobStatus::Running => pal.status_green,
+        crate::frontend::jobs::JobStatus::Done => pal.status_green,
+        crate::frontend::jobs::JobStatus::Failed => pal.status_red,
+        crate::frontend::jobs::JobStatus::Cancelling
+        | crate::frontend::jobs::JobStatus::Lost
+        | crate::frontend::jobs::JobStatus::Cancelled => pal.status_amber,
     };
-    let text = match exit_code {
-        Some(code) if code != 0 => format!("{label} ({code})"),
-        _ => label.to_string(),
+    let label = if remote {
+        format!("Last known: {}", status.label())
+    } else {
+        status.label().to_string()
     };
-    RichText::new(text).strong().color(color)
+    RichText::new(label).strong().color(color)
 }
 
-/// The detached remote jobs from the global registry: status, identity, and a
-/// per-row remote-scratch cleanup. Populated by the opt-in refresh, so it
-/// reflects the last probe rather than live state.
-fn render_remote_jobs(state: &AppState, ui: &mut egui::Ui, actions: &mut Vec<AppAction>) {
-    if state.ui.remote_jobs.is_empty() {
+fn render_controlled_jobs(state: &AppState, ui: &mut egui::Ui, actions: &mut Vec<AppAction>) {
+    let jobs = crate::frontend::jobs::list_controlled_jobs(state);
+    if jobs.is_empty() {
         return;
     }
     let pal = crate::frontend::theme::palette(ui);
-    ui.label(RichText::new("Remote Jobs").strong());
+    ui.label(RichText::new("Jobs").strong());
+    if jobs
+        .iter()
+        .any(|job| job.backend == crate::frontend::jobs::JobBackend::RemoteRegistry)
+    {
+        ui.label(
+            RichText::new("Remote status is last-known; use Refresh Remote to probe it.")
+                .small()
+                .color(pal.text_tertiary),
+        );
+    }
     ui.add_space(4.0);
-    for job in &state.ui.remote_jobs {
+    for job in &jobs {
         Frame::group(ui.style())
             .inner_margin(Margin::same(8))
             .show(ui, |ui| {
@@ -258,21 +270,36 @@ fn render_remote_jobs(state: &AppState, ui: &mut egui::Ui, actions: &mut Vec<App
                 ui.horizontal(|ui| {
                     ui.vertical(|ui| {
                         ui.label(
-                            RichText::new(format!("{} · {}", job.host_label, job.job_kind))
-                                .strong(),
+                            RichText::new(format!("{} / {}", job.kind.label(), job.label)).strong(),
                         );
-                        let short = job.run_uuid.get(..8).unwrap_or(job.run_uuid.as_str());
                         ui.label(
-                            RichText::new(format!("{short} · {}", job.engine_id))
-                                .small()
-                                .color(pal.text_tertiary),
+                            RichText::new(format!(
+                                "{} / {}{}",
+                                job.id.token(),
+                                job.backend.label(),
+                                job.stage
+                                    .as_ref()
+                                    .map(|stage| format!(" / {stage}"))
+                                    .unwrap_or_default()
+                            ))
+                            .small()
+                            .color(pal.text_tertiary),
                         );
                     });
                     ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                        if ui.button("Remove scratch").clicked() {
-                            actions.push(AppAction::RemoveRemoteScratch(job.run_uuid.clone()));
+                        if let Some(run_uuid) = job.run_uuid.as_ref()
+                            && ui.button("Remove scratch").clicked()
+                        {
+                            actions.push(AppAction::RemoveRemoteScratch(run_uuid.clone()));
                         }
-                        ui.label(remote_status_badge(&pal, job.status, job.exit_code));
+                        if job.cancel.can_cancel() && ui.button("Cancel").clicked() {
+                            actions.push(AppAction::CancelControlledJob(job.id.clone()));
+                        }
+                        ui.label(job_status_badge(
+                            &pal,
+                            job.status,
+                            job.backend == crate::frontend::jobs::JobBackend::RemoteRegistry,
+                        ));
                     });
                 });
             });


### PR DESCRIPTION
## Summary

Add a shared job control plane for local, assistant, and remote jobs.

This PR introduces unified job snapshots and cancellation by job id, then wires that control path through the console, assistant tools, task monitor, dispatcher cancellation handlers, and transient-job cleanup.

## Changes

- Add unified job identifiers, live job snapshots, status formatting, and cancellation routing
- Add `jobs`, `jobs status`, and `jobs cancel <id>` console commands
- Add assistant-facing `list_jobs` and `cancel_job` tools
- Extend task and remote job statuses with cancelling/cancelled states
- Route local optimization, disorder, QM, docking, and engine cancellation through the shared control plane
- Track QM cancellation with stage-boundary handling and a shared `JobCancelHandle`
- Update the task monitor and assistant running-job strip to use unified job snapshots
- Move agent tool tests into a dedicated test module
- Update feature-addition docs for the new job control path

## Verification

- `cargo pr-check`
