### PR TITLE
docs: streamline README and expand setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,31 +9,44 @@
 
 <p align="left"><em>Computational environment for chemistry, biology &amp; materials research.</em></p>
 
+<p align="left">
+  <a href="https://silicolab.github.io/silicolab/"><img alt="Documentation" src="https://img.shields.io/badge/docs-silicolab.github.io-2563eb"></a>
+  <a href="https://github.com/silicolab/silicolab/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/silicolab/silicolab/actions/workflows/ci.yml/badge.svg?branch=main"></a>
+  <a href="https://github.com/silicolab/silicolab/actions/workflows/docs.yml"><img alt="Docs" src="https://github.com/silicolab/silicolab/actions/workflows/docs.yml/badge.svg?branch=main"></a>
+  <a href="https://github.com/silicolab/silicolab/releases"><img alt="Release" src="https://img.shields.io/github/v/release/silicolab/silicolab?include_prereleases&sort=semver"></a>
+  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-GPL--3.0--or--later%20OR%20commercial-blue"></a>
+</p>
+
+**Read the [user manual](https://silicolab.github.io/silicolab/) or download a
+prebuilt executable from [GitHub Releases](https://github.com/silicolab/silicolab/releases).**
+
 ![SilicoLab screenshot](docs/images/main-window.png)
 
 ## Features
 
 - Interactive 3D visualization and editing of molecular and crystal structures
-- 2D molecule sketcher â€” draw a molecule (atoms, bonds, ring/fragment templates,
+- 2D molecule sketcher - draw a molecule (atoms, bonds, ring/fragment templates,
   charges) on a canvas and build it into a real 3D structure; also import/export
   SMILES, with a scriptable `sketch <SMILES>` command in the console and CLI
 - Force-field geometry optimization
 - Quantum chemistry calculations
 - Guided molecular dynamics setup and execution (powered by GROMACS)
-- Reticular structure builder â€” assemble COFs and MOFs from building blocks
+- Reticular structure builder - assemble COFs and MOFs from building blocks
 - One scripting language for everything: the same scripts run in the GUI
   console and headless on the CLI, making workflows easy to automate and
   agent-friendly
 
 ## Installation
 
-### Prebuilt Executables
+### Prebuilt executables
 
-Prebuilt executables can be downloaded from GitHub Releases.
+Download prebuilt executables from
+[GitHub Releases](https://github.com/silicolab/silicolab/releases).
 
-### Build from Source
+### Build from source
 
-Install the Rust toolchain, then build the release executable:
+Install the [Rust toolchain](https://rustup.rs), then build the release
+executable:
 
 ```sh
 cargo build --release
@@ -57,59 +70,22 @@ silicolab workflow.sls
 ```
 
 The same scripts also run interactively in the GUI console. The full user
-manual (English and ä¸­æ–‡) lives at <https://silicolab.github.io/silicolab/>.
+manual in English and Chinese lives at <https://silicolab.github.io/silicolab/>.
 
-## External Dependencies
+## External tools
 
-### GROMACS (required for molecular dynamics)
+SilicoLab can run without optional external tools until you use features that
+need them. Molecular dynamics requires GROMACS. Quantum chemistry is available
+through the built-in Hartree engine. See the manual for setup details:
 
-Molecular dynamics simulations require [GROMACS](https://www.gromacs.org/) to be installed separately.
-GPU acceleration is **strongly recommended** â€” running MD on CPU alone is technically possible but prohibitively slow for any non-trivial system.
+- [External tools](https://silicolab.github.io/silicolab/getting-started/external-tools/)
+- [Remote execution over SSH](https://silicolab.github.io/silicolab/getting-started/remote-execution/)
 
-- **Windows:** Install GROMACS inside [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (`sudo apt install gromacs`). For GPU support, compile from source with CUDA inside WSL.
-- **Linux:** `sudo apt install gromacs` for a quick start; compile from source with CUDA/ROCm for GPU acceleration.
-- **macOS:** `brew install gromacs`. Note that GPU acceleration is not supported on Apple hardware, so MD performance will be limited.
+## Development
 
-### Remote execution over SSH (optional)
-
-Heavy compute can be offloaded to a remote Linux machine (an HPC login node, a GPU
-box) while the GUI stays on your laptop. **Quantum chemistry, molecular docking, and
-MD/GROMACS can all run remotely.** SilicoLab drives the OS OpenSSH client
-(`ssh`/`scp`) as subprocesses â€” no extra dependency to install (the OpenSSH client
-ships with macOS/Linux and is an on-by-default optional feature on Windows 11; enable
-it under *Settings â†’ Apps â†’ Optional features â†’ OpenSSH Client* if it is missing). On
-first use SilicoLab deploys a small self-contained worker to the host (pinned to the
-app version and verified against its published checksum before it runs).
-
-**Set up a host** in *Settings â†’ Engines â†’ Remote Hosts*:
-
-1. **Add host** â€” give it a label, hostname/IP, username, and (optionally) a port
-   and a remote work directory (defaults to `~/.silicolab`). Under *Setup commands*
-   put whatever a fresh, non-interactive SSH shell needs to make `gmx` runnable â€”
-   e.g. `module load gromacs` or `source /opt/gromacs/bin/GMXRC` â€” one per line.
-2. **Set up passwordless login** â€” SilicoLab generates a dedicated key
-   (`~/.silicolab/keys/id_silicolab_ed25519`, never your own keys) and shows a
-   one-line command to run once on the host (paste it into a terminal, or type
-   `! <command>` in the SilicoLab prompt). Click **Verify** to confirm. Passwordless
-   (key-based) login is required so unattended jobs never block on a password.
-3. **Detect GROMACS** â€” probes the host for `gmx` and records its version. This is
-   needed only for MD; QM and docking run inside the deployed worker, so they need
-   no host-side tool.
-
-**Run remotely:** every task panel â€” Run MD, Build MD System, QM, and Molecular
-Docking â€” carries a **Run on** selector; pick your host there. (In Build MD System the
-selector applies to the GROMACS build; the built-in geometry build always runs
-locally.) New panels start from the **Default compute target** set in *Settings â†’
-Engines â†’ Remote Hosts*, and you can change it per run. SilicoLab stages the inputs up, runs the job (launching each `gmx`
-step detached so a dropped connection can't kill it), streams the live log back, and
-stages results down â€” the result (structure, energies, trajectory) appears exactly as
-for a local run. Press **Esc** to cancel (it kills the remote job too).
-
-v1 limitations: a remote run occupies the single engine-job slot while active;
-closing the app leaves an in-flight remote job running (a `remote_run.json` record
-is written into the local run directory) but does not auto-reattach to it; remote
-scratch directories under `<work_root>/runs/<run-id>` are not garbage-collected
-automatically.
+- [Contributing guide](CONTRIBUTING.md)
+- [Architecture notes](ARCHITECTURE.md)
+- [Feature wiring guide](docs/adding-a-feature.md)
 
 ## License
 

--- a/docs-site/src/content/docs/getting-started/external-tools.md
+++ b/docs-site/src/content/docs/getting-started/external-tools.md
@@ -1,0 +1,38 @@
+---
+title: External tools
+description: Configure external programs used by SilicoLab feature modules.
+sidebar:
+  order: 3
+---
+
+SilicoLab can launch without optional external tools. Install these programs
+only when you need the features that call them.
+
+## GROMACS
+
+Molecular dynamics simulations require
+[GROMACS](https://www.gromacs.org/) to be installed separately.
+
+GPU acceleration is strongly recommended. Running molecular dynamics on CPU
+alone is technically possible, but it is usually too slow for non-trivial
+systems.
+
+- **Windows:** Install GROMACS inside
+  [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) with
+  `sudo apt install gromacs` for a quick start. For GPU acceleration, compile
+  GROMACS from source with CUDA inside WSL.
+- **Linux:** Install the package with `sudo apt install gromacs` for a quick
+  start. For production MD, compile from source with CUDA or ROCm support.
+- **macOS:** Install with `brew install gromacs`. GPU acceleration is not
+  supported on Apple hardware, so MD performance will be limited.
+
+After installation, open SilicoLab and let the engine settings detect the
+`gmx` executable before running MD.
+
+## Remote hosts
+
+Heavy calculations can also run on a remote Linux host over SSH. This is useful
+when your laptop has no GPU or when the required engine is available only on an
+HPC login node or workstation.
+
+See [Remote execution](./remote-execution/) for the SSH setup flow.

--- a/docs-site/src/content/docs/getting-started/installation.md
+++ b/docs-site/src/content/docs/getting-started/installation.md
@@ -29,7 +29,9 @@ Some features call external programs at run time. You can install them later —
 SilicoLab works without them until you use the corresponding feature.
 
 - **GROMACS** — required for molecular dynamics simulations.
-- **ORCA** — used for quantum chemistry calculations.
 
-A dedicated setup guide for these tools (including GPU acceleration and
-remote execution over SSH) is planned for an upcoming section of this manual.
+Quantum chemistry is available through the built-in Hartree engine.
+
+See [External tools](./external-tools/) for setup notes, including GPU
+acceleration. See [Remote execution](./remote-execution/) to run heavy jobs on
+a remote Linux host over SSH.

--- a/docs-site/src/content/docs/getting-started/remote-execution.md
+++ b/docs-site/src/content/docs/getting-started/remote-execution.md
@@ -1,0 +1,64 @@
+---
+title: Remote execution
+description: Offload heavy compute jobs to a remote Linux host over SSH.
+sidebar:
+  order: 4
+---
+
+Heavy compute can be offloaded to a remote Linux machine, such as an HPC login
+node or GPU workstation, while the GUI stays on your laptop.
+
+Quantum chemistry, molecular docking, and MD/GROMACS can all run remotely.
+SilicoLab drives the OS OpenSSH client (`ssh` and `scp`) as subprocesses. The
+OpenSSH client ships with macOS and Linux. On Windows 11, enable it under
+**Settings > Apps > Optional features > OpenSSH Client** if it is missing.
+
+On first use, SilicoLab deploys a small self-contained worker to the host. The
+worker is pinned to the app version and verified against its published checksum
+before it runs.
+
+## Set up a host
+
+Open **Settings > Engines > Remote Hosts**.
+
+1. Select **Add host** and enter a label, hostname or IP address, username, and
+   optionally a port and remote work directory. The default work directory is
+   `~/.silicolab`.
+2. Under **Setup commands**, enter the commands a fresh non-interactive SSH
+   shell needs before engine commands are available. For example, use
+   `module load gromacs` or `source /opt/gromacs/bin/GMXRC` to make `gmx`
+   runnable. Enter one command per line.
+3. Select **Set up passwordless login**. SilicoLab generates a dedicated key at
+   `~/.silicolab/keys/id_silicolab_ed25519` and shows a one-line command to run
+   once on the host. This key is separate from your personal SSH keys.
+4. Select **Verify** to confirm that key-based login works. Passwordless login
+   is required so unattended jobs never block on a password prompt.
+5. Select **Detect GROMACS** if you plan to run MD. This probes the host for
+   `gmx` and records the detected version. Quantum chemistry and docking run
+   inside the deployed worker, so they do not need a host-side GROMACS install.
+
+## Run remotely
+
+Task panels for **Run MD**, **Build MD System**, **QM**, and **Molecular
+Docking** include a **Run on** selector. Pick the remote host there. In **Build
+MD System**, the selector applies to the GROMACS build step; the built-in
+geometry build always runs locally.
+
+New panels start from the **Default compute target** configured in
+**Settings > Engines > Remote Hosts**, and you can change the target per run.
+
+SilicoLab stages inputs up, runs the job, streams the live log back, and stages
+results down. The result appears in the project the same way as a local run.
+For GROMACS jobs, each `gmx` step is launched detached so a dropped SSH
+connection does not kill the calculation.
+
+Press **Esc** to cancel a remote run. SilicoLab also stops the remote job.
+
+## Current limitations
+
+- A remote run occupies the single engine-job slot while active.
+- Closing the app leaves an in-flight remote job running. SilicoLab writes a
+  `remote_run.json` record into the local run directory, but it does not
+  auto-reattach to that job yet.
+- Remote scratch directories under `<work_root>/runs/<run-id>` are not
+  garbage-collected automatically.

--- a/docs-site/src/content/docs/zh/getting-started/external-tools.md
+++ b/docs-site/src/content/docs/zh/getting-started/external-tools.md
@@ -1,0 +1,33 @@
+---
+title: 外部工具
+description: 配置 SilicoLab 各功能模块调用的外部程序。
+sidebar:
+  order: 3
+---
+
+SilicoLab 在没有可选外部工具时也可以启动。只有在使用对应功能时，才需要安装
+这些程序。
+
+## GROMACS
+
+分子动力学模拟需要单独安装 [GROMACS](https://www.gromacs.org/)。
+
+强烈建议使用 GPU 加速。只用 CPU 运行分子动力学在技术上可行，但对于稍复杂的
+体系通常会非常慢。
+
+- **Windows：** 在 [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)
+  中安装 GROMACS。快速开始可用 `sudo apt install gromacs`。如需 GPU 加速，
+  请在 WSL 中从源码编译带 CUDA 支持的 GROMACS。
+- **Linux：** 快速开始可用 `sudo apt install gromacs`。正式运行 MD 时，
+  建议从源码编译并启用 CUDA 或 ROCm。
+- **macOS：** 可用 `brew install gromacs` 安装。Apple 硬件不支持 GROMACS
+  GPU 加速，因此 MD 性能会受限。
+
+安装后，打开 SilicoLab，在引擎设置中检测 `gmx` 可执行文件，再运行 MD。
+
+## 远程主机
+
+大型计算也可以通过 SSH 运行在远程 Linux 主机上。当本机没有 GPU，或所需引擎
+只在 HPC 登录节点、工作站上可用时，这种方式很有用。
+
+参见[远程执行](./remote-execution/)了解 SSH 配置流程。

--- a/docs-site/src/content/docs/zh/getting-started/installation.md
+++ b/docs-site/src/content/docs/zh/getting-started/installation.md
@@ -27,7 +27,8 @@ Windows 下为 `silicolab.exe`）。
 相应功能之前，SilicoLab 无需它们也能正常运行。
 
 - **GROMACS** —— 运行分子动力学模拟时必需。
-- **ORCA** —— 用于量子化学计算。
 
-这些工具的完整配置指南（含 GPU 加速与 SSH 远程计算）将在本手册的
-后续章节中提供。
+SilicoLab 已内置 Hartree 引擎，可用于量子化学计算。
+
+请阅读[外部工具](./external-tools/)了解配置说明，包括 GPU 加速。
+如需通过 SSH 在远程 Linux 主机上运行大型任务，请阅读[远程执行](./remote-execution/)。

--- a/docs-site/src/content/docs/zh/getting-started/remote-execution.md
+++ b/docs-site/src/content/docs/zh/getting-started/remote-execution.md
@@ -1,0 +1,57 @@
+---
+title: 远程执行
+description: 通过 SSH 将大型计算任务提交到远程 Linux 主机。
+sidebar:
+  order: 4
+---
+
+大型计算可以转移到远程 Linux 主机上运行，例如 HPC 登录节点或 GPU 工作站；
+图形界面仍然留在你的笔记本上。
+
+量子化学、分子对接和 MD/GROMACS 都可以远程运行。SilicoLab 会调用操作系统
+自带的 OpenSSH 客户端（`ssh` 和 `scp`）。macOS 和 Linux 默认提供 OpenSSH
+客户端；Windows 11 如缺少该组件，可在 **设置 > 应用 > 可选功能 >
+OpenSSH Client** 中启用。
+
+首次使用时，SilicoLab 会向主机部署一个小型自包含 worker。worker 会绑定到
+当前应用版本，并在运行前用发布的校验和验证。
+
+## 配置主机
+
+打开 **Settings > Engines > Remote Hosts**。
+
+1. 选择 **Add host**，填写标签、主机名或 IP、用户名，并可选填写端口和远程
+   工作目录。默认工作目录是 `~/.silicolab`。
+2. 在 **Setup commands** 中填写非交互 SSH shell 启动后需要执行的命令，让
+   引擎命令可用。例如可用 `module load gromacs` 或
+   `source /opt/gromacs/bin/GMXRC` 让 `gmx` 可运行。每行填写一条命令。
+3. 选择 **Set up passwordless login**。SilicoLab 会生成一把专用密钥：
+   `~/.silicolab/keys/id_silicolab_ed25519`，并显示一条需要在远程主机上
+   执行一次的命令。这把密钥独立于你的个人 SSH 密钥。
+4. 选择 **Verify**，确认基于密钥的登录可用。无密码登录是必需的，否则无人值守
+   任务可能会卡在密码提示上。
+5. 如果要运行 MD，选择 **Detect GROMACS**。这会在主机上探测 `gmx` 并记录
+   版本。量子化学和分子对接运行在部署的 worker 内，因此不需要主机侧安装
+   GROMACS。
+
+## 远程运行
+
+**Run MD**、**Build MD System**、**QM** 和 **Molecular Docking** 面板都有
+**Run on** 选择器，可在其中选择远程主机。在 **Build MD System** 中，该选择器
+只作用于 GROMACS 构建步骤；内置几何构建始终在本地运行。
+
+新面板会使用 **Settings > Engines > Remote Hosts** 中配置的
+**Default compute target**，但每次运行前都可以单独修改。
+
+SilicoLab 会上传输入文件、运行任务、回传实时日志并下载结果。结果会像本地运行
+一样出现在项目中。对于 GROMACS 任务，每个 `gmx` 步骤都会以 detached 方式启动，
+因此 SSH 连接中断不会杀掉计算。
+
+按 **Esc** 可以取消远程任务；SilicoLab 也会停止远程作业。
+
+## 当前限制
+
+- 远程任务运行时会占用唯一的 engine-job 槽位。
+- 关闭应用后，正在运行的远程任务会继续留在主机上。SilicoLab 会在本地运行目录
+  写入 `remote_run.json` 记录，但目前还不会自动重新连接该任务。
+- `<work_root>/runs/<run-id>` 下的远程临时目录目前不会自动清理。


### PR DESCRIPTION
## Summary

- Streamline the root README into a clearer project entry point with badges, manual/download links, concise setup, and development links.
- Move detailed external-tool and remote-execution guidance into the docs site.
- Add English and Chinese docs pages for external tools and SSH remote execution.
- Clarify that quantum chemistry is available through the built-in Hartree engine and remove ORCA references until that integration exists.

## Validation

- Ran `npm run build` in `docs-site`
- Starlight internal link validation passed