### PR TITLE
ci: deny warnings in the Clippy job only, not across every job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -D warnings
   # Full debuginfo dominates compile time and balloons the cache; line tables
   # keep usable panic backtraces at a fraction of the size.
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
@@ -82,11 +81,17 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all --check
 
+  # `-D warnings` lives here, not in the workflow-level env: a warning is a lint
+  # verdict, and only this job reports lint verdicts. Denying warnings across
+  # every job means a new rustc lint fails the Test matrix too, hiding whether
+  # the code under test actually works. `--all-targets` already lints test code.
   clippy:
     name: Clippy
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -39,6 +39,7 @@ fn pr_check() -> Result<(), String> {
         5,
         "fmt",
         &["fmt", "--all", "--check", "--quiet"],
+        Warnings::Allow,
     )?;
     run_cargo_step(
         &repo_root,
@@ -52,6 +53,7 @@ fn pr_check() -> Result<(), String> {
             "--all-features",
             "--quiet",
         ],
+        Warnings::Deny,
     )?;
     assert_worker_pure_rust(&repo_root, 3, 5)?;
     assert_rust_file_sizes(&repo_root, 4, 5)?;
@@ -61,6 +63,7 @@ fn pr_check() -> Result<(), String> {
         5,
         "test",
         &["test", "--workspace", "--all-features", "--quiet"],
+        Warnings::Allow,
     )?;
 
     println!(
@@ -77,16 +80,25 @@ fn repo_root() -> Result<PathBuf, String> {
         .ok_or_else(|| "could not resolve repository root".to_owned())
 }
 
+/// Mirrors CI: only the clippy job denies warnings, so a new rustc lint fails
+/// lint checking rather than masquerading as a test failure.
+#[derive(Clone, Copy)]
+enum Warnings {
+    Deny,
+    Allow,
+}
+
 fn run_cargo_step(
     repo_root: &Path,
     index: usize,
     total: usize,
     name: &str,
     args: &[&str],
+    warnings: Warnings,
 ) -> Result<(), String> {
     let started_at = Instant::now();
     print_step(index, total, name);
-    let output = cargo_output(repo_root, args)?;
+    let output = cargo_output(repo_root, args, warnings)?;
 
     if !output.status.success() {
         print_command_failure("cargo", args, &output);
@@ -120,6 +132,7 @@ fn assert_worker_pure_rust(repo_root: &Path, index: usize, total: usize) -> Resu
             "--prefix",
             "none",
         ],
+        Warnings::Allow,
     )?;
 
     if !output.status.success() {
@@ -178,13 +191,17 @@ fn assert_worker_pure_rust(repo_root: &Path, index: usize, total: usize) -> Resu
     }
 }
 
-fn cargo_output(repo_root: &Path, args: &[&str]) -> Result<Output, String> {
-    Command::new("cargo")
+fn cargo_output(repo_root: &Path, args: &[&str], warnings: Warnings) -> Result<Output, String> {
+    let mut command = Command::new("cargo");
+    command
         .args(args)
         .current_dir(repo_root)
         .env("CARGO_TERM_COLOR", "always")
-        .env("RUSTFLAGS", "-D warnings")
-        .env("CARGO_PROFILE_DEV_DEBUG", "line-tables-only")
+        .env("CARGO_PROFILE_DEV_DEBUG", "line-tables-only");
+    if let Warnings::Deny = warnings {
+        command.env("RUSTFLAGS", "-D warnings");
+    }
+    command
         .output()
         .map_err(|error| format!("failed to run cargo {}: {error}", args.join(" ")))
 }


### PR DESCRIPTION
Follow-up to #27.

`RUSTFLAGS: -D warnings` sat in the workflow-level `env`, so every job that compiled Rust inherited it. When Rust 1.97.0 added the `float_literal_f32_fallback` lint, that turned a lint verdict into a compile error inside `cargo test`, and all three `Test` jobs went red alongside `Clippy` — on a tree whose tests were fine. The failure said nothing about whether the code worked, only that a new lint existed, and it said so in the four noisiest places at once.

Move the flag onto the job that exists to render lint verdicts, and mirror the split in `xtask` (`.rules` requires it to track CI's local gates: *"update `xtask` when CI's local checks change"*).

### Lint coverage is unchanged

`cargo clippy --workspace --all-targets --all-features` already lints test and bench targets, so a warning in test code still fails `Clippy`. Verified rather than assumed — planting an unused variable inside a `#[cfg(test)]` module:

```
[1/5] fmt ... ok (1.2s)
[2/5] clippy ... failed
error: unused variable: `unused_variable_probe`
```

What changes is that the `Test` matrix now reports on the tests, and the next rustc lint rollover reds exactly one job whose name says why.

### Cache

The `Test` jobs' cargo cache keys hash `RUSTFLAGS`, so they miss once and repopulate on the next push to main. `Swatinem/rust-cache` defaults `add-job-id-key: true`, so `Clippy` and `Test` were never sharing a cache entry — this splits nothing and adds no cache set. I read that from `master`'s `action.yml` while the workflow pins `@v2`; I'll confirm the actual key shape from this PR's first run log rather than leave it as an assumption.

### Verification

`cargo pr-check` on a clean tree, rustc 1.97.0 — all five steps pass (131s).
