### PR TITLE
feat(agent): add the agent skills subsystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
  "self_update",
  "serde",
  "serde_json",
+ "serde_yml",
  "sha2",
  "ureq",
  "uuid",
@@ -3200,6 +3201,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "linebender_resource_handle"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5275,6 +5286,21 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]

--- a/compute-core/Cargo.toml
+++ b/compute-core/Cargo.toml
@@ -15,6 +15,8 @@ rayon = "1"
 sdfrust = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+# The maintained fork of the archived serde_yaml, API-compatible for our use.
+serde_yml = "0.0.12"
 uuid = { version = "1", features = ["v4"] }
 
 # Networking stack, behind the default-on `network` feature. It pulls a TLS

--- a/compute-core/src/engines/methods/mod.rs
+++ b/compute-core/src/engines/methods/mod.rs
@@ -25,12 +25,12 @@
 
 use std::sync::OnceLock;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::engines::qm::QmMethod;
 
 /// Which engine / command surface a rule applies to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Engine {
     /// Molecular QM (`qm energy|optimize|freq`).
@@ -45,7 +45,7 @@ pub enum Engine {
 
 impl Engine {
     /// The `.sls` verb(s) a rule's commands must start with.
-    fn verbs(self) -> &'static [&'static str] {
+    pub(crate) fn verbs(self) -> &'static [&'static str] {
         match self {
             Engine::Qm | Engine::QmPeriodic => &["qm"],
             Engine::Md => &["md"],
@@ -54,7 +54,7 @@ impl Engine {
     }
 
     /// Section heading in the always-on table.
-    fn heading(self) -> &'static str {
+    pub(crate) fn heading(self) -> &'static str {
         match self {
             Engine::Qm => "Quantum chemistry — molecular (qm energy|optimize|freq)",
             Engine::QmPeriodic => "Quantum chemistry — periodic / crystal (qm periodic)",
@@ -64,7 +64,8 @@ impl Engine {
     }
 
     /// Render order for the table.
-    const ALL: [Engine; 4] = [Engine::Qm, Engine::QmPeriodic, Engine::Md, Engine::Docking];
+    pub(crate) const ALL: [Engine; 4] =
+        [Engine::Qm, Engine::QmPeriodic, Engine::Md, Engine::Docking];
 }
 
 /// One knowledge unit: a situation, the runnable command(s) for it, its
@@ -102,7 +103,7 @@ fn default_true() -> bool {
 
 /// The embedded, parsed core. Immutable after first init (like the engine
 /// registry tables); not mutable global state.
-fn rules() -> &'static [MethodRule] {
+pub(crate) fn rules() -> &'static [MethodRule] {
     static RULES: OnceLock<Vec<MethodRule>> = OnceLock::new();
     RULES.get_or_init(load_embedded)
 }
@@ -125,124 +126,16 @@ fn load_embedded() -> Vec<MethodRule> {
 }
 
 /// The always-on decision table injected into the (cacheable) system prompt.
-/// Holds no volatile state, so the string is byte-stable across turns.
+/// Delegates to the skills manifest over the built-in set, so there is one
+/// renderer. Holds no volatile state, so the string is byte-stable across turns.
 pub fn kb_table() -> String {
-    render_table(rules())
+    crate::skills::skills_manifest(&crate::skills::builtin_skills())
 }
 
-fn render_table(rules: &[MethodRule]) -> String {
-    let mut out = String::from(
-        "Method-selection guide — pick the engine + command for the task, then act. \
-         Reach for QM (`qm …`) for electronic structure, energies, and spectra of \
-         molecules and small systems; MD (`md …`) for dynamics, solvation, and large \
-         flexible systems; docking (`dock …`) for ligand–receptor poses; periodic QM \
-         (`qm periodic`) for crystals. Call the `recommend_method` tool for the full \
-         details/caveats of any line, and `qm recommend <task>` for the curated QM \
-         level of theory.\n",
-    );
-    for engine in Engine::ALL {
-        let group: Vec<&MethodRule> = rules
-            .iter()
-            .filter(|rule| rule.engine == engine && rule.in_table)
-            .collect();
-        if group.is_empty() {
-            continue;
-        }
-        out.push('\n');
-        out.push_str(engine.heading());
-        out.push_str(":\n");
-        for rule in group {
-            out.push_str("- ");
-            out.push_str(&rule.description);
-            out.push('\n');
-            for line in &rule.command {
-                out.push_str("    ");
-                out.push_str(line);
-                out.push('\n');
-            }
-        }
-    }
-    out
-}
-
-/// On-demand guidance for a free-text task: keyword-scores every rule (in-table
-/// and tool-only) and returns the best one or two in full. Backs the read-only
-/// `recommend_method` tool. Never errors; an unmatched task returns the table.
+/// On-demand guidance for a free-text task over the built-in set. Delegates to
+/// the skills lookup, so there is one scorer. Never errors.
 pub fn recommend(task: &str) -> String {
-    let rules = rules();
-    let query = task.to_ascii_lowercase();
-    let terms: Vec<&str> = query
-        .split(|c: char| !c.is_alphanumeric())
-        .filter(|term| term.len() > 2)
-        .collect();
-
-    let mut scored: Vec<(usize, &MethodRule)> = rules
-        .iter()
-        .map(|rule| (score_rule(rule, &terms), rule))
-        .filter(|(score, _)| *score > 0)
-        .collect();
-    scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.name.cmp(&b.1.name)));
-
-    if scored.is_empty() {
-        return format!(
-            "No specific rule matched \u{201c}{task}\u{201d}. The full method-selection \
-             guide:\n\n{}",
-            render_table(rules)
-        );
-    }
-    let mut out = String::new();
-    for (_, rule) in scored.iter().take(2) {
-        out.push_str(&render_detail(rule));
-        out.push('\n');
-    }
-    out.trim_end().to_string()
-}
-
-/// Score a rule against the query terms: an exact trigger match weighs more than
-/// a substring hit in the name/description.
-fn score_rule(rule: &MethodRule, terms: &[&str]) -> usize {
-    let haystack = format!(
-        "{} {} {}",
-        rule.name,
-        rule.description,
-        rule.triggers.join(" ")
-    )
-    .to_ascii_lowercase();
-    terms
-        .iter()
-        .map(|term| {
-            if rule.triggers.iter().any(|tr| tr.eq_ignore_ascii_case(term)) {
-                3
-            } else if haystack.contains(term) {
-                1
-            } else {
-                0
-            }
-        })
-        .sum()
-}
-
-fn render_detail(rule: &MethodRule) -> String {
-    let mut out = format!("## {}\n{}\n", rule.name, rule.description);
-    if !rule.command.is_empty() {
-        out.push_str("run:\n");
-        for line in &rule.command {
-            out.push_str("  ");
-            out.push_str(line);
-            out.push('\n');
-        }
-    }
-    for caveat in &rule.caveats {
-        out.push_str("- caveat: ");
-        out.push_str(caveat);
-        out.push('\n');
-    }
-    if !rule.body.trim().is_empty() {
-        out.push('\n');
-        out.push_str(rule.body.trim());
-        out.push('\n');
-    }
-    out
+    crate::skills::recommend(&crate::skills::builtin_skills(), task)
 }
 
 /// Validate one rule against the **live** engine capabilities. Returns a
@@ -355,7 +248,7 @@ const VETTED_FUNCTIONALS: &[&str] = &[
 /// composite, or a DFT functional on [`VETTED_FUNCTIONALS`] — never the free-text
 /// `Dft(_)` fallback (which `QmMethod::parse` produces for typos, since it never
 /// rejects). A trailing `-d3`/`-d4` dispersion suffix is allowed.
-fn is_vetted_qm_method(token: &str) -> bool {
+pub(crate) fn is_vetted_qm_method(token: &str) -> bool {
     let (method, _dispersion) = QmMethod::parse(token);
     match method {
         QmMethod::Dft(name) => VETTED_FUNCTIONALS
@@ -389,7 +282,7 @@ const VETTED_BASES: &[&str] = &[
     "aug-cc-pvtz",
 ];
 
-fn is_vetted_qm_basis(token: &str) -> bool {
+pub(crate) fn is_vetted_qm_basis(token: &str) -> bool {
     VETTED_BASES
         .iter()
         .any(|basis| basis.eq_ignore_ascii_case(token))

--- a/compute-core/src/lib.rs
+++ b/compute-core/src/lib.rs
@@ -19,5 +19,6 @@ pub mod io;
 pub mod launch;
 pub mod md;
 pub mod payload;
+pub mod skills;
 pub mod wire;
 pub mod workflows;

--- a/compute-core/src/skills/mod.rs
+++ b/compute-core/src/skills/mod.rs
@@ -1,0 +1,528 @@
+//! The unified agent-facing skills subsystem.
+//!
+//! Generalizes the method-selection KB (`engines::methods`) along two axes:
+//! its data can come from disk `SKILL.md` files, not just the compiled-in core;
+//! and a skill is a general domain workflow, not only a method-selection rule.
+//! The built-in KB is folded in as the [`SkillSource::Builtin`] source, so one
+//! validation path, one manifest, and one lookup serve both.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::engines::methods::Engine;
+
+/// Where a loaded skill came from. Governs name-collision precedence
+/// (`Project` > `User` > `Builtin`) and is shown in the manifest for provenance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillSource {
+    Builtin,
+    User,
+    Project,
+}
+
+/// A declared placeholder in a skill's `.sls` command template.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SkillParam {
+    pub name: String,
+    #[serde(default)]
+    pub required: bool,
+}
+
+/// One skill: a discoverable, parameterizable domain workflow. Superset of
+/// [`crate::engines::methods::MethodRule`].
+#[derive(Debug, Clone)]
+pub struct Skill {
+    pub name: String,
+    /// Method-class skills carry an engine; general workflow skills may omit it.
+    pub engine: Option<Engine>,
+    pub description: String,
+    pub triggers: Vec<String>,
+    pub params: Vec<SkillParam>,
+    pub command: Vec<String>,
+    pub caveats: Vec<String>,
+    pub body: String,
+    pub in_table: bool,
+    pub source: SkillSource,
+}
+
+/// The `SKILL.md` YAML frontmatter. Deserialized on load, serialized on save.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct Frontmatter {
+    name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    engine: Option<Engine>,
+    description: String,
+    #[serde(default)]
+    triggers: Vec<String>,
+    #[serde(default)]
+    params: Vec<SkillParam>,
+    #[serde(default)]
+    command: Vec<String>,
+    #[serde(default)]
+    caveats: Vec<String>,
+    #[serde(default = "default_true")]
+    in_table: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Parse a `SKILL.md` document (YAML frontmatter fenced by `---`, then a
+/// markdown body) into a [`Skill`]. Returns a human-readable error on a missing
+/// fence or a YAML parse failure.
+pub fn parse_skill_md(text: &str, source: SkillSource) -> Result<Skill, String> {
+    let rest = text
+        .strip_prefix("---")
+        .ok_or("missing YAML frontmatter fence")?;
+    let rest = rest
+        .strip_prefix("\r\n")
+        .or_else(|| rest.strip_prefix('\n'))
+        .unwrap_or(rest);
+    let end = rest.find("\n---").ok_or("unterminated YAML frontmatter")?;
+    let yaml = &rest[..end];
+    let after = &rest[end + "\n---".len()..];
+    let body = after
+        .strip_prefix("\r\n")
+        .or_else(|| after.strip_prefix('\n'))
+        .unwrap_or(after);
+    let fm: Frontmatter =
+        serde_yml::from_str(yaml).map_err(|err| format!("frontmatter parse error: {err}"))?;
+    Ok(Skill {
+        name: fm.name,
+        engine: fm.engine,
+        description: fm.description,
+        triggers: fm.triggers,
+        params: fm.params,
+        command: fm.command,
+        caveats: fm.caveats,
+        body: body.trim_end().to_string(),
+        in_table: fm.in_table,
+        source,
+    })
+}
+
+/// The compiled-in method KB, lifted into [`Skill`] values under
+/// [`SkillSource::Builtin`]. Phase 1 keeps the KB as the built-in source; a later
+/// phase migrates it to on-disk `SKILL.md` files.
+pub fn builtin_skills() -> Vec<Skill> {
+    crate::engines::methods::rules()
+        .iter()
+        .map(|rule| Skill {
+            name: rule.name.clone(),
+            engine: Some(rule.engine),
+            description: rule.description.clone(),
+            triggers: rule.triggers.clone(),
+            params: Vec::new(),
+            command: rule.command.clone(),
+            caveats: rule.caveats.clone(),
+            body: rule.body.clone(),
+            in_table: rule.in_table,
+            source: SkillSource::Builtin,
+        })
+        .collect()
+}
+
+/// Validate a skill against the safety floor, generalizing
+/// [`crate::engines::methods::validate_rule`]. Structural checks plus, for
+/// engine-bearing skills, the same `--method`/`--basis` vetting the built-in KB
+/// uses. This does NOT parse the `.sls` grammar — that check lives in the crate
+/// that owns the grammar (see the `silicolab` skills bridge).
+pub fn validate_skill(skill: &Skill) -> Result<(), String> {
+    let name = &skill.name;
+    if name.is_empty()
+        || name.len() > 64
+        || !name
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        return Err(format!(
+            "skill name `{name}` must be kebab-case, 1..=64 chars"
+        ));
+    }
+    if skill.description.trim().is_empty() || skill.description.chars().count() > 200 {
+        return Err(format!("{name}: description must be 1..=200 chars"));
+    }
+    if skill.triggers.is_empty() {
+        return Err(format!("{name}: needs at least one trigger keyword"));
+    }
+    let declared: HashSet<&str> = skill.params.iter().map(|p| p.name.as_str()).collect();
+    let mut pins_method_or_basis = false;
+    for line in &skill.command {
+        for placeholder in placeholders(line) {
+            if !declared.contains(placeholder.as_str()) {
+                return Err(format!(
+                    "{name}: command references undeclared placeholder `{{{placeholder}}}`"
+                ));
+            }
+        }
+        pins_method_or_basis |= validate_command_line(skill, line)?;
+    }
+    if skill.engine == Some(Engine::Qm) && pins_method_or_basis && skill.caveats.is_empty() {
+        return Err(format!(
+            "{name}: a QM skill that pins --method/--basis must carry at least one caveat"
+        ));
+    }
+    Ok(())
+}
+
+/// Validate one command line; returns whether it pins a `--method`/`--basis`.
+fn validate_command_line(skill: &Skill, command: &str) -> Result<bool, String> {
+    let tokens: Vec<&str> = command.split_whitespace().collect();
+    let verb = tokens.first().copied().unwrap_or_default();
+    if let Some(engine) = skill.engine
+        && !engine.verbs().contains(&verb)
+    {
+        return Err(format!(
+            "{}: command `{command}` starts with `{verb}`, invalid for engine {:?}",
+            skill.name, engine
+        ));
+    }
+    let mut pins = false;
+    let mut index = 0;
+    while index < tokens.len() {
+        let flag = tokens[index];
+        if flag == "--method" || flag == "--basis" {
+            pins = true;
+            if skill.engine.is_none() {
+                return Err(format!(
+                    "{}: an engine-agnostic skill may not pin `{flag}` (no engine to vet against)",
+                    skill.name
+                ));
+            }
+            let value = tokens.get(index + 1).copied().unwrap_or_default();
+            // A placeholder value is chosen at run time; it can't be vetted here.
+            if skill.engine == Some(Engine::Qm) && !is_placeholder(value) {
+                let vetted = if flag == "--method" {
+                    crate::engines::methods::is_vetted_qm_method(value)
+                } else {
+                    crate::engines::methods::is_vetted_qm_basis(value)
+                };
+                if !vetted {
+                    return Err(format!(
+                        "{}: `{flag} {value}` is not on the vetted list",
+                        skill.name
+                    ));
+                }
+            }
+            index += 2;
+        } else {
+            index += 1;
+        }
+    }
+    Ok(pins)
+}
+
+fn is_placeholder(token: &str) -> bool {
+    token.starts_with('{') && token.ends_with('}') && token.len() >= 2
+}
+
+/// Extract the `{name}` placeholder names referenced in a command line.
+fn placeholders(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = line.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'{'
+            && let Some(close) = line[index + 1..].find('}')
+        {
+            let name = &line[index + 1..index + 1 + close];
+            if !name.is_empty() {
+                out.push(name.to_string());
+            }
+            index = index + 1 + close + 1;
+            continue;
+        }
+        index += 1;
+    }
+    out
+}
+
+/// The always-on decision manifest injected into the (cacheable) system prompt.
+/// Generalizes [`crate::engines::methods::kb_table`]: engine-bearing skills are
+/// grouped under their engine heading; engine-agnostic skills under "Workflows".
+/// Only `in_table` skills appear, keeping the per-turn cost bounded. Non-builtin
+/// skills are annotated with their source for provenance.
+pub fn skills_manifest(skills: &[Skill]) -> String {
+    // The manifest is spliced into every system prompt, so its size must stay
+    // bounded no matter how many `in_table` skills are loaded from disk. Enforce
+    // the same budget the prompt was designed around at render time; the long
+    // tail that does not fit is dropped with a pointer to `recommend_method`.
+    const MAX_LINES: usize = 100;
+    const MAX_CHARS: usize = 6000;
+    // Reserve headroom for the one-line overflow tail so the final string is
+    // guaranteed to stay strictly within the budget.
+    const SOFT_LINES: usize = MAX_LINES - 2;
+    const SOFT_CHARS: usize = MAX_CHARS - 120;
+
+    let mut out = String::from(
+        "Skills — method guidance and reusable workflows: pick one and fill its \
+         template, then act. Reach for QM (`qm …`) for electronic structure, \
+         energies, and spectra of molecules and small systems; MD (`md …`) for \
+         dynamics, solvation, and large flexible systems; docking (`dock …`) for \
+         ligand–receptor poses; periodic QM (`qm periodic`) for crystals. Call the \
+         `recommend_method` tool for the full details/caveats of any line, and \
+         `qm recommend <task>` for the curated QM level of theory.\n",
+    );
+
+    // Ordered sections: one per engine (built-in KB + engine-tagged skills), then
+    // engine-agnostic workflows last, so truncation drops the tail — not the core
+    // method guidance.
+    let mut sections: Vec<(String, Vec<&Skill>)> = Vec::new();
+    for engine in Engine::ALL {
+        let group: Vec<&Skill> = skills
+            .iter()
+            .filter(|s| s.engine == Some(engine) && s.in_table)
+            .collect();
+        if !group.is_empty() {
+            sections.push((format!("{}:", engine.heading()), group));
+        }
+    }
+    let workflows: Vec<&Skill> = skills
+        .iter()
+        .filter(|s| s.engine.is_none() && s.in_table)
+        .collect();
+    if !workflows.is_empty() {
+        sections.push(("Workflows:".to_string(), workflows));
+    }
+    let total: usize = sections.iter().map(|(_, group)| group.len()).sum();
+
+    let mut emitted = 0usize;
+    for (heading, group) in &sections {
+        let mut heading_written = false;
+        for skill in group {
+            // Format the entry (plus its heading, if this is the section's first)
+            // into a chunk, then check the projected size before committing it.
+            let mut chunk = String::new();
+            if !heading_written {
+                chunk.push('\n');
+                chunk.push_str(heading);
+                chunk.push('\n');
+            }
+            write_manifest_entry(&mut chunk, skill);
+
+            let projected_chars = out.chars().count() + chunk.chars().count();
+            let projected_lines = count_lines(&out) + count_lines(&chunk);
+            // Always emit at least one entry so the core is never empty; past
+            // that, stop before the soft budget and append the overflow tail.
+            // The unconditional first entry stays within the hard budget because
+            // `write_manifest_entry` clamps each entry on its own.
+            if emitted > 0 && (projected_chars > SOFT_CHARS || projected_lines > SOFT_LINES) {
+                let remaining = total - emitted;
+                out.push_str(&format!(
+                    "… +{remaining} more — use recommend_method to surface them.\n"
+                ));
+                return out;
+            }
+            out.push_str(&chunk);
+            heading_written = true;
+            emitted += 1;
+        }
+    }
+    out
+}
+
+/// Count the newline-terminated lines in `s`. For the manifest — whose every
+/// line ends in `\n` — this matches `str::lines().count()`, the metric the
+/// budget test asserts against.
+fn count_lines(s: &str) -> usize {
+    s.bytes().filter(|&b| b == b'\n').count()
+}
+
+fn write_manifest_entry(out: &mut String, skill: &Skill) {
+    // Per-entry bounds. `skills_manifest` always emits the first entry even
+    // when it alone would blow the soft budget (the manifest must never be
+    // empty), so a single pathological `in_table` skill has to be clamped
+    // here for the hard budget to hold.
+    const MAX_ENTRY_LINES: usize = 12;
+    const MAX_ENTRY_CHARS: usize = 1200;
+
+    let mut entry = String::from("- ");
+    // Validation caps descriptions at 200 chars, but the manifest must stay
+    // bounded even for skills that never went through `validate_skill`.
+    for c in skill.description.chars().take(200) {
+        entry.push(if c == '\n' { ' ' } else { c });
+    }
+    match skill.source {
+        SkillSource::Builtin => {}
+        SkillSource::User => entry.push_str(" [user]"),
+        SkillSource::Project => entry.push_str(" [project]"),
+    }
+    entry.push('\n');
+    for line in &skill.command {
+        let projected_chars = entry.chars().count() + line.chars().count() + 5;
+        let projected_lines = count_lines(&entry) + 1 + line.matches('\n').count();
+        if projected_chars > MAX_ENTRY_CHARS || projected_lines > MAX_ENTRY_LINES {
+            entry.push_str("    … (recommend_method has the full template)\n");
+            break;
+        }
+        entry.push_str("    ");
+        entry.push_str(line);
+        entry.push('\n');
+    }
+    out.push_str(&entry);
+}
+
+/// On-demand guidance for a free-text task: keyword-scores every skill and
+/// returns the best one or two in full. Generalizes
+/// [`crate::engines::methods::recommend`]. Never errors; an unmatched task
+/// returns the full manifest.
+pub fn recommend(skills: &[Skill], task: &str) -> String {
+    let query = task.to_ascii_lowercase();
+    let terms: Vec<&str> = query
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|term| term.len() > 2)
+        .collect();
+
+    let mut scored: Vec<(usize, &Skill)> = skills
+        .iter()
+        .map(|skill| (score_skill(skill, &terms), skill))
+        .filter(|(score, _)| *score > 0)
+        .collect();
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.name.cmp(&b.1.name)));
+
+    if scored.is_empty() {
+        return format!(
+            "No specific skill matched \u{201c}{task}\u{201d}. The full guide:\n\n{}",
+            skills_manifest(skills)
+        );
+    }
+    let mut out = String::new();
+    for (_, skill) in scored.iter().take(2) {
+        out.push_str(&render_detail(skill));
+        out.push('\n');
+    }
+    out.trim_end().to_string()
+}
+
+fn score_skill(skill: &Skill, terms: &[&str]) -> usize {
+    let haystack = format!(
+        "{} {} {}",
+        skill.name,
+        skill.description,
+        skill.triggers.join(" ")
+    )
+    .to_ascii_lowercase();
+    terms
+        .iter()
+        .map(|term| {
+            if skill
+                .triggers
+                .iter()
+                .any(|tr| tr.eq_ignore_ascii_case(term))
+            {
+                3
+            } else if haystack.contains(term) {
+                1
+            } else {
+                0
+            }
+        })
+        .sum()
+}
+
+fn render_detail(skill: &Skill) -> String {
+    let mut out = format!("## {}\n{}\n", skill.name, skill.description);
+    if !skill.params.is_empty() {
+        out.push_str("params: ");
+        let names: Vec<String> = skill
+            .params
+            .iter()
+            .map(|p| {
+                if p.required {
+                    format!("{} (required)", p.name)
+                } else {
+                    p.name.clone()
+                }
+            })
+            .collect();
+        out.push_str(&names.join(", "));
+        out.push('\n');
+    }
+    if !skill.command.is_empty() {
+        out.push_str("run:\n");
+        for line in &skill.command {
+            out.push_str("  ");
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    for caveat in &skill.caveats {
+        out.push_str("- caveat: ");
+        out.push_str(caveat);
+        out.push('\n');
+    }
+    if !skill.body.trim().is_empty() {
+        out.push('\n');
+        out.push_str(skill.body.trim());
+        out.push('\n');
+    }
+    out
+}
+
+/// Load skills from all sources, merged with precedence
+/// `Project` > `User` > `Builtin`. Each source directory is scanned for
+/// `<name>/SKILL.md` files. A file that fails to parse or validate is skipped
+/// with a warning (never a panic). The built-in KB is always included.
+pub fn load_skills(user_dir: Option<&Path>, project_dir: Option<&Path>) -> Vec<Skill> {
+    use std::collections::BTreeMap;
+    // BTreeMap keyed by name gives a stable, sorted order and last-write-wins.
+    let mut by_name: BTreeMap<String, Skill> = BTreeMap::new();
+    for skill in builtin_skills() {
+        by_name.insert(skill.name.clone(), skill);
+    }
+    if let Some(dir) = user_dir {
+        for skill in scan_dir(dir, SkillSource::User) {
+            by_name.insert(skill.name.clone(), skill);
+        }
+    }
+    if let Some(dir) = project_dir {
+        for skill in scan_dir(dir, SkillSource::Project) {
+            by_name.insert(skill.name.clone(), skill);
+        }
+    }
+    by_name.into_values().collect()
+}
+
+/// Scan one source directory for `<name>/SKILL.md`, parsing and validating each.
+/// Invalid entries are logged and skipped.
+fn scan_dir(dir: &Path, source: SkillSource) -> Vec<Skill> {
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return out, // missing dir is normal, not an error
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                eprintln!("skills: skipping unreadable dir entry: {err}");
+                continue;
+            }
+        };
+        let path = entry.path().join("SKILL.md");
+        if !path.is_file() {
+            continue;
+        }
+        let text = match std::fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(err) => {
+                eprintln!("skills: could not read {}: {err}", path.display());
+                continue;
+            }
+        };
+        match parse_skill_md(&text, source) {
+            Ok(skill) => match validate_skill(&skill) {
+                Ok(()) => out.push(skill),
+                Err(reason) => eprintln!("skills: skipping {}: {reason}", path.display()),
+            },
+            Err(reason) => eprintln!("skills: skipping {}: {reason}", path.display()),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/compute-core/src/skills/mod.rs
+++ b/compute-core/src/skills/mod.rs
@@ -219,8 +219,12 @@ fn is_placeholder(token: &str) -> bool {
     token.starts_with('{') && token.ends_with('}') && token.len() >= 2
 }
 
-/// Extract the `{name}` placeholder names referenced in a command line.
-fn placeholders(line: &str) -> Vec<String> {
+/// Byte spans (brace-inclusive) of every `{…}` group in a command line — the
+/// one scanner behind [`placeholders`] and [`substitute_placeholders`], so
+/// extraction and substitution cannot drift apart. Scanning bytes is safe:
+/// `{` and `}` are ASCII, so they never match inside a multi-byte char, and
+/// every span boundary lands on a char boundary.
+fn placeholder_spans(line: &str) -> Vec<(usize, usize)> {
     let mut out = Vec::new();
     let bytes = line.as_bytes();
     let mut index = 0;
@@ -228,15 +232,40 @@ fn placeholders(line: &str) -> Vec<String> {
         if bytes[index] == b'{'
             && let Some(close) = line[index + 1..].find('}')
         {
-            let name = &line[index + 1..index + 1 + close];
-            if !name.is_empty() {
-                out.push(name.to_string());
-            }
-            index = index + 1 + close + 1;
+            let end = index + 1 + close + 1;
+            out.push((index, end));
+            index = end;
             continue;
         }
         index += 1;
     }
+    out
+}
+
+/// Extract the `{name}` placeholder names referenced in a command line.
+/// An empty `{}` group is not a placeholder (there is no name to declare),
+/// though [`substitute_placeholders`] still replaces it.
+fn placeholders(line: &str) -> Vec<String> {
+    placeholder_spans(line)
+        .into_iter()
+        .filter_map(|(start, end)| {
+            let name = &line[start + 1..end - 1];
+            (!name.is_empty()).then(|| name.to_string())
+        })
+        .collect()
+}
+
+/// Replace every `{…}` group in a command line with `value`, copying the
+/// surrounding text through verbatim (multi-byte UTF-8 included).
+pub fn substitute_placeholders(line: &str, value: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut cursor = 0;
+    for (start, end) in placeholder_spans(line) {
+        out.push_str(&line[cursor..start]);
+        out.push_str(value);
+        cursor = end;
+    }
+    out.push_str(&line[cursor..]);
     out
 }
 

--- a/compute-core/src/skills/tests.rs
+++ b/compute-core/src/skills/tests.rs
@@ -368,3 +368,25 @@ fn manifest_clamps_a_single_pathological_entry() {
         "clamped entry must point at recommend_method; got:\n{manifest}"
     );
 }
+
+#[test]
+fn substitute_placeholders_replaces_groups_and_keeps_utf8_intact() {
+    assert_eq!(
+        substitute_placeholders("dock --ligand {ligand}", "0"),
+        "dock --ligand 0"
+    );
+    assert_eq!(
+        substitute_placeholders("translate {dx} {dy} {dz}", "0"),
+        "translate 0 0 0"
+    );
+    // Regression: a byte-cast copy turned "café" into "cafÃ©", making a
+    // placeholder-free line compare unequal to its substituted form.
+    assert_eq!(
+        substitute_placeholders("open café.pdb", "0"),
+        "open café.pdb"
+    );
+    assert_eq!(
+        substitute_placeholders("label {text} — café", "0"),
+        "label 0 — café"
+    );
+}

--- a/compute-core/src/skills/tests.rs
+++ b/compute-core/src/skills/tests.rs
@@ -1,0 +1,370 @@
+use super::*;
+
+#[test]
+fn parses_frontmatter_and_body() {
+    let text = "---\n\
+name: dock-a-ligand\n\
+engine: docking\n\
+description: Dock a ligand into the active receptor.\n\
+triggers: [dock, ligand]\n\
+params:\n\
+  - {name: ligand, required: true}\n\
+command:\n\
+  - \"dock --receptor active --ligand {ligand}\"\n\
+---\n\
+# Dock a ligand\n\
+\n\
+Body text.\n";
+    let skill = parse_skill_md(text, SkillSource::User).expect("parses");
+    assert_eq!(skill.name, "dock-a-ligand");
+    assert_eq!(skill.engine, Some(Engine::Docking));
+    assert_eq!(skill.triggers, vec!["dock", "ligand"]);
+    assert_eq!(skill.params.len(), 1);
+    assert_eq!(skill.params[0].name, "ligand");
+    assert!(skill.params[0].required);
+    assert_eq!(
+        skill.command,
+        vec!["dock --receptor active --ligand {ligand}"]
+    );
+    assert!(skill.body.starts_with("# Dock a ligand"));
+    assert!(skill.in_table, "in_table defaults to true");
+    assert_eq!(skill.source, SkillSource::User);
+}
+
+#[test]
+fn missing_fence_is_an_error() {
+    assert!(parse_skill_md("no frontmatter here", SkillSource::User).is_err());
+}
+
+fn skill(engine: Option<Engine>, command: Vec<&str>, caveats: Vec<&str>) -> Skill {
+    Skill {
+        name: "s".into(),
+        engine,
+        description: "d".into(),
+        triggers: vec!["t".into()],
+        params: vec![],
+        command: command.into_iter().map(str::to_string).collect(),
+        caveats: caveats.into_iter().map(str::to_string).collect(),
+        body: String::new(),
+        in_table: true,
+        source: SkillSource::User,
+    }
+}
+
+#[test]
+fn rejects_bad_name_and_description() {
+    let mut s = skill(None, vec![], vec![]);
+    s.name = "Not Kebab".into();
+    assert!(validate_skill(&s).is_err());
+    let mut s = skill(None, vec![], vec![]);
+    s.description = "x".repeat(201);
+    assert!(validate_skill(&s).is_err());
+    let mut s = skill(None, vec![], vec![]);
+    s.triggers = vec![];
+    assert!(validate_skill(&s).is_err());
+}
+
+#[test]
+fn rejects_unvetted_method_and_missing_caveat() {
+    let bad = skill(
+        Some(Engine::Qm),
+        vec!["qm energy --method notreal"],
+        vec!["c"],
+    );
+    assert!(validate_skill(&bad).is_err());
+    let no_caveat = skill(
+        Some(Engine::Qm),
+        vec!["qm energy --method r2scan-3c"],
+        vec![],
+    );
+    assert!(validate_skill(&no_caveat).is_err());
+    let ok = skill(
+        Some(Engine::Qm),
+        vec!["qm energy --method r2scan-3c"],
+        vec!["slow but accurate"],
+    );
+    assert!(validate_skill(&ok).is_ok());
+}
+
+#[test]
+fn engine_agnostic_may_not_pin_method_but_may_run_commands() {
+    let pins = skill(None, vec!["qm energy --method b3lyp"], vec!["c"]);
+    assert!(
+        validate_skill(&pins).is_err(),
+        "no engine to vet a method against"
+    );
+    let plain = skill(None, vec!["open receptor.pdb"], vec![]);
+    assert!(validate_skill(&plain).is_ok());
+}
+
+#[test]
+fn rejects_undeclared_placeholder() {
+    let mut s = skill(
+        Some(Engine::Docking),
+        vec!["dock --receptor active --ligand {ligand}"],
+        vec![],
+    );
+    s.params = vec![]; // {ligand} not declared
+    assert!(validate_skill(&s).is_err());
+    s.params = vec![SkillParam {
+        name: "ligand".into(),
+        required: true,
+    }];
+    assert!(validate_skill(&s).is_ok());
+}
+
+#[test]
+fn builtin_skills_are_nonempty_and_valid() {
+    let skills = builtin_skills();
+    assert!(!skills.is_empty(), "built-in KB produced no skills");
+    for s in &skills {
+        assert_eq!(s.source, SkillSource::Builtin);
+        assert!(s.engine.is_some(), "every KB rule has an engine");
+        validate_skill(s).unwrap_or_else(|e| panic!("invalid built-in skill: {e}"));
+    }
+}
+
+#[test]
+fn manifest_is_bounded_and_points_at_qm_recommend() {
+    let manifest = skills_manifest(&builtin_skills());
+    assert!(manifest.lines().count() < 100, "manifest exceeds 100 lines");
+    assert!(
+        manifest.chars().count() < 6000,
+        "manifest exceeds 6000 chars"
+    );
+    assert!(manifest.contains("qm recommend"));
+}
+
+#[test]
+fn manifest_budget_holds_for_a_large_disk_skill_set() {
+    // The builtin-only bound test above cannot catch runaway growth from
+    // disk skills, since the live prompt renders `state.ui.agent.skills`.
+    // A big pile of `in_table` skills must still stay within budget: the
+    // manifest truncates the long tail with a pointer to recommend_method.
+    let mut skills: Vec<Skill> = Vec::new();
+    for i in 0..200 {
+        skills.push(Skill {
+            name: format!("workflow-{i:03}"),
+            engine: None,
+            description: format!(
+                "Reusable workflow number {i} for stress-testing the manifest budget."
+            ),
+            triggers: vec![format!("trigger{i}")],
+            params: vec![],
+            command: vec!["representation cartoon".into()],
+            caveats: vec![],
+            body: String::new(),
+            in_table: true,
+            source: SkillSource::User,
+        });
+    }
+    let manifest = skills_manifest(&skills);
+    assert!(
+        manifest.lines().count() < 100,
+        "manifest exceeds 100 lines: {}",
+        manifest.lines().count()
+    );
+    assert!(
+        manifest.chars().count() < 6000,
+        "manifest exceeds 6000 chars: {}",
+        manifest.chars().count()
+    );
+    assert!(
+        manifest.contains("more — use recommend_method"),
+        "overflow must point at recommend_method; got:\n{manifest}"
+    );
+}
+
+#[test]
+fn manifest_groups_workflows_and_annotates_source() {
+    let mut skills = builtin_skills();
+    skills.push(Skill {
+        name: "prep-active-site".into(),
+        engine: None,
+        description: "Prep the active site before docking.".into(),
+        triggers: vec!["prep".into()],
+        params: vec![],
+        command: vec!["representation cartoon".into()],
+        caveats: vec![],
+        body: String::new(),
+        in_table: true,
+        source: SkillSource::Project,
+    });
+    let manifest = skills_manifest(&skills);
+    assert!(
+        manifest.contains("Workflows"),
+        "engine-agnostic skills get a Workflows group"
+    );
+    assert!(
+        manifest.contains("[project]"),
+        "non-builtin skills are annotated with their source"
+    );
+}
+
+#[test]
+fn recommend_matches_triggers_and_never_empty() {
+    let skills = builtin_skills();
+    let out = recommend(&skills, "free energy and thermochemistry of a reaction");
+    assert!(
+        out.to_lowercase().contains("freq") || out.contains("qm recommend"),
+        "got: {out}"
+    );
+    assert!(!recommend(&skills, "zzzzz qqqqq").is_empty());
+}
+
+#[test]
+fn placeholder_method_value_skips_vetting() {
+    let mut s = skill(
+        Some(Engine::Qm),
+        vec!["qm energy --method {method}"],
+        vec!["user picks the method"],
+    );
+    s.params = vec![SkillParam {
+        name: "method".into(),
+        required: true,
+    }];
+    assert!(
+        validate_skill(&s).is_ok(),
+        "a placeholder method can't be vetted at authoring time"
+    );
+}
+
+#[test]
+fn load_merges_sources_with_project_precedence() {
+    let tmp = std::env::temp_dir().join(format!("sl-skills-test-{}", std::process::id()));
+    let user_dir = tmp.join("user");
+    let project_dir = tmp.join("project");
+    let make = |root: &std::path::Path, name: &str, desc: &str| {
+        let dir = root.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        let md = format!(
+            "---\nname: {name}\ndescription: {desc}\ntriggers: [demo]\ncommand:\n  - \"representation cartoon\"\n---\nBody.\n"
+        );
+        std::fs::write(dir.join("SKILL.md"), md).unwrap();
+    };
+    make(&user_dir, "demo-skill", "user version");
+    make(&project_dir, "demo-skill", "project version");
+    make(&user_dir, "user-only", "only in user");
+
+    let skills = load_skills(Some(&user_dir), Some(&project_dir));
+
+    let demo = skills
+        .iter()
+        .find(|s| s.name == "demo-skill")
+        .expect("demo present");
+    assert_eq!(
+        demo.description, "project version",
+        "project overrides user"
+    );
+    assert_eq!(demo.source, SkillSource::Project);
+    assert!(
+        skills.iter().any(|s| s.name == "user-only"),
+        "user-only survives"
+    );
+    assert!(
+        skills.iter().any(|s| s.source == SkillSource::Builtin),
+        "builtin merged in"
+    );
+
+    std::fs::remove_dir_all(&tmp).ok();
+}
+
+#[test]
+fn load_skips_invalid_files_without_panicking() {
+    let tmp = std::env::temp_dir().join(format!("sl-skills-bad-{}", std::process::id()));
+    let user_dir = tmp.join("user");
+    let dir = user_dir.join("broken");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("SKILL.md"), "not valid frontmatter").unwrap();
+    // Should not panic; broken skill simply absent.
+    let skills = load_skills(Some(&user_dir), None);
+    assert!(skills.iter().all(|s| s.name != "broken"));
+    std::fs::remove_dir_all(&tmp).ok();
+}
+
+#[test]
+fn load_skips_files_that_fail_validation() {
+    // Well-formed YAML/all required fields present, so `parse_skill_md`
+    // succeeds; `Bad_Name` is not kebab-case, so `validate_skill` rejects it.
+    // This exercises the DISTINCT `Err` arm from a parse failure.
+    let text = "---\n\
+name: Bad_Name\n\
+description: A skill with a non-kebab-case name.\n\
+triggers: [demo]\n\
+---\n\
+Body.\n";
+
+    // Confirm the fixture genuinely reaches the validate arm before ever
+    // touching disk: parsing must succeed, and validation must fail.
+    let parsed = parse_skill_md(text, SkillSource::User).expect("frontmatter parses successfully");
+    assert_eq!(parsed.name, "Bad_Name");
+    let validation_err = validate_skill(&parsed).expect_err("non-kebab-case name fails validation");
+    assert!(
+        validation_err.contains("kebab-case"),
+        "got: {validation_err}"
+    );
+
+    let tmp = std::env::temp_dir().join(format!(
+        "sl-skills-invalid-validation-{}",
+        std::process::id()
+    ));
+    let user_dir = tmp.join("user");
+    let dir = user_dir.join("bad-name");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("SKILL.md"), text).unwrap();
+
+    // Should not panic; the invalid skill is skipped, leaving only built-ins.
+    let skills = load_skills(Some(&user_dir), None);
+    assert!(skills.iter().all(|s| s.name != "Bad_Name"));
+    assert_eq!(
+        skills.len(),
+        builtin_skills().len(),
+        "only built-ins survive when the sole user skill fails validation"
+    );
+
+    std::fs::remove_dir_all(&tmp).ok();
+}
+
+#[test]
+fn load_with_nonexistent_dir_is_noop() {
+    let tmp = std::env::temp_dir().join(format!("sl-skills-does-not-exist-{}", std::process::id()));
+    // Deliberately do NOT create `tmp`; `Some(&tmp)` must still short-circuit
+    // cleanly through `scan_dir`'s `read_dir` `Err(_) => return out` branch,
+    // not the `None`-guard short-circuit.
+    assert!(!tmp.exists(), "fixture precondition: dir must not exist");
+
+    let skills = load_skills(Some(&tmp), None);
+    assert_eq!(
+        skills.len(),
+        builtin_skills().len(),
+        "a nonexistent dir contributes nothing beyond the built-ins"
+    );
+}
+
+#[test]
+fn manifest_clamps_a_single_pathological_entry() {
+    // The first entry is always emitted even when it alone exceeds the soft
+    // budget (the manifest must never be empty), so the per-entry clamp in
+    // `write_manifest_entry` is what keeps a hand-authored `in_table` skill
+    // with a huge description or template within the hard budget.
+    let mut s = skill(None, vec![], vec![]);
+    s.description = "d".repeat(1000); // far past the validated 200-char cap
+    s.command = (0..500)
+        .map(|i| format!("representation cartoon --entry {i}"))
+        .collect();
+    let manifest = skills_manifest(&[s]);
+    assert!(
+        manifest.lines().count() < 100,
+        "manifest exceeds 100 lines: {}",
+        manifest.lines().count()
+    );
+    assert!(
+        manifest.chars().count() < 6000,
+        "manifest exceeds 6000 chars: {}",
+        manifest.chars().count()
+    );
+    assert!(
+        manifest.contains("recommend_method has the full template"),
+        "clamped entry must point at recommend_method; got:\n{manifest}"
+    );
+}

