### PR TITLE
fix(frontend): suffix float literals passed to egui's `impl Into<f32>`

### DIFF
--- a/src/frontend/sketcher/canvas.rs
+++ b/src/frontend/sketcher/canvas.rs
@@ -56,7 +56,7 @@ pub(super) fn show_canvas(state: &mut SketcherState, ui: &mut Ui) {
     painter.rect_stroke(
         rect,
         4.0,
-        Stroke::new(1.0, ui.visuals().widgets.noninteractive.bg_stroke.color),
+        Stroke::new(1.0_f32, ui.visuals().widgets.noninteractive.bg_stroke.color),
         StrokeKind::Inside,
     );
 
@@ -114,7 +114,7 @@ fn draw_hover(
     {
         let a = state.to_screen(rect, state.sketch.atoms[bond.a].pos);
         let b = state.to_screen(rect, state.sketch.atoms[bond.b].pos);
-        painter.line_segment([a, b], Stroke::new(9.0, halo));
+        painter.line_segment([a, b], Stroke::new(9.0_f32, halo));
     }
 }
 
@@ -205,7 +205,7 @@ fn draw_atoms(state: &SketcherState, painter: &eframe::egui::Painter, rect: Rect
 
         // Selection ring.
         if state.selected_atoms.contains(&index) {
-            painter.circle_stroke(center, 11.0, Stroke::new(2.0, selection));
+            painter.circle_stroke(center, 11.0, Stroke::new(2.0_f32, selection));
         }
 
         // Carbons are drawn as bare vertices unless isolated.
@@ -240,7 +240,7 @@ fn draw_atoms(state: &SketcherState, painter: &eframe::egui::Painter, rect: Rect
             let warn = Color32::from_rgb(225, 70, 70);
             painter.line_segment(
                 [center + vec2(-8.0, 11.0), center + vec2(8.0, 11.0)],
-                Stroke::new(2.0, warn),
+                Stroke::new(2.0_f32, warn),
             );
         }
     }
@@ -290,7 +290,7 @@ fn draw_overlays(
                 let a = state.to_screen(rect, anchor);
                 let b = state.to_screen(rect, pointer);
                 draw_dashed(painter, a, b, Stroke::new(BOND_WIDTH, preview));
-                painter.circle_stroke(b, 6.0, Stroke::new(1.5, preview));
+                painter.circle_stroke(b, 6.0, Stroke::new(1.5_f32, preview));
             }
         }
         Some(GesturePreview::Chain { count }) => {
@@ -306,7 +306,11 @@ fn draw_overlays(
         }
         Some(GesturePreview::Rotate { center, degrees }) => {
             let c = state.to_screen(rect, center);
-            painter.circle_stroke(c, 4.0, Stroke::new(1.5, Color32::from_rgb(110, 170, 120)));
+            painter.circle_stroke(
+                c,
+                4.0,
+                Stroke::new(1.5_f32, Color32::from_rgb(110, 170, 120)),
+            );
             painter.text(
                 c + vec2(12.0, -12.0),
                 Align2::LEFT_CENTER,
@@ -327,7 +331,7 @@ fn draw_overlays(
                 painter.rect_stroke(
                     marquee,
                     0.0,
-                    Stroke::new(1.0, Color32::from_rgb(90, 140, 245)),
+                    Stroke::new(1.0_f32, Color32::from_rgb(90, 140, 245)),
                     StrokeKind::Inside,
                 );
             }
@@ -358,7 +362,7 @@ fn draw_ring_preview(
     for (local, vertex) in placement.vertices.iter().enumerate() {
         let pos = state.to_screen(rect, placement.positions[local]);
         if vertex.is_some() {
-            painter.circle_stroke(pos, 6.0, Stroke::new(1.5, color));
+            painter.circle_stroke(pos, 6.0, Stroke::new(1.5_f32, color));
         } else {
             painter.circle_filled(pos, 2.0, color);
         }

--- a/src/frontend/theme.rs
+++ b/src/frontend/theme.rs
@@ -624,7 +624,7 @@ fn build_visuals(scheme: ColorScheme, dark: bool) -> Visuals {
     // buttons / `selectable_label`s (see `Style::button_style`). A transparent
     // color there makes the selected combo/menu item's text invisible.
     visuals.selection.bg_fill = pal.selection_fill;
-    visuals.selection.stroke = Stroke::new(0.0, pal.text_strong);
+    visuals.selection.stroke = Stroke::new(0.0_f32, pal.text_strong);
     visuals.hyperlink_color = pal.accent;
 
     // Controls have gently rounded corners. egui defaults to 2-3px; nudge up.
@@ -649,8 +649,8 @@ fn build_visuals(scheme: ColorScheme, dark: bool) -> Visuals {
     // state: egui subtracts `bg_stroke.width` from button/selectable inner
     // margins, so switching to `Stroke::NONE` makes ComboBox menu rows and
     // selectable labels shift by a pixel while hovering.
-    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, pal.hairline);
-    let invisible_stable_stroke = Stroke::new(1.0, Color32::TRANSPARENT);
+    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, pal.hairline);
+    let invisible_stable_stroke = Stroke::new(1.0_f32, Color32::TRANSPARENT);
 
     visuals.widgets.hovered.weak_bg_fill = pal.item_fill_hover;
     visuals.widgets.hovered.bg_fill = pal.item_fill_hover;
@@ -672,7 +672,7 @@ fn build_visuals(scheme: ColorScheme, dark: bool) -> Visuals {
     visuals.widgets.active.fg_stroke.color = pal.text_primary;
     visuals.widgets.open.fg_stroke.color = pal.text_primary;
 
-    visuals.window_stroke = Stroke::new(1.0, pal.hairline);
+    visuals.window_stroke = Stroke::new(1.0_f32, pal.hairline);
 
     // Popups (tooltips, menus, combo lists) and windows get a soft, mostly
     // *vertical* drop shadow. egui's default shoves the popup shadow well to the

--- a/src/frontend/ui/dock.rs
+++ b/src/frontend/ui/dock.rs
@@ -521,7 +521,7 @@ fn paint_insertion_bar(
     ui.painter().vline(
         x,
         (strip_rect.top() + 4.0)..=(strip_rect.bottom() - 4.0),
-        Stroke::new(2.0, pal.accent),
+        Stroke::new(2.0_f32, pal.accent),
     );
 }
 
@@ -681,7 +681,7 @@ pub(super) fn render_dock_reveal_targets(
                     rect,
                     egui::CornerRadius::same(crate::frontend::theme::radius::CARD),
                     fill,
-                    Stroke::new(1.0, pal.accent),
+                    Stroke::new(1.0_f32, pal.accent),
                     egui::StrokeKind::Inside,
                 );
             });

--- a/src/frontend/ui/gauge.rs
+++ b/src/frontend/ui/gauge.rs
@@ -131,7 +131,7 @@ fn sparkline(ui: &mut egui::Ui, history: &VecDeque<Option<f32>>, height: f32, co
     painter.hline(
         rect.left()..=rect.right(),
         rect.bottom() - 0.5,
-        Stroke::new(1.0, pal.text_tertiary.gamma_multiply(0.25)),
+        Stroke::new(1.0_f32, pal.text_tertiary.gamma_multiply(0.25)),
     );
 
     if history.len() < 2 {
@@ -167,7 +167,7 @@ fn sparkline(ui: &mut egui::Ui, history: &VecDeque<Option<f32>>, height: f32, co
         mesh.add_triangle(base, base + 2, base + 3);
     }
     painter.add(egui::Shape::mesh(mesh));
-    painter.add(egui::Shape::line(pts, Stroke::new(1.6, color)));
+    painter.add(egui::Shape::line(pts, Stroke::new(1.6_f32, color)));
 }
 
 #[cfg(test)]

--- a/src/frontend/ui/modal.rs
+++ b/src/frontend/ui/modal.rs
@@ -32,7 +32,7 @@ pub(super) fn window_frame(ctx: &egui::Context, inner_margin: egui::Margin) -> e
         .corner_radius(egui::CornerRadius::same(
             crate::frontend::theme::radius::MODAL,
         ))
-        .stroke(egui::Stroke::new(1.0, stroke_color))
+        .stroke(egui::Stroke::new(1.0_f32, stroke_color))
         .shadow(egui::Shadow {
             offset: [0, 8],
             blur: 24,

--- a/src/frontend/ui/notification.rs
+++ b/src/frontend/ui/notification.rs
@@ -35,7 +35,7 @@ pub(super) fn render_notification(state: &AppState, ui: &egui::Ui, actions: &mut
             ui.set_max_width(460.0);
             Frame::default()
                 .fill(pal.window_backing)
-                .stroke(Stroke::new(1.0, pal.hairline))
+                .stroke(Stroke::new(1.0_f32, pal.hairline))
                 .corner_radius(egui::CornerRadius::same(theme::radius::MODAL))
                 .inner_margin(Margin::same(14))
                 .shadow(egui::Shadow {

--- a/src/frontend/ui/panel_bodies.rs
+++ b/src/frontend/ui/panel_bodies.rs
@@ -47,7 +47,7 @@ pub(super) fn weak_panel_hairline(ui: &mut egui::Ui, alpha: u8) {
     ui.painter().hline(
         rect.left()..=rect.right(),
         rect.center().y,
-        Stroke::new(1.0, pal.neutral_overlay(alpha)),
+        Stroke::new(1.0_f32, pal.neutral_overlay(alpha)),
     );
 }
 

--- a/src/frontend/ui/panel_bodies/assistant.rs
+++ b/src/frontend/ui/panel_bodies/assistant.rs
@@ -466,7 +466,7 @@ fn render_approval_card(
         let frame_inner_width = (panel_width - 20.0).max(48.0);
         Frame::default()
             .fill(blend(accent, pal.input_fill, 0.86))
-            .stroke(Stroke::new(1.0, blend(accent, pal.hairline, 0.4)))
+            .stroke(Stroke::new(1.0_f32, blend(accent, pal.hairline, 0.4)))
             .corner_radius(CornerRadius::same(radius::CARD))
             .inner_margin(Margin::symmetric(10, 8))
             .show(ui, |ui| {

--- a/src/frontend/ui/panel_bodies/assistant_composer.rs
+++ b/src/frontend/ui/panel_bodies/assistant_composer.rs
@@ -137,7 +137,7 @@ pub(crate) fn render_assistant_composer(
         let frame_inner_width = (content_width - 16.0).max(80.0);
         let response = Frame::default()
             .fill(pal.input_fill)
-            .stroke(Stroke::new(1.0, pal.hairline))
+            .stroke(Stroke::new(1.0_f32, pal.hairline))
             .corner_radius(CornerRadius::same(composer_radius))
             .inner_margin(Margin::symmetric(8, 8))
             .show(ui, |ui| {
@@ -215,7 +215,7 @@ pub(crate) fn render_assistant_composer(
         ui.painter().rect_stroke(
             composer_rect,
             CornerRadius::same(composer_radius),
-            Stroke::new(1.0, pal.accent),
+            Stroke::new(1.0_f32, pal.accent),
             egui::StrokeKind::Inside,
         );
         ui.ctx()

--- a/src/frontend/ui/panel_bodies/assistant_transcript.rs
+++ b/src/frontend/ui/panel_bodies/assistant_transcript.rs
@@ -158,7 +158,7 @@ pub(super) fn render_tool_block(
                 ui.painter().hline(
                     line_rect.left()..=line_rect.right(),
                     line_rect.center().y,
-                    Stroke::new(1.0, pal.neutral_overlay(18)),
+                    Stroke::new(1.0_f32, pal.neutral_overlay(18)),
                 );
                 ui.add_space(5.0);
 

--- a/src/frontend/ui/panel_bodies/console.rs
+++ b/src/frontend/ui/panel_bodies/console.rs
@@ -81,7 +81,7 @@ pub(crate) fn render_console_panel(
 
             let response = Frame::default()
                 .fill(pal.input_fill)
-                .stroke(Stroke::new(1.0, pal.hairline))
+                .stroke(Stroke::new(1.0_f32, pal.hairline))
                 .corner_radius(egui::CornerRadius::same(input_radius))
                 .inner_margin(Margin::symmetric(INPUT_X_MARGIN as i8, 3))
                 .show(ui, |ui| {

--- a/src/frontend/ui/panel_bodies/monitor.rs
+++ b/src/frontend/ui/panel_bodies/monitor.rs
@@ -393,7 +393,7 @@ pub(crate) fn render_monitor_popover(state: &mut AppState, ctx: &egui::Context) 
             let pal = crate::frontend::theme::palette(ui);
             egui::Frame::popup(ui.style())
                 .fill(pal.window_backing)
-                .stroke(egui::Stroke::new(1.0, pal.hairline))
+                .stroke(egui::Stroke::new(1.0_f32, pal.hairline))
                 .corner_radius(egui::CornerRadius::same(
                     crate::frontend::theme::radius::CARD,
                 ))

--- a/src/frontend/ui/panel_bodies/sequence.rs
+++ b/src/frontend/ui/panel_bodies/sequence.rs
@@ -292,9 +292,9 @@ fn render_residue_cell(
     }
 
     let stroke = if residue.any_selected || residue.primary_selected || hovered {
-        Stroke::new(1.0, pal.accent)
+        Stroke::new(1.0_f32, pal.accent)
     } else {
-        Stroke::new(1.0, pal.neutral_overlay(24))
+        Stroke::new(1.0_f32, pal.neutral_overlay(24))
     };
     ui.painter().rect_stroke(
         rect,

--- a/src/frontend/ui/plot_view.rs
+++ b/src/frontend/ui/plot_view.rs
@@ -59,12 +59,12 @@ pub(crate) fn render_chart(
                 Mark::Line => plot_ui.line(
                     Line::new(series.name.clone(), PlotPoints::from(series.points.clone()))
                         .color(color)
-                        .width(1.5),
+                        .width(1.5_f32),
                 ),
                 Mark::Sticks => plot_ui.points(
                     Points::new(series.name.clone(), PlotPoints::from(series.points.clone()))
-                        .stems(0.0)
-                        .radius(1.5)
+                        .stems(0.0_f32)
+                        .radius(1.5_f32)
                         .color(color),
                 ),
             }

--- a/src/frontend/ui/primary_sidebar.rs
+++ b/src/frontend/ui/primary_sidebar.rs
@@ -231,7 +231,7 @@ pub(crate) fn render_primary_sidebar(
             card_rect,
             segment_radius,
             card_fill,
-            Stroke::new(1.0, pal.hairline),
+            Stroke::new(1.0_f32, pal.hairline),
             egui::StrokeKind::Inside,
         );
 
@@ -402,7 +402,7 @@ fn render_sidebar_monitor_footer(
     let top = ui.max_rect().left_top();
     let right = ui.max_rect().right_top().x;
     ui.painter()
-        .hline(top.x..=right, top.y, Stroke::new(1.0, pal.hairline));
+        .hline(top.x..=right, top.y, Stroke::new(1.0_f32, pal.hairline));
     ui.add_space(9.0);
     // Inset the right edge so the gauges sit with equal ~10px margins inside the
     // sidebar (the panel's own inner margins are 10 left / 2 right): this keeps
@@ -440,7 +440,7 @@ pub(crate) fn render_sidebar_search_popover(
             .show(&ctx, |ui| {
                 Frame::popup(ui.style())
                     .fill(pal.input_fill)
-                    .stroke(Stroke::new(1.0, pal.hairline))
+                    .stroke(Stroke::new(1.0_f32, pal.hairline))
                     .corner_radius(egui::CornerRadius::same(
                         crate::frontend::theme::radius::CARD,
                     ))

--- a/src/frontend/ui/workspace.rs
+++ b/src/frontend/ui/workspace.rs
@@ -438,7 +438,7 @@ fn render_scratch_workspace(state: &mut AppState, ui: &mut egui::Ui, actions: &m
                 for project in recent_projects {
                     let response = Frame::default()
                         .fill(pal.item_fill)
-                        .stroke(Stroke::new(1.0, pal.hairline))
+                        .stroke(Stroke::new(1.0_f32, pal.hairline))
                         .corner_radius(egui::CornerRadius::same(
                             crate::frontend::theme::radius::CARD,
                         ))
@@ -485,10 +485,10 @@ fn render_scratch_action_button(
             let visuals = &mut ui.style_mut().visuals.widgets;
             visuals.inactive.weak_bg_fill = pal.item_fill;
             visuals.inactive.bg_fill = pal.item_fill;
-            visuals.inactive.bg_stroke = Stroke::new(1.0, pal.hairline);
+            visuals.inactive.bg_stroke = Stroke::new(1.0_f32, pal.hairline);
             visuals.hovered.weak_bg_fill = pal.item_fill_hover;
             visuals.hovered.bg_fill = pal.item_fill_hover;
-            visuals.hovered.bg_stroke = Stroke::new(1.0, pal.hairline);
+            visuals.hovered.bg_stroke = Stroke::new(1.0_f32, pal.hairline);
             // 44px-tall call-to-action buttons take the large radius step
             // (Apple sizes radii with control height).
             let large = egui::CornerRadius::same(crate::frontend::theme::radius::LARGE);

--- a/src/frontend/widgets/reticular.rs
+++ b/src/frontend/widgets/reticular.rs
@@ -59,7 +59,7 @@ pub fn component_preview(
         painter.rect_stroke(
             rect,
             canvas_radius,
-            Stroke::new(1.0, pal.hairline),
+            Stroke::new(1.0_f32, pal.hairline),
             egui::StrokeKind::Inside,
         );
 
@@ -106,11 +106,11 @@ pub fn component_preview(
                         let perp = perpendicular_offset(start, end, offset);
                         painter.line_segment(
                             [start + perp, end + perp],
-                            Stroke::new(1.5, Color32::from_rgb(80, 84, 90)),
+                            Stroke::new(1.5_f32, Color32::from_rgb(80, 84, 90)),
                         );
                         painter.line_segment(
                             [start - perp, end - perp],
-                            Stroke::new(1.5, Color32::from_rgb(80, 84, 90)),
+                            Stroke::new(1.5_f32, Color32::from_rgb(80, 84, 90)),
                         );
                     }
                     BondType::Triple => {
@@ -118,15 +118,15 @@ pub fn component_preview(
                         let perp = perpendicular_offset(start, end, offset);
                         painter.line_segment(
                             [start, end],
-                            Stroke::new(1.5, Color32::from_rgb(80, 84, 90)),
+                            Stroke::new(1.5_f32, Color32::from_rgb(80, 84, 90)),
                         );
                         painter.line_segment(
                             [start + perp, end + perp],
-                            Stroke::new(1.5, Color32::from_rgb(80, 84, 90)),
+                            Stroke::new(1.5_f32, Color32::from_rgb(80, 84, 90)),
                         );
                         painter.line_segment(
                             [start - perp, end - perp],
-                            Stroke::new(1.5, Color32::from_rgb(80, 84, 90)),
+                            Stroke::new(1.5_f32, Color32::from_rgb(80, 84, 90)),
                         );
                     }
                     BondType::Aromatic => {
@@ -144,7 +144,7 @@ pub fn component_preview(
                     _ => {
                         painter.line_segment(
                             [start, end],
-                            Stroke::new(2.0, Color32::from_rgb(80, 84, 90)),
+                            Stroke::new(2.0_f32, Color32::from_rgb(80, 84, 90)),
                         );
                     }
                 }
@@ -194,11 +194,11 @@ pub fn component_preview(
             );
             painter.line_segment(
                 [pos + Vec2::new(-4.0, 0.0), pos + Vec2::new(4.0, 0.0)],
-                Stroke::new(1.4, port_color),
+                Stroke::new(1.4_f32, port_color),
             );
             painter.line_segment(
                 [pos + Vec2::new(0.0, -4.0), pos + Vec2::new(0.0, 4.0)],
-                Stroke::new(1.4, port_color),
+                Stroke::new(1.4_f32, port_color),
             );
 
             if let Some(atom) = component.atoms.get(site.binding_atom) {
@@ -212,7 +212,7 @@ pub fn component_preview(
                     COMPONENT_PREVIEW_ATOM_RADIUS + COMPONENT_PREVIEW_ATOM_STROKE_WIDTH * 0.5,
                     COMPONENT_PREVIEW_PORT_RADIUS + COMPONENT_PREVIEW_PORT_STROKE_WIDTH * 0.5,
                 ) {
-                    painter.line_segment([start, end], Stroke::new(1.0, port_color));
+                    painter.line_segment([start, end], Stroke::new(1.0_f32, port_color));
                 }
             }
         }


### PR DESCRIPTION
Rust 1.97.0 added `float_literal_f32_fallback`, a warn-by-default future-compat lint that fires when an unsuffixed float literal reaches a generic parameter only `f32` satisfies. `Stroke::new(1.0, color)` takes `impl Into<f32>`, so `1.0` infers as `{float}`, defaults to `f64`, finds no `f32: From<f64>`, and silently falls back to `f32`. The lint flags exactly that fallback, and its future-compat note says it becomes a hard error in a later release.

CI installs the latest stable via `dtolnay/rust-toolchain@stable` and sets `RUSTFLAGS: -D warnings`, so the day 1.97.0 shipped, every job that compiles the GUI crate began failing on 46 of these across 17 files — main and every open PR at once, with no code change behind it.

### This is not a regression from #25

The commit main is sitting on is a glycan stereochemistry fix that touches no file under `src/frontend/`. Its own PR run passed on rustc 1.96.1 at 11:12 UTC; the merge run failed on 1.97.0 at 13:49 UTC. `feat/export-selected-structures`, based on that same commit, reports the identical 46 errors. The breakage is a toolchain rollover, not a merge.

### The change

Apply the compiler's own suggestion, `1.0` → `1.0_f32`, at each of the 46 sites. Every suggestion is `MachineApplicable`; this is `cargo fix` output. The diff is byte-for-byte the previous text plus the suffix — the one exception is a `circle_stroke` call in the sketcher that rustfmt rewraps because the longer literal pushes it past the width limit.

Suffixed literals are valid on both 1.96 and 1.97 and trip no lint on either, so this needs no toolchain pin. It also needs no `#[allow(float_literal_f32_fallback)]` — that would in fact *break* 1.96, which does not know the lint name and rejects it under `unknown_lints`.

### Verification

Locally on rustc 1.97.0 with `RUSTFLAGS=-D warnings`, reproducing each CI job:

- `cargo clippy --workspace --all-targets --all-features` — clean
- `cargo fmt --all --check` — clean
- `cargo test --workspace --all-features` — 1099 passed, 0 failed
- the 800-physical-line file-size gate — no file over the limit

### Follow-ups (separate PRs)

- `RUSTFLAGS: -D warnings` sits in the workflow-level `env`, so this pure-lint failure also took down all three `Test` jobs, whose pass/fail has nothing to do with lint warnings. Narrowing it to the `Clippy` job would keep the test signal readable the next time rustc adds a lint.
- `feat/export-selected-structures` needs a rebase onto this fix; it is red for the same reason and will not recover on its own.