--- a/src/frontend/agent/loop_driver.rs
+++ b/src/frontend/agent/loop_driver.rs
@@ -51,7 +51,8 @@ in the console). One command per call.
 - `inspect` returns a read-only view of the current workspace.
 - `list_jobs` returns local, assistant, and remote jobs from the unified job control plane.
 - `cancel_job` requests cancellation for a job id returned by `list_jobs`.
-- `save_script` saves a reusable `.sls` workflow of commands to the project.
+- `save_skill` saves a reusable, discoverable skill (a named set of `.sls` command steps) so a \
+workflow can be found again via `recommend_method` and replayed with placeholders filled in.
 
 Working style:
 - Call `inspect` before acting when you are unsure of the current state — never guess \
@@ -97,11 +98,11 @@ The full command catalog and a method-selection guide follow.";
 /// the always-on method-selection table. Holds no volatile per-turn state (that
 /// flows through `inspect`), so it caches; the KB table is built from compiled-in
 /// data and is byte-stable across turns.
-fn system_prompt() -> String {
+fn system_prompt(skills: &[crate::skills::Skill]) -> String {
     format!(
         "{PERSONA}\n\n{}\n\n{}",
         crate::frontend::console::command_catalog(),
-        crate::engines::methods::kb_table()
+        crate::skills::skills_manifest(skills)
     )
 }
 
@@ -142,12 +143,12 @@ fn describe_call(call: &crate::io::llm::types::ToolCall) -> String {
             .and_then(|value| value.as_str())
             .map(|task| format!("recommend_method {task}"))
             .unwrap_or_else(|| "recommend_method".to_string()),
-        "save_script" => call
+        "save_skill" => call
             .input
-            .get("filename")
+            .get("name")
             .and_then(|value| value.as_str())
-            .map(|filename| format!("save_script {filename}"))
-            .unwrap_or_else(|| "save_script".to_string()),
+            .map(|name| format!("save_skill {name}"))
+            .unwrap_or_else(|| "save_skill".to_string()),
         other => other.to_string(),
     }
 }

--- a/src/frontend/agent/loop_driver/tool_batch.rs
+++ b/src/frontend/agent/loop_driver/tool_batch.rs
@@ -66,7 +66,7 @@ pub fn gated_pending(state: &AppState) -> Vec<ToolCall> {
         .collect()
 }
 
-/// In `Plan` mode the doer tools (`run_command`, `save_script`) never execute —
+/// In `Plan` mode the doer tools (`run_command`, `save_skill`) never execute —
 /// each is recorded as a not-run proposal. Read-only perception (`inspect`,
 /// `recommend_method`) still runs, since it changes nothing and the model needs
 /// to see the workspace to propose a grounded plan.
@@ -74,7 +74,7 @@ fn propose_in_plan_mode(state: &mut AppState, ctx: &egui::Context) {
     while let Some(call) = state.ui.agent.pending_calls.pop_front() {
         if matches!(
             call.name.as_str(),
-            "run_command" | "save_script" | "cancel_job"
+            "run_command" | "save_skill" | "cancel_job"
         ) {
             push_tool_call_entry(state, &call);
             let summary = format!(

--- a/src/frontend/agent/loop_driver/turn.rs
+++ b/src/frontend/agent/loop_driver/turn.rs
@@ -95,12 +95,17 @@ pub fn spawn_next_turn(state: &mut AppState, ctx: &egui::Context) {
     let stream = registry::active_provider(&state.config.assistant)
         .caps_for(&state.config.assistant.model)
         .supports_streaming;
+    let project_root = state
+        .workspace
+        .project()
+        .map(|project| project.root.clone());
+    state.ui.agent.ensure_skills_loaded(project_root);
     let cfg = LlmConfig {
         model: state.config.assistant.model.clone(),
         effort: state.config.assistant.effort,
         max_output_tokens: MAX_OUTPUT_TOKENS,
         stream,
-        system: system_prompt(),
+        system: system_prompt(&state.ui.agent.skills),
     };
     let tools = tools::tool_defs();
     let history = state.ui.agent.history.clone();

--- a/src/frontend/agent/mod.rs
+++ b/src/frontend/agent/mod.rs
@@ -6,6 +6,7 @@
 pub mod loop_driver;
 pub mod registry;
 pub mod session;
+mod skills_bridge;
 pub mod tools;
 
 #[cfg(test)]

--- a/src/frontend/agent/session.rs
+++ b/src/frontend/agent/session.rs
@@ -122,7 +122,7 @@ pub struct AssistantConversation {
     /// `tool_result` blocks gathered so far in the current batch; flushed into a
     /// single neutral `Tool` message when the batch completes.
     pub collected_results: Vec<ContentBlock>,
-    /// Command verbs (the top-level name, or `save_script`) the user chose to
+    /// Command verbs (the top-level name, or `save_skill`) the user chose to
     /// auto-allow for the rest of this conversation. Checked before the approval
     /// gate; never overrides the `Destructive` floor.
     pub allowed_verbs: HashSet<String>,
@@ -250,6 +250,12 @@ impl AssistantConversation {
 pub struct AgentSession {
     pub conversations: Vec<AssistantConversation>,
     pub active_conversation: AssistantConversationId,
+    /// Skills available to the agent (built-in + user + project). Loaded lazily
+    /// on the first turn and reloaded after authoring (`save_skill`) or a
+    /// workspace change — project skills are project-scoped, so switching or
+    /// closing a project invalidates this cache (see `invalidate_skills`).
+    pub skills: Vec<crate::skills::Skill>,
+    pub skills_loaded: bool,
     next_conversation_id: u64,
     next_conversation_number: u64,
     pub renaming_conversation: Option<AssistantConversationId>,
@@ -276,6 +282,8 @@ impl Default for AgentSession {
                 "Chat 1".to_string(),
             )],
             active_conversation,
+            skills: Vec::new(),
+            skills_loaded: false,
             next_conversation_id: 2,
             next_conversation_number: 2,
             renaming_conversation: None,
@@ -302,6 +310,27 @@ impl DerefMut for AgentSession {
 }
 
 impl AgentSession {
+    /// Load skills on first use (built-in + user + project). Idempotent.
+    pub fn ensure_skills_loaded(&mut self, project_root: Option<std::path::PathBuf>) {
+        if !self.skills_loaded {
+            self.skills = crate::frontend::agent::skills_bridge::load_agent_skills(project_root);
+            self.skills_loaded = true;
+        }
+    }
+
+    /// Force a reload (e.g. after `save_skill` writes a new file).
+    pub fn reload_skills(&mut self, project_root: Option<std::path::PathBuf>) {
+        self.skills = crate::frontend::agent::skills_bridge::load_agent_skills(project_root);
+        self.skills_loaded = true;
+    }
+
+    /// Drop the loaded-skills cache so the next turn reloads them. Called on
+    /// workspace changes (project open/close/switch): project skills are
+    /// project-scoped, and the reload picks up the new `project_root`.
+    pub fn invalidate_skills(&mut self) {
+        self.skills_loaded = false;
+    }
+
     pub fn active(&self) -> &AssistantConversation {
         self.conversations
             .iter()
@@ -490,6 +519,19 @@ mod tests {
         assert_eq!(session.history.len(), 1);
         assert_eq!(session.transcript.len(), 1);
         assert_eq!(session.input, "draft");
+    }
+
+    #[test]
+    fn invalidate_skills_clears_loaded_flag_so_next_turn_reloads() {
+        let mut session = AgentSession {
+            skills_loaded: true,
+            ..Default::default()
+        };
+        session.invalidate_skills();
+        assert!(
+            !session.skills_loaded,
+            "invalidate_skills must clear the cache so ensure_skills_loaded reloads"
+        );
     }
 
     #[test]

--- a/src/frontend/agent/skills_bridge.rs
+++ b/src/frontend/agent/skills_bridge.rs
@@ -36,7 +36,7 @@ pub fn load_agent_skills(project_root: Option<PathBuf>) -> Vec<Skill> {
 /// land on an enum-constrained slot.
 fn commands_parse(skill: &Skill) -> bool {
     for line in &skill.command {
-        let substituted = substitute_placeholders(line);
+        let substituted = skills::substitute_placeholders(line, "0");
         let has_placeholder = substituted != *line;
         if !has_placeholder && !command_parses(&substituted) {
             eprintln!(
@@ -49,44 +49,9 @@ fn commands_parse(skill: &Skill) -> bool {
     true
 }
 
-/// Replace every `{name}` placeholder with `0` so placeholder-free lines can be
-/// parse-checked, and so numeric-position templates (e.g. `translate {dx} {dy}
-/// {dz}` → `translate 0 0 0`) still parse-check cleanly. `0` is not a universal
-/// stand-in — see [`commands_parse`] — so lines that still contain a
-/// placeholder after substitution are not rejected on parse failure.
-fn substitute_placeholders(line: &str) -> String {
-    let mut out = String::with_capacity(line.len());
-    let bytes = line.as_bytes();
-    let mut index = 0;
-    while index < bytes.len() {
-        if bytes[index] == b'{'
-            && let Some(close) = line[index + 1..].find('}')
-        {
-            out.push('0');
-            index = index + 1 + close + 1;
-            continue;
-        }
-        out.push(bytes[index] as char);
-        index += 1;
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn substitutes_placeholders_with_zero() {
-        assert_eq!(
-            substitute_placeholders("dock --ligand {ligand}"),
-            "dock --ligand 0"
-        );
-        assert_eq!(
-            substitute_placeholders("no placeholders"),
-            "no placeholders"
-        );
-    }
 
     #[test]
     fn builtin_skills_all_parse() {
@@ -137,6 +102,26 @@ mod tests {
         assert!(
             !skills.iter().any(|s| s.name == "frobnicate-thing"),
             "a placeholder-free line with an unknown verb must be dropped"
+        );
+    }
+
+    #[test]
+    fn filters_placeholder_free_utf8_lines_intact() {
+        // Regression: the old byte-cast substitution mangled multi-byte UTF-8
+        // into mojibake, so `substituted != *line` misread any non-ASCII
+        // placeholder-free line as templated and the grammar check never ran.
+        let mut skills = vec![test_skill("frobnicate-cafe", &["frobnicate café"], &[])];
+        skills.retain(commands_parse);
+        assert!(
+            skills.is_empty(),
+            "a non-ASCII placeholder-free line with an unknown verb must be dropped"
+        );
+
+        let mut skills = vec![test_skill("open-cafe", &["open café.pdb"], &[])];
+        skills.retain(commands_parse);
+        assert!(
+            skills.iter().any(|s| s.name == "open-cafe"),
+            "a valid non-ASCII line must survive the filter"
         );
     }
 

--- a/src/frontend/agent/skills_bridge.rs
+++ b/src/frontend/agent/skills_bridge.rs
@@ -1,0 +1,179 @@
+//! GUI-side skills loading. `compute-core` owns the disk loader but cannot parse
+//! the `.sls` grammar (it lives in this crate), so the second-stage grammar
+//! filter — rejecting skills whose command templates don't parse — lives here.
+
+use std::path::PathBuf;
+
+use crate::skills::{self, Skill};
+
+use crate::frontend::console::command_parses;
+
+/// Load skills for the assistant: the built-in KB plus `SKILL.md` files from the
+/// user dir (`~/.silicolab/skills`) and the open project's `skills/` dir, then
+/// drop any whose command templates fail to parse under the `.sls` grammar.
+pub fn load_agent_skills(project_root: Option<PathBuf>) -> Vec<Skill> {
+    let user_dir = crate::hosts::config_dir().join("skills");
+    let project_dir = project_root.map(|root| root.join("skills"));
+    let mut skills = skills::load_skills(Some(&user_dir), project_dir.as_deref());
+    skills.retain(commands_parse);
+    skills
+}
+
+/// Every placeholder-free command line parses.
+///
+/// There is no token that is valid in every argument position: `.sls` grammars
+/// mix free-form string/path/numeric slots (where `0` parses fine) with
+/// enum-constrained slots such as `parse_color_value`, `parse_atom_style`,
+/// `parse_light_preset`, and `parse_surface_style` (where `0` is never a valid
+/// value). So substituting `0` and parse-checking the result can only prove a
+/// negative for lines that carry no placeholder at all — those are checked as
+/// written, and a parse failure there is a real, unconditional grammar error.
+/// A line that does carry a placeholder is *trusted*: `compute-core`'s
+/// `validate_skill` (which every loaded skill has already passed) rejects any
+/// undeclared `{name}`, so the value will come from a real parameter at
+/// runtime, and runtime parsing is the actual backstop. Dropping such a skill
+/// here would silently discard legitimate skills whose templates happen to
+/// land on an enum-constrained slot.
+fn commands_parse(skill: &Skill) -> bool {
+    for line in &skill.command {
+        let substituted = substitute_placeholders(line);
+        let has_placeholder = substituted != *line;
+        if !has_placeholder && !command_parses(&substituted) {
+            eprintln!(
+                "skills: dropping `{}` — placeholder-free command does not parse: {line}",
+                skill.name
+            );
+            return false;
+        }
+    }
+    true
+}
+
+/// Replace every `{name}` placeholder with `0` so placeholder-free lines can be
+/// parse-checked, and so numeric-position templates (e.g. `translate {dx} {dy}
+/// {dz}` → `translate 0 0 0`) still parse-check cleanly. `0` is not a universal
+/// stand-in — see [`commands_parse`] — so lines that still contain a
+/// placeholder after substitution are not rejected on parse failure.
+fn substitute_placeholders(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let bytes = line.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'{'
+            && let Some(close) = line[index + 1..].find('}')
+        {
+            out.push('0');
+            index = index + 1 + close + 1;
+            continue;
+        }
+        out.push(bytes[index] as char);
+        index += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn substitutes_placeholders_with_zero() {
+        assert_eq!(
+            substitute_placeholders("dock --ligand {ligand}"),
+            "dock --ligand 0"
+        );
+        assert_eq!(
+            substitute_placeholders("no placeholders"),
+            "no placeholders"
+        );
+    }
+
+    #[test]
+    fn builtin_skills_all_parse() {
+        // The built-in set must survive the grammar filter unchanged.
+        let loaded = load_agent_skills(None);
+        assert!(
+            loaded
+                .iter()
+                .any(|s| s.source == crate::skills::SkillSource::Builtin)
+        );
+    }
+
+    /// Build a minimal user skill for exercising `commands_parse` directly,
+    /// bypassing disk loading and `validate_skill` (whose invariants — declared
+    /// params matching every `{name}` — the caller is responsible for upholding
+    /// in these literals).
+    fn test_skill(name: &str, command: &[&str], params: &[&str]) -> Skill {
+        Skill {
+            name: name.to_string(),
+            engine: None,
+            description: "a test skill".to_string(),
+            triggers: vec!["test".to_string()],
+            params: params
+                .iter()
+                .map(|name| skills::SkillParam {
+                    name: (*name).to_string(),
+                    required: true,
+                })
+                .collect(),
+            command: command.iter().map(|line| (*line).to_string()).collect(),
+            caveats: Vec::new(),
+            body: String::new(),
+            in_table: true,
+            source: skills::SkillSource::User,
+        }
+    }
+
+    #[test]
+    fn drops_skill_with_unparseable_placeholder_free_command() {
+        // No placeholder in the line, and `frobnicate` is not a console verb —
+        // this is the one case the filter must still definitively reject.
+        let mut skills = vec![test_skill(
+            "frobnicate-thing",
+            &["frobnicate --foo bar"],
+            &[],
+        )];
+        skills.retain(commands_parse);
+        assert!(
+            !skills.iter().any(|s| s.name == "frobnicate-thing"),
+            "a placeholder-free line with an unknown verb must be dropped"
+        );
+    }
+
+    #[test]
+    fn keeps_skill_templating_an_enum_constrained_argument() {
+        // Regression for the over-drop bug: `color chain <id> <color>` is a real
+        // command, but substituting `{color}` with `0` produces `color chain 0
+        // 0`, which `parse_color_value` rejects (it only accepts named colors or
+        // `#rrggbb`). Before the fix this dropped the whole skill; now the
+        // declared placeholder defers to `validate_skill` + runtime parsing, so
+        // the skill must survive.
+        let mut skills = vec![test_skill(
+            "color-chain-by-param",
+            &["color chain {chain} {color}"],
+            &["chain", "color"],
+        )];
+        skills.retain(commands_parse);
+        assert!(
+            skills.iter().any(|s| s.name == "color-chain-by-param"),
+            "a template landing on an enum-constrained slot must survive"
+        );
+    }
+
+    #[test]
+    fn keeps_skill_templating_a_numeric_argument() {
+        // `view size <width> <height>` takes two plain f32 positions, so `0 0`
+        // parses after substitution — this already worked pre-fix and must keep
+        // working.
+        let mut skills = vec![test_skill(
+            "resize-view",
+            &["view size {width} {height}"],
+            &["width", "height"],
+        )];
+        skills.retain(commands_parse);
+        assert!(
+            skills.iter().any(|s| s.name == "resize-view"),
+            "a numeric-position template that parses after `0` substitution must survive"
+        );
+    }
+}

--- a/src/frontend/agent/tools.rs
+++ b/src/frontend/agent/tools.rs
@@ -122,27 +122,61 @@ pub fn tool_defs() -> Vec<ToolDef> {
             }),
         },
         ToolDef {
-            name: "save_script".to_string(),
-            description: "Save a reusable SilicoLab `.sls` script of console commands to the \
-                project so a workflow can be replayed with `run <file>`. Use this to capture a \
-                sequence of steps you ran. Writes a file, so it may need the user's approval \
-                depending on their approval mode."
+            name: "save_skill".to_string(),
+            description: "Save a reusable SilicoLab skill so a workflow can be discovered and \
+                replayed later. A skill is a named set of `.sls` command steps with a short \
+                description and trigger keywords; use `{placeholder}` in a step for a value the \
+                user supplies at run time and declare each in `params`. Saved skills surface \
+                through `recommend_method` on the next turn. Writes a file, so it may need the \
+                user's approval depending on their approval mode."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "filename": {
+                    "name": {
                         "type": "string",
-                        "description": "Script file name (a `.sls` suffix is added if missing). \
-                            No directories — a bare name."
+                        "description": "Kebab-case skill id (letters, digits, dashes), e.g. `dock-a-ligand`."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "One line: what the skill does and when to use it (<= 200 chars)."
+                    },
+                    "triggers": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Keywords that should surface this skill."
                     },
                     "commands": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "One `.sls` command per array element."
+                        "description": "One `.sls` command per element; `{placeholder}` for run-time values."
+                    },
+                    "params": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Placeholder name, without braces, referenced as `{name}` in a command."
+                                },
+                                "required": {
+                                    "type": "boolean",
+                                    "description": "Whether the caller must supply this placeholder at run time."
+                                }
+                            },
+                            "required": ["name"],
+                            "additionalProperties": false
+                        },
+                        "description": "One entry per `{placeholder}` used in `commands`; every placeholder must be declared here."
+                    },
+                    "caveats": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional trade-offs or gotchas."
                     }
                 },
-                "required": ["filename", "commands"],
+                "required": ["name", "description", "triggers", "commands"],
                 "additionalProperties": false
             }),
         },
@@ -155,12 +189,12 @@ pub struct ToolOutcome {
     pub is_error: bool,
 }
 
-/// The approval [`RiskLevel`] of a tool call. `save_script` writes a file
+/// The approval [`RiskLevel`] of a tool call. `save_skill` writes a file
 /// (FileWrite); `run_command` defers to the grammar's [`command_risk`] so risk is
 /// declared once, next to each command; perception tools are read-only.
 pub fn risk_of_call(call: &ToolCall) -> RiskLevel {
     match call.name.as_str() {
-        "save_script" => RiskLevel::FileWrite,
+        "save_skill" => RiskLevel::FileWrite,
         "cancel_job" => RiskLevel::Destructive,
         "run_command" => {
             let command = call
@@ -248,12 +282,17 @@ pub fn execute_tool(state: &mut AppState, call: &ToolCall) -> ToolOutcome {
                 .get("task")
                 .and_then(Value::as_str)
                 .unwrap_or_default();
+            let project_root = state
+                .workspace
+                .project()
+                .map(|project| project.root.clone());
+            state.ui.agent.ensure_skills_loaded(project_root);
             ToolOutcome {
-                content: crate::engines::methods::recommend(task),
+                content: crate::skills::recommend(&state.ui.agent.skills, task),
                 is_error: false,
             }
         }
-        "save_script" => save_script_tool(state, &call.input),
+        "save_skill" => save_skill_tool(state, &call.input),
         other => ToolOutcome {
             content: format!("Unknown tool `{other}`."),
             is_error: true,
@@ -305,61 +344,81 @@ fn cancel_job_tool(state: &mut AppState, id: &str) -> ToolOutcome {
     }
 }
 
-/// Write a `.sls` script of console commands into the project's `scripts/`
-/// directory (or a temp scripts dir in a scratch workspace). The filename is
-/// restricted to a bare name to keep writes inside that directory.
-fn save_script_tool(state: &mut AppState, input: &Value) -> ToolOutcome {
-    let Some(filename) = input.get("filename").and_then(Value::as_str) else {
+/// Write a skill as `<dir>/<name>/SKILL.md` — the project's `skills/` dir when a
+/// project is open, else the user dir (`~/.silicolab/skills/`). Validates before
+/// writing and reloads the session's skills so the new one is discoverable.
+fn save_skill_tool(state: &mut AppState, input: &Value) -> ToolOutcome {
+    let Some(name) = input.get("name").and_then(Value::as_str) else {
         return ToolOutcome {
-            content: "save_script requires a `filename`.".to_string(),
+            content: "save_skill requires a `name`.".to_string(),
             is_error: true,
         };
     };
-    let commands: Vec<String> = match input.get("commands").and_then(Value::as_array) {
-        Some(items) => items
-            .iter()
-            .filter_map(|value| value.as_str().map(str::to_string))
-            .collect(),
-        None => {
+    let Some(description) = input.get("description").and_then(Value::as_str) else {
+        return ToolOutcome {
+            content: "save_skill requires a `description`.".to_string(),
+            is_error: true,
+        };
+    };
+    let triggers = string_array(input, "triggers");
+    let commands = string_array(input, "commands");
+    let caveats = string_array(input, "caveats");
+    let params = param_array(input, "params");
+    if commands.is_empty() {
+        return ToolOutcome {
+            content: "save_skill requires at least one command.".to_string(),
+            is_error: true,
+        };
+    }
+
+    let md = render_skill_md(name, description, &triggers, &commands, &caveats, &params);
+
+    // Validate by round-tripping through the parser + validator before writing.
+    // The write path below is derived from `skill.name` (the parsed/validated
+    // value), never the raw `name` input, so a name that only *looks* safe
+    // after YAML parsing (e.g. truncated by an unquoted `#` comment) can never
+    // steer `dir` outside the skills tree: it either round-trips to the exact
+    // raw string and gets checked by `validate_skill`, or it's rejected here.
+    let skill = match crate::skills::parse_skill_md(&md, crate::skills::SkillSource::User) {
+        Ok(skill) => match crate::skills::validate_skill(&skill) {
+            Ok(()) => skill,
+            Err(reason) => {
+                return ToolOutcome {
+                    content: format!("invalid skill: {reason}"),
+                    is_error: true,
+                };
+            }
+        },
+        Err(reason) => {
             return ToolOutcome {
-                content: "save_script requires a `commands` array.".to_string(),
+                content: format!("invalid skill: {reason}"),
                 is_error: true,
             };
         }
     };
 
-    let name = std::path::Path::new(filename.trim());
-    // Reject any path components — only a bare file name is allowed.
-    if filename.contains(['/', '\\']) || name.file_name() != Some(name.as_os_str()) {
-        return ToolOutcome {
-            content: format!("`{filename}` must be a bare file name (no directories)."),
-            is_error: true,
-        };
-    }
-    let mut file_name = name.to_string_lossy().to_string();
-    if !file_name.to_ascii_lowercase().ends_with(".sls") {
-        file_name.push_str(".sls");
-    }
-
-    let dir = agent_scripts_dir(state);
+    let project_root = state
+        .workspace
+        .project()
+        .map(|project| project.root.clone());
+    let base = project_root
+        .clone()
+        .map(|root| root.join("skills"))
+        .unwrap_or_else(|| crate::hosts::config_dir().join("skills"));
+    let dir = base.join(&skill.name);
     if let Err(error) = std::fs::create_dir_all(&dir) {
         return ToolOutcome {
             content: format!("could not create {}: {error}", dir.display()),
             is_error: true,
         };
     }
-    let path = dir.join(&file_name);
-    let mut body = String::from("# SilicoLab script — generated by the assistant.\n");
-    for command in &commands {
-        body.push_str(command.trim());
-        body.push('\n');
-    }
-    match std::fs::write(&path, body) {
+    let path = dir.join("SKILL.md");
+    match std::fs::write(&path, md) {
         Ok(()) => {
+            state.ui.agent.reload_skills(project_root);
             let summary = format!(
-                "saved {} ({} command(s)); replay with `run {}`",
-                path.display(),
-                commands.len(),
+                "saved skill `{}` to {}; discoverable via recommend_method",
+                skill.name,
                 path.display()
             );
             state.output_log.push(summary.clone());
@@ -375,14 +434,112 @@ fn save_script_tool(state: &mut AppState, input: &Value) -> ToolOutcome {
     }
 }
 
-/// Where agent-authored scripts are written: a `scripts/` dir in the open
-/// project, or a temp fallback in a scratch workspace.
-fn agent_scripts_dir(state: &AppState) -> std::path::PathBuf {
-    state
-        .workspace
-        .project()
-        .map(|project| project.root.join("scripts"))
-        .unwrap_or_else(|| std::env::temp_dir().join("silicolab").join("scripts"))
+/// Collect a JSON string-array field into a `Vec<String>` (missing → empty).
+fn string_array(input: &Value, key: &str) -> Vec<String> {
+    input
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// A declared `{placeholder}`, as read from the tool's `params` input. Mirrors
+/// [`crate::skills::SkillParam`], the shape `render_skill_md` emits and
+/// `parse_skill_md` reads back.
+struct ToolParam {
+    name: String,
+    required: bool,
+}
+
+/// Collect the JSON `params` array into `Vec<ToolParam>` (missing/malformed
+/// entries → skipped; missing key → empty).
+fn param_array(input: &Value, key: &str) -> Vec<ToolParam> {
+    input
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| {
+                    let name = item.get("name")?.as_str()?.to_string();
+                    let required = item
+                        .get("required")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false);
+                    Some(ToolParam { name, required })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Render a `SKILL.md` document from the tool's fields. Every scalar,
+/// including `name`, is routed through [`yaml_scalar`] so the value
+/// `parse_skill_md` reads back matches the raw input exactly (no YAML
+/// comment/special-character truncation can desync the two).
+fn render_skill_md(
+    name: &str,
+    description: &str,
+    triggers: &[String],
+    commands: &[String],
+    caveats: &[String],
+    params: &[ToolParam],
+) -> String {
+    let mut out = String::from("---\n");
+    out.push_str(&format!("name: {}\n", yaml_scalar(name)));
+    out.push_str(&format!("description: {}\n", yaml_scalar(description)));
+    out.push_str("triggers:\n");
+    for t in triggers {
+        out.push_str(&format!("  - {}\n", yaml_scalar(t)));
+    }
+    // Saved skills are lookup-only by default: discoverable via recommend_method
+    // and triggers, but kept out of the always-on system-prompt manifest so a
+    // growing library can't inflate every turn's prompt.
+    out.push_str("in_table: false\n");
+    if !params.is_empty() {
+        out.push_str("params:\n");
+        for p in params {
+            out.push_str(&format!(
+                "  - name: {}\n    required: {}\n",
+                yaml_scalar(&p.name),
+                p.required
+            ));
+        }
+    }
+    out.push_str("command:\n");
+    for c in commands {
+        out.push_str(&format!("  - {}\n", yaml_scalar(c)));
+    }
+    if !caveats.is_empty() {
+        out.push_str("caveats:\n");
+        for c in caveats {
+            out.push_str(&format!("  - {}\n", yaml_scalar(c)));
+        }
+    }
+    out.push_str("---\n");
+    out.push_str(&format!("# {name}\n\nGenerated by the assistant.\n"));
+    out
+}
+
+/// Quote a YAML scalar so special characters (`:`, `{`, `#`, quotes, embedded
+/// newlines/carriage returns) are safe and round-trip exactly.
+fn yaml_scalar(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len() + 2);
+    for c in value.chars() {
+        match c {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            other => escaped.push(other),
+        }
+    }
+    format!("\"{escaped}\"")
 }
 
 /// Run one `.sls` command, echoing it and its result into the shared

--- a/src/frontend/agent/tools/tests.rs
+++ b/src/frontend/agent/tools/tests.rs
@@ -9,11 +9,16 @@ fn call(command: &str) -> ToolCall {
     }
 }
 
-fn save_script_call() -> ToolCall {
+fn save_skill_call() -> ToolCall {
     ToolCall {
         id: "s".to_string(),
-        name: "save_script".to_string(),
-        input: json!({ "filename": "wf", "commands": ["open x.pdb"] }),
+        name: "save_skill".to_string(),
+        input: json!({
+            "name": "demo-skill",
+            "description": "A demo skill for tests.",
+            "triggers": ["demo"],
+            "commands": ["representation cartoon"]
+        }),
     }
 }
 
@@ -50,7 +55,7 @@ fn risk_classification_matches_the_grammar() {
         risk_of_call(&call("save image out.png")),
         RiskLevel::FileWrite
     );
-    assert_eq!(risk_of_call(&save_script_call()), RiskLevel::FileWrite);
+    assert_eq!(risk_of_call(&save_skill_call()), RiskLevel::FileWrite);
     assert_eq!(risk_of_call(&call("md build")), RiskLevel::Expensive);
     assert_eq!(
         risk_of_call(&call("qm energy --method r2scan-3c")),
@@ -116,7 +121,7 @@ fn autosafe_runs_edits_but_gates_writes_compute_and_destructive() {
     assert!(gated("qm energy"));
     assert!(gated("delete chain A"));
     assert!(needs_confirmation(
-        &save_script_call(),
+        &save_skill_call(),
         ApprovalMode::AutoSafe,
         &HashSet::new(),
         &HashSet::new(),
@@ -207,21 +212,249 @@ fn perception_tools_are_never_gated() {
     }
 }
 
-#[test]
-fn save_script_writes_and_rejects_paths() {
+/// Point `state.workspace` at a temp-dir project so `save_skill_tool` writes
+/// under a disposable `skills/` directory instead of the real `~/.silicolab`.
+fn state_with_temp_project(tag: &str) -> (AppState, std::path::PathBuf) {
+    let root = std::env::temp_dir().join(format!(
+        "sl-save-skill-test-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
     let mut state = AppState::scratch(Default::default(), Vec::new());
-    let ok = save_script_tool(
+    state.workspace = crate::backend::project::WorkspaceSession::Project(
+        crate::backend::project::ProjectSession::from_root(root.clone(), "test".to_string()),
+    );
+    (state, root)
+}
+
+/// A workspace change (project open/close/switch) routes through
+/// `reset_transient_state`, which must invalidate the agent's skills cache so
+/// the next turn reloads project-scoped skills for the new root. Without this,
+/// opening a project mid-session leaves its `skills/` undiscovered.
+#[test]
+fn reset_transient_state_invalidates_skills_cache() {
+    let (mut state, root) = state_with_temp_project("skills-invalidate");
+    state.ui.agent.skills_loaded = true;
+    crate::frontend::dispatcher::reset_transient_state(&mut state);
+    assert!(
+        !state.ui.agent.skills_loaded,
+        "workspace change must invalidate the skills cache"
+    );
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn save_skill_writes_valid_and_rejects_invalid() {
+    let (mut state, root) = state_with_temp_project("valid-invalid");
+
+    // Valid skill writes and reports success.
+    let ok = save_skill_tool(
         &mut state,
-        &json!({ "filename": "demo", "commands": ["fetch 4hhb", "color hetero"] }),
+        &json!({
+            "name": "demo-skill",
+            "description": "Set a cartoon representation.",
+            "triggers": ["demo", "cartoon"],
+            "commands": ["representation cartoon"]
+        }),
+    );
+    assert!(!ok.is_error, "valid skill should save: {}", ok.content);
+    let written = root.join("skills").join("demo-skill").join("SKILL.md");
+    assert!(written.is_file(), "expected {} to exist", written.display());
+
+    // The written file round-trips through the parser/validator.
+    let text = std::fs::read_to_string(&written).unwrap();
+    let parsed = crate::skills::parse_skill_md(&text, crate::skills::SkillSource::User)
+        .expect("written SKILL.md parses");
+    crate::skills::validate_skill(&parsed).expect("written skill validates");
+    assert_eq!(parsed.name, "demo-skill");
+    // Saved skills default to lookup-only so they don't inflate the always-on
+    // manifest; they surface through recommend_method / triggers instead.
+    assert!(
+        !parsed.in_table,
+        "saved skills must default to in_table: false"
+    );
+
+    // Invalid: bad name (not kebab-case) is rejected, nothing panics, and no
+    // file is written for it.
+    let bad = save_skill_tool(
+        &mut state,
+        &json!({
+            "name": "Bad Name",
+            "description": "x",
+            "triggers": ["demo"],
+            "commands": ["representation cartoon"]
+        }),
+    );
+    assert!(bad.is_error, "non-kebab name must be rejected");
+    assert!(!root.join("skills").join("Bad Name").exists());
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
+/// Regression for the path-traversal finding: `render_skill_md` used to emit
+/// the `name:` line unquoted, so a value like `good-name #/../../evil` was
+/// truncated by YAML's comment rule to `good-name` when read back — passing
+/// `validate_skill` — while the write path was built from the RAW,
+/// unvalidated input, so `dir = base.join(name)` resolved the `../../` and
+/// escaped the skills tree. `name:` is now quoted via `yaml_scalar` (so the
+/// full raw string round-trips and a non-kebab name is correctly rejected),
+/// and the write path is built from the validated `skill.name`, never the
+/// raw input. Every listed name must be rejected with nothing written
+/// anywhere, in or out of the temp skills tree.
+#[test]
+fn save_skill_rejects_path_traversal_names_and_writes_nothing() {
+    let (mut state, root) = state_with_temp_project("traversal");
+
+    for traversal_name in [
+        "good-name #/../../evil",
+        "../../evil",
+        "Bad Name",
+        "../evil",
+    ] {
+        let result = save_skill_tool(
+            &mut state,
+            &json!({
+                "name": traversal_name,
+                "description": "Attempted path traversal via yaml comment truncation.",
+                "triggers": ["evil"],
+                "commands": ["representation cartoon"]
+            }),
+        );
+        assert!(
+            result.is_error,
+            "traversal-y name `{traversal_name}` must be rejected: {}",
+            result.content
+        );
+
+        // Nothing escaped the temp project root.
+        let outside = root.parent().unwrap().join("evil");
+        assert!(
+            !outside.exists(),
+            "`{traversal_name}` must not write outside the skills tree"
+        );
+    }
+
+    // Nothing was written under the skills dir at all — every attempt failed
+    // validation before any filesystem side effect.
+    let skills_dir = root.join("skills");
+    if skills_dir.exists() {
+        let entries: Vec<_> = std::fs::read_dir(&skills_dir).unwrap().collect();
+        assert!(
+            entries.is_empty(),
+            "skills dir must have no stray entries from rejected names"
+        );
+    }
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
+/// Regression for the `params`/`{placeholder}` finding: the tool description
+/// tells the model to declare placeholders in `params`, but the input schema
+/// had no such property, so `params` was always empty and `validate_skill`
+/// rejected any command referencing a `{placeholder}`. `save_skill` now reads
+/// `params` from the tool input and `render_skill_md` emits a `params:`
+/// block; this must round-trip through `parse_skill_md`/`validate_skill`.
+#[test]
+fn save_skill_with_declared_params_round_trips_placeholder_command() {
+    let (mut state, root) = state_with_temp_project("params");
+
+    let ok = save_skill_tool(
+        &mut state,
+        &json!({
+            "name": "dock-with-params",
+            "description": "Dock a ligand into a receptor using run-time placeholders.",
+            "triggers": ["dock", "ligand"],
+            "commands": ["dock --receptor {receptor} --ligand {ligand}"],
+            "params": [
+                { "name": "receptor", "required": true },
+                { "name": "ligand", "required": true }
+            ]
+        }),
+    );
+    assert!(
+        !ok.is_error,
+        "a skill with declared params for its placeholders should validate and save: {}",
+        ok.content
+    );
+
+    let written = root
+        .join("skills")
+        .join("dock-with-params")
+        .join("SKILL.md");
+    assert!(written.is_file(), "expected {} to exist", written.display());
+
+    let text = std::fs::read_to_string(&written).unwrap();
+    let parsed = crate::skills::parse_skill_md(&text, crate::skills::SkillSource::User)
+        .expect("written SKILL.md parses");
+    crate::skills::validate_skill(&parsed).expect("written skill validates");
+
+    assert_eq!(parsed.params.len(), 2);
+    assert!(
+        parsed
+            .params
+            .iter()
+            .any(|p| p.name == "receptor" && p.required)
+    );
+    assert!(
+        parsed
+            .params
+            .iter()
+            .any(|p| p.name == "ligand" && p.required)
+    );
+    assert_eq!(
+        parsed.command,
+        vec!["dock --receptor {receptor} --ligand {ligand}"]
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn saved_skill_is_discoverable_via_recommend_method() {
+    let (mut state, root) = state_with_temp_project("recommend");
+
+    let ok = save_skill_tool(
+        &mut state,
+        &json!({
+            "name": "quantum-zzyzx-workflow",
+            "description": "A very specific made-up workflow for the test.",
+            "triggers": ["zzyzx"],
+            "commands": ["representation cartoon"]
+        }),
     );
     assert!(!ok.is_error, "expected success: {}", ok.content);
-    assert!(ok.content.contains("demo.sls"));
 
-    let bad = save_script_tool(
-        &mut state,
-        &json!({ "filename": "../evil", "commands": [] }),
+    // save_skill_tool must have reloaded the session's skills.
+    assert!(
+        state
+            .ui
+            .agent
+            .skills
+            .iter()
+            .any(|s| s.name == "quantum-zzyzx-workflow"),
+        "reload_skills should pick up the newly saved skill"
     );
-    assert!(bad.is_error);
+
+    let out = execute_tool(
+        &mut state,
+        &ToolCall {
+            id: "r".into(),
+            name: "recommend_method".into(),
+            input: json!({ "task": "zzyzx" }),
+        },
+    );
+    assert!(!out.is_error);
+    assert!(
+        out.content.contains("quantum-zzyzx-workflow"),
+        "recommend_method should surface the saved skill: {}",
+        out.content
+    );
+
+    std::fs::remove_dir_all(&root).ok();
 }
 
 #[test]

--- a/src/frontend/console/grammar.rs
+++ b/src/frontend/console/grammar.rs
@@ -617,6 +617,26 @@ pub(crate) fn command_risk(command: &str) -> RiskLevel {
     }
 }
 
+/// Whether a raw `.sls` line would be accepted by the console — either a bare
+/// script-path shortcut or a line that parses under the grammar. Used to reject
+/// skill templates that reference a non-existent command or flag at load time
+/// (`command_risk` returns `ReadOnly` on a parse failure, so it can't be used to
+/// detect one).
+///
+/// Caveat: the catch-all verbs (`qm`, `md`, `disorder`) take their tail via
+/// `trailing_var_arg`, so an unknown flag on those verbs still parses here and
+/// only fails when the engine runs the line. This filter guarantees the verb
+/// exists and the line is structurally valid — not that every flag is.
+pub(crate) fn command_parses(command: &str) -> bool {
+    if super::looks_like_script_path(command) {
+        return true;
+    }
+    let Ok(words) = super::shell_words(command) else {
+        return false;
+    };
+    root_command().try_get_matches_from(&words).is_ok()
+}
+
 fn render_clap_error(err: clap::Error) -> Result<String> {
     use clap::error::ErrorKind;
     match err.kind() {
@@ -671,4 +691,22 @@ pub(crate) fn parse_command(words: &[String]) -> std::result::Result<Command, St
     Root::from_arg_matches(&matches)
         .map(|root| root.command)
         .map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod parse_tests {
+    use super::*;
+
+    #[test]
+    fn command_parses_accepts_valid_and_rejects_unknown_verbs() {
+        assert!(command_parses("representation cartoon"));
+        assert!(command_parses("dock --receptor active --ligand 0"));
+        assert!(!command_parses("notacommand --wat"));
+        assert!(!command_parses("frobnicate --foo bar")); // unknown verb -> parse error
+
+        // Catch-all verbs (qm/md/disorder) use trailing_var_arg, so they accept
+        // any tail; command_parses only rejects unknown verbs / structurally-
+        // invalid lines, not unknown flags on these verbs.
+        assert!(command_parses("qm --this-flag-does-not-exist")); // qm's trailing_var_arg accepts any tail
+    }
 }

--- a/src/frontend/dispatcher/project.rs
+++ b/src/frontend/dispatcher/project.rs
@@ -79,6 +79,9 @@ pub(crate) fn reset_transient_state(state: &mut AppState) {
     // project doesn't leave stale (and unreachable) task tabs docked. Fixed-view
     // placement is untouched.
     state.ui.layout.dock.clear_task_tabs();
+    // A workspace change alters which project skills apply; drop the agent's
+    // skills cache so the next turn reloads them for the new `project_root`.
+    state.ui.agent.invalidate_skills();
 }
 
 pub(crate) fn replace_workspace_from_project(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,4 @@ pub mod frontend;
 // and the serializable payload/wire bridge) lives in `compute-core`. Re-export it
 // under the historical module paths so the rest of the app keeps using
 // `crate::domain`, `crate::engines`, etc. unchanged.
-pub use compute_core::{domain, engines, hosts, io, payload, wire, workflows};
+pub use compute_core::{domain, engines, hosts, io, payload, skills, wire, workflows};


### PR DESCRIPTION
## Summary

Add a skills subsystem for the assistant: reusable, discoverable domain workflows defined as `SKILL.md` files, merged with the built-in method KB and rendered into a budget-bounded system-prompt manifest.

## Changes

- Add a `Skill` model, `SKILL.md` frontmatter parser, and `validate_skill` with `--method`/`--basis` vetting and placeholder checks
- Lift the built-in method KB into `Skill` values and route `kb_table`/`recommend` through the shared skills renderer
- Load and merge skills from the user and project directories with project > user > builtin precedence; invalid files are skipped with a warning
- Render an always-on manifest with hard line/char budgets, per-entry clamping, and an overflow pointer to `recommend_method`
- Add `command_parses` and a load-time grammar filter so disk skill templates that reference nonexistent commands are rejected (catch-all verbs validate their flags at run time)
- Replace `save_script` with a discoverable `save_skill` tool: validated by round-tripping through the parser, path-traversal-safe write path, `params` placeholder support
- Reload skills on workspace change so project skills follow the open project
- Swap the archived `serde_yaml` for the maintained `serde_yml` fork

## Verification

- `cargo pr-check`