### PR TITLE
feat(frontend): confirm before leaving unsaved work

### DIFF
--- a/src/frontend/actions.rs
+++ b/src/frontend/actions.rs
@@ -5,6 +5,10 @@ pub enum AppAction {
     OpenRecentProject(std::path::PathBuf),
     CloseProject,
     SaveProject,
+    RequestLeave(LeaveIntent),
+    SaveAndLeave,
+    DiscardAndLeave,
+    CancelLeave,
     NewEmptyEntry,
     OpenFile,
     OpenPdbFetchDialog,
@@ -474,6 +478,56 @@ pub enum AppAction {
     /// Decline the heavy-structure suggestion for an entry and render it at full
     /// detail (no silent simplification).
     RenderHeavyEntryAtFull(u64),
+}
+
+/// A user request that leaves the current workspace or exits the app.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LeaveIntent {
+    Quit,
+    OpenProject,
+    OpenRecentProject(std::path::PathBuf),
+    CloseProject,
+}
+
+impl LeaveIntent {
+    pub fn action_label(&self) -> &'static str {
+        match self {
+            Self::Quit => "quit",
+            Self::OpenProject | Self::OpenRecentProject(_) => "open another project",
+            Self::CloseProject => "close this project",
+        }
+    }
+
+    pub fn save_button_label(&self) -> &'static str {
+        match self {
+            Self::Quit => "Save and Quit",
+            Self::OpenProject | Self::OpenRecentProject(_) => "Save and Open",
+            Self::CloseProject => "Save and Close",
+        }
+    }
+}
+
+/// State for the modal that guards leaving with unsaved project or scratch data.
+#[derive(Debug, Clone)]
+pub struct LeaveConfirmation {
+    pub intent: LeaveIntent,
+    pub save_error: Option<String>,
+}
+
+impl LeaveConfirmation {
+    pub fn new(intent: LeaveIntent) -> Self {
+        Self {
+            intent,
+            save_error: None,
+        }
+    }
+
+    pub fn save_failed(intent: LeaveIntent, error: impl Into<String>) -> Self {
+        Self {
+            intent,
+            save_error: Some(error.into()),
+        }
+    }
 }
 
 /// A non-modal notification surfaced over the workspace: a short message that,

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -10,7 +10,12 @@ use crate::{
         project::{WorkspaceSession, open_project, remember_opened_project},
     },
     domain::Structure,
-    frontend::{actions::AppAction, dispatcher, shortcuts, state::AppState, ui},
+    frontend::{
+        actions::{AppAction, LeaveIntent},
+        dispatcher, shortcuts,
+        state::AppState,
+        ui,
+    },
 };
 
 pub fn run(structure: Structure, source_path: Option<PathBuf>) -> Result<()> {
@@ -567,8 +572,19 @@ impl eframe::App for SilicoLabApp {
             ctx.send_viewport_cmd(egui::ViewportCommand::Title(viewport_title.clone()));
             self.last_viewport_title = viewport_title;
         }
-        if ctx.input(|input| input.viewport().close_requested()) {
-            dispatcher::shutdown(&mut self.state);
+        if self.state.ui.request_window_close {
+            self.state.ui.request_window_close = false;
+            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+        }
+        if ctx.input(|input| input.viewport().close_requested())
+            && !self.state.ui.allow_window_close
+        {
+            ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
+            dispatcher::dispatch(
+                &mut self.state,
+                AppAction::RequestLeave(LeaveIntent::Quit),
+                &ctx,
+            );
         }
         self.open_dropped_files(&ctx);
         dispatcher::poll_jobs(&mut self.state, &ctx);

--- a/src/frontend/dispatcher/mod.rs
+++ b/src/frontend/dispatcher/mod.rs
@@ -25,7 +25,7 @@ use crate::{
         registry::{EngineId, EngineRegistry},
     },
     frontend::{
-        actions::AppAction,
+        actions::{AppAction, LeaveIntent},
         jobs::{
             EngineWorkerMessage, GromacsPipelineRequest, OptimizationWorkerMessage,
             QmWorkerMessage, engine_poll_frame, optimization_finished_message,
@@ -100,6 +100,10 @@ pub fn dispatch(state: &mut AppState, action: AppAction, ctx: &egui::Context) {
             | AppAction::CreateProject
             | AppAction::CloseProject
             | AppAction::SaveProject
+            | AppAction::RequestLeave(_)
+            | AppAction::SaveAndLeave
+            | AppAction::DiscardAndLeave
+            | AppAction::CancelLeave
     );
     // Autosave only when the persisted entry state actually changes — an entry
     // added, removed, or edited. View-only changes (camera, render styles,
@@ -108,10 +112,16 @@ pub fn dispatch(state: &mut AppState, action: AppAction, ctx: &egui::Context) {
     let fingerprint_before = (!manages_own_persistence).then(|| state.entries_fingerprint());
     match action {
         AppAction::CreateProject => create_project_action(state),
-        AppAction::OpenProject => open_project_action(state),
-        AppAction::OpenRecentProject(path) => open_project_path(state, path),
-        AppAction::CloseProject => close_project(state),
+        AppAction::OpenProject => request_leave(state, LeaveIntent::OpenProject, ctx),
+        AppAction::OpenRecentProject(path) => {
+            request_leave(state, LeaveIntent::OpenRecentProject(path), ctx)
+        }
+        AppAction::CloseProject => request_leave(state, LeaveIntent::CloseProject, ctx),
         AppAction::SaveProject => save_project(state),
+        AppAction::RequestLeave(intent) => request_leave(state, intent, ctx),
+        AppAction::SaveAndLeave => save_and_leave(state, ctx),
+        AppAction::DiscardAndLeave => discard_and_leave(state, ctx),
+        AppAction::CancelLeave => cancel_leave(state),
         AppAction::NewEmptyEntry => new_empty_entry(state),
         AppAction::OpenFile => open_file(state),
         AppAction::OpenPdbFetchDialog => open_pdb_fetch_dialog(state),

--- a/src/frontend/dispatcher/project.rs
+++ b/src/frontend/dispatcher/project.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::frontend::actions::{LeaveConfirmation, LeaveIntent};
 
 /// Flush a coalesced autosave once its debounce window has elapsed. Called every
 /// frame from the app loop; a no-op when nothing is pending. While a save is
@@ -11,7 +12,7 @@ pub fn flush_pending_autosave(state: &mut AppState, ctx: &egui::Context) {
     let now = ctx.input(|input| input.time);
     if now >= deadline {
         // `persist_project` clears the deadline itself.
-        persist_project(state, false);
+        let _ = persist_project(state, false);
     } else {
         ctx.request_repaint_after(std::time::Duration::from_secs_f64(deadline - now));
     }
@@ -20,26 +21,27 @@ pub fn flush_pending_autosave(state: &mut AppState, ctx: &egui::Context) {
 /// Clean-shutdown checkpoint for window close: persist the project (including
 /// undo history) and release the session lock so the next launch knows the
 /// session ended cleanly. Skips database compaction to keep exit responsive.
-pub fn shutdown(state: &mut AppState) {
+pub fn shutdown(state: &mut AppState) -> anyhow::Result<()> {
     // The workbench layout is a global preference (persisted even in a scratch
     // workspace), so flush any pending layout save before the project-only gate.
     if state.layout_save_deadline().is_some() {
         persist_layout(state);
     }
     if !state.workspace.is_project() {
-        return;
+        return Ok(());
     }
-    persist_project(state, true);
+    persist_project(state, true)?;
     if let Some(project) = state.workspace.project() {
         housekeeping::release_lock(project);
     }
+    Ok(())
 }
 
-pub(crate) fn persist_project(state: &mut AppState, persist_history: bool) {
+pub(crate) fn persist_project(state: &mut AppState, persist_history: bool) -> anyhow::Result<()> {
     // Any pending coalesced autosave is subsumed by this save.
     state.clear_autosave_deadline();
     let Some(project) = state.workspace.project() else {
-        return;
+        return Ok(());
     };
     // Save from borrowed references into the live state rather than cloning the
     // whole workspace: in an entry-heavy project (e.g. a 20-model NMR ensemble)
@@ -53,9 +55,17 @@ pub(crate) fn persist_project(state: &mut AppState, persist_history: bool) {
         view: &view,
         history: &state.history,
     };
-    let result = save_project_ref(project, &snapshot, persist_history);
-    if let Err(error) = result {
-        state.set_message(format!("Project save failed: {error}"));
+    match save_project_ref(project, &snapshot, persist_history) {
+        Ok(()) => {
+            state.mark_project_saved();
+            Ok(())
+        }
+        Err(error) => {
+            let message = error.to_string();
+            state.mark_project_save_failed(message.clone());
+            state.set_message(format!("Project save failed: {message}"));
+            Err(error)
+        }
     }
 }
 
@@ -124,6 +134,7 @@ pub(crate) fn replace_workspace_from_project(
     reset_transient_state(state);
     reset_chart_caches(state);
     state.load_viewport_for_active_entry();
+    state.mark_project_saved();
     let set_current_dir_error = std::env::set_current_dir(&project.root).err();
     if let Err(error) =
         remember_opened_project(&mut state.config, &mut state.recent_projects, &project)
@@ -185,29 +196,30 @@ pub(crate) fn create_project_action(state: &mut AppState) {
     }
 }
 
-pub(crate) fn open_project_action(state: &mut AppState) {
-    let Some(path) = rfd::FileDialog::new()
+fn pick_project_folder(state: &AppState) -> Option<PathBuf> {
+    rfd::FileDialog::new()
         .set_directory(&state.config.default_project_dir)
         .pick_folder()
-    else {
-        return;
-    };
-    open_project_path(state, path);
 }
 
-pub(crate) fn open_project_path(state: &mut AppState, path: PathBuf) {
-    persist_project(state, true);
+fn open_project_action_without_persist(state: &mut AppState) {
+    let Some(path) = pick_project_folder(state) else {
+        return;
+    };
+    open_project_path_without_persist(state, path);
+}
+
+fn open_project_path_without_persist(state: &mut AppState, path: PathBuf) {
     match open_project_dir(&path) {
         Ok((project, snapshot)) => replace_workspace_from_project(state, project, snapshot),
         Err(error) => state.set_message(error.to_string()),
     }
 }
 
-pub(crate) fn close_project(state: &mut AppState) {
-    persist_project(state, true);
+fn close_project_without_persist(state: &mut AppState, run_maintenance: bool) {
     // Compact the databases and release the lock now that we are leaving cleanly.
     if let Some(project) = state.workspace.project().cloned() {
-        if let Err(error) = housekeeping::run_maintenance(&project) {
+        if run_maintenance && let Err(error) = housekeeping::run_maintenance(&project) {
             state.set_message(format!("Project maintenance failed: {error}"));
         }
         housekeeping::release_lock(&project);
@@ -230,15 +242,117 @@ pub(crate) fn close_project(state: &mut AppState) {
     reset_transient_state(state);
     reset_chart_caches(state);
     state.clear_history();
+    state.mark_project_saved();
 }
 
 pub(crate) fn save_project(state: &mut AppState) {
     if state.workspace.is_project() {
-        persist_project(state, true);
-        state.set_message(format!("Saved project {}", state.workspace.label()));
+        if persist_project(state, true).is_ok() {
+            state.set_message(format!("Saved project {}", state.workspace.label()));
+        }
         return;
     }
     create_project_action(state);
+}
+
+pub(crate) fn request_leave(state: &mut AppState, intent: LeaveIntent, ctx: &egui::Context) {
+    if state.needs_leave_confirmation() {
+        let mut confirmation = LeaveConfirmation::new(intent);
+        if let Some(error) = state.project_save_error() {
+            confirmation.save_error = Some(error.to_string());
+        }
+        state.ui.leave_confirmation = Some(confirmation);
+        return;
+    }
+
+    if let Err(error) = execute_leave_intent(state, intent.clone(), ctx, true) {
+        state.ui.leave_confirmation =
+            Some(LeaveConfirmation::save_failed(intent, error.to_string()));
+    }
+}
+
+pub(crate) fn cancel_leave(state: &mut AppState) {
+    state.ui.leave_confirmation = None;
+}
+
+pub(crate) fn save_and_leave(state: &mut AppState, ctx: &egui::Context) {
+    let Some(confirmation) = state.ui.leave_confirmation.take() else {
+        return;
+    };
+    let intent = confirmation.intent;
+    if let Err(error) = execute_leave_intent(state, intent.clone(), ctx, true) {
+        state.ui.leave_confirmation =
+            Some(LeaveConfirmation::save_failed(intent, error.to_string()));
+    }
+}
+
+pub(crate) fn discard_and_leave(state: &mut AppState, ctx: &egui::Context) {
+    let Some(confirmation) = state.ui.leave_confirmation.take() else {
+        return;
+    };
+    let intent = confirmation.intent;
+    if let Err(error) = execute_leave_intent(state, intent.clone(), ctx, false) {
+        state.ui.leave_confirmation =
+            Some(LeaveConfirmation::save_failed(intent, error.to_string()));
+    }
+}
+
+fn execute_leave_intent(
+    state: &mut AppState,
+    intent: LeaveIntent,
+    ctx: &egui::Context,
+    save_current: bool,
+) -> anyhow::Result<()> {
+    if save_current && state.scratch_has_unsaved_content() {
+        create_project_action(state);
+        if state.scratch_has_unsaved_content() {
+            state.ui.leave_confirmation = Some(LeaveConfirmation::new(intent));
+            return Ok(());
+        }
+    }
+
+    match intent {
+        LeaveIntent::Quit => {
+            if save_current {
+                shutdown(state)?;
+            } else {
+                abandon_project_session(state);
+                if state.layout_save_deadline().is_some() {
+                    persist_layout(state);
+                }
+            }
+            state.ui.allow_window_close = true;
+            state.ui.request_window_close = true;
+            ctx.request_repaint();
+        }
+        LeaveIntent::OpenProject => {
+            if save_current {
+                persist_project(state, true)?;
+            }
+            open_project_action_without_persist(state);
+        }
+        LeaveIntent::OpenRecentProject(path) => {
+            if save_current {
+                persist_project(state, true)?;
+            }
+            open_project_path_without_persist(state, path);
+        }
+        LeaveIntent::CloseProject => {
+            if save_current {
+                persist_project(state, true)?;
+                close_project_without_persist(state, true);
+            } else {
+                close_project_without_persist(state, false);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn abandon_project_session(state: &mut AppState) {
+    if let Some(project) = state.workspace.project() {
+        housekeeping::release_lock(project);
+    }
 }
 
 pub(crate) fn load_active_entry(state: &mut AppState) {

--- a/src/frontend/state/app.rs
+++ b/src/frontend/state/app.rs
@@ -53,6 +53,8 @@ pub struct AppState {
     workspace_structure: Structure,
     workspace_save_path: PathBuf,
     last_logged_message: String,
+    last_saved_entries_fingerprint: u64,
+    project_save_error: Option<String>,
     /// egui time (seconds) at which a coalesced autosave should flush, or `None`
     /// when no project change is pending. Set by the dispatcher after a
     /// persist-worthy action and drained on the UI thread once the debounce
@@ -115,6 +117,8 @@ impl AppState {
             workspace_structure: structure,
             workspace_save_path: save_path,
             last_logged_message: message,
+            last_saved_entries_fingerprint: 0,
+            project_save_error: None,
             autosave_deadline: None,
             layout_save_deadline: None,
         };
@@ -146,6 +150,7 @@ impl AppState {
         state
             .history
             .set_active_entry(state.entries.active_entry_id());
+        state.mark_project_saved();
         state
     }
 
@@ -328,6 +333,58 @@ impl AppState {
             group.name.hash(&mut hasher);
         }
         hasher.finish()
+    }
+
+    pub fn mark_project_saved(&mut self) {
+        self.last_saved_entries_fingerprint = self.entries_fingerprint();
+        self.project_save_error = None;
+    }
+
+    pub fn mark_project_save_failed(&mut self, error: impl Into<String>) {
+        self.project_save_error = Some(error.into());
+    }
+
+    pub fn project_save_error(&self) -> Option<&str> {
+        self.project_save_error.as_deref()
+    }
+
+    pub fn has_project_changes_to_save(&self) -> bool {
+        self.workspace.is_project()
+            && (self.autosave_deadline.is_some()
+                || self.entries_fingerprint() != self.last_saved_entries_fingerprint
+                || self.project_save_error.is_some())
+    }
+
+    pub fn has_unsaved_workspace_drafts(&self) -> bool {
+        self.ui.editor.is_some()
+            || self.ui.sketcher.is_some()
+            || self.ui.reticular_builder.is_some()
+            || self.ui.nanosheet_builder.is_some()
+            || self.ui.block_editor.is_some()
+            || self.ui.pending_optimization.is_some()
+            || self.ui.pending_qm.is_some()
+            || self.ui.pending_supercell.is_some()
+            || self.ui.pending_protein_prep.is_some()
+            || self.ui.pending_md_system.is_some()
+            || self.ui.pending_md_run.is_some()
+            || self.ui.pending_disorder.is_some()
+            || self.ui.pending_docking.is_some()
+            || self.ui.pending_ptm.is_some()
+            || self.ui.pending_pdb_fetch.is_some()
+            || self.ui.pending_export.is_some()
+    }
+
+    pub fn scratch_has_unsaved_content(&self) -> bool {
+        !self.workspace.is_project()
+            && (!self.entries.records.is_empty()
+                || !self.tasks.tasks.is_empty()
+                || self.has_unsaved_workspace_drafts())
+    }
+
+    pub fn needs_leave_confirmation(&self) -> bool {
+        self.scratch_has_unsaved_content()
+            || self.has_project_changes_to_save()
+            || self.has_unsaved_workspace_drafts()
     }
 
     /// Schedule a coalesced autosave to flush `delay_seconds` after `now_seconds`

--- a/src/frontend/state/app/tests.rs
+++ b/src/frontend/state/app/tests.rs
@@ -1,4 +1,10 @@
 use super::*;
+use std::path::PathBuf;
+
+use crate::{
+    backend::project::{ProjectSession, WorkspaceSession},
+    domain::Structure,
+};
 
 #[test]
 fn remote_gpu_live_apply_tracks_latest_and_history() {
@@ -27,4 +33,48 @@ fn remote_gpu_live_apply_tracks_latest_and_history() {
     assert_eq!(live.gpus[0].util_history.len(), 2);
     assert_eq!(live.gpus[0].util_history.back().copied(), Some(Some(80.0)));
     assert!(live.last_error.is_none());
+}
+
+#[test]
+fn scratch_content_requires_leave_confirmation() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    assert!(!state.needs_leave_confirmation());
+
+    state
+        .entries
+        .add_entry(Structure::empty(), None, PathBuf::from("scratch.cif"));
+
+    assert!(state.scratch_has_unsaved_content());
+    assert!(state.needs_leave_confirmation());
+}
+
+#[test]
+fn project_saved_fingerprint_tracks_leave_confirmation() {
+    let project =
+        ProjectSession::from_root(PathBuf::from("target/test-leave-project"), "test".into());
+    let mut state = AppState::new(
+        Structure::empty(),
+        None,
+        WorkspaceSession::Project(project),
+        Default::default(),
+        Vec::new(),
+        None,
+    );
+
+    assert!(!state.has_project_changes_to_save());
+    assert!(!state.needs_leave_confirmation());
+
+    state
+        .entries
+        .add_entry(Structure::empty(), None, PathBuf::from("entry.cif"));
+    assert!(state.has_project_changes_to_save());
+    assert!(state.needs_leave_confirmation());
+
+    state.mark_project_saved();
+    assert!(!state.has_project_changes_to_save());
+    assert!(!state.needs_leave_confirmation());
+
+    state.mark_project_save_failed("disk full");
+    assert!(state.has_project_changes_to_save());
+    assert!(state.needs_leave_confirmation());
 }

--- a/src/frontend/state/app/ui_state.rs
+++ b/src/frontend/state/app/ui_state.rs
@@ -109,6 +109,15 @@ pub struct UiState {
     pub pending_pdb_fetch: Option<String>,
     /// The open Export dialog's draft, or `None` when it is closed.
     pub pending_export: Option<crate::frontend::state::ExportPrompt>,
+    /// Modal confirmation shown before leaving when the current workspace has
+    /// changes or scratch data that could be lost.
+    pub leave_confirmation: Option<crate::frontend::actions::LeaveConfirmation>,
+    /// Set after the user confirmed quitting. The next native close request is
+    /// allowed through instead of being intercepted into another confirmation.
+    pub allow_window_close: bool,
+    /// One-frame latch used to issue the actual window close after a canceled
+    /// native close request has completed.
+    pub request_window_close: bool,
     /// The single active non-modal notification (a message plus optional action
     /// buttons), or `None`. Posting a new one replaces any current one.
     pub notification: Option<crate::frontend::actions::Notification>,
@@ -243,6 +252,9 @@ impl Default for UiState {
             pending_ptm: None,
             pending_pdb_fetch: None,
             pending_export: None,
+            leave_confirmation: None,
+            allow_window_close: false,
+            request_window_close: false,
             notification: None,
             pending_heavy_gate: None,
             heavy_render_decided: std::collections::BTreeSet::new(),

--- a/src/frontend/ui/leave_confirm.rs
+++ b/src/frontend/ui/leave_confirm.rs
@@ -1,0 +1,136 @@
+//! Confirmation shown before the user leaves with unsaved project or Scratch
+//! data. The dialog only emits actions; the dispatcher owns all persistence and
+//! workspace transitions.
+
+use eframe::egui::{self, Align, Button, Color32, Layout, RichText};
+
+use crate::frontend::{actions::AppAction, state::AppState};
+
+const WINDOW_WIDTH: f32 = 460.0;
+const WINDOW_HEIGHT_SINGLE_LINE: f32 = 112.0;
+const WINDOW_HEIGHT_WRAPPED: f32 = 140.0;
+const BUTTON_ROW_HEIGHT: f32 = 28.0;
+
+pub fn show(state: &mut AppState, ctx: &egui::Context, actions: &mut Vec<AppAction>) {
+    let Some(confirmation) = state.ui.leave_confirmation.as_ref() else {
+        return;
+    };
+
+    let intent = confirmation.intent.clone();
+    let save_error = confirmation.save_error.clone();
+    let scratch = state.scratch_has_unsaved_content();
+    let has_drafts = state.has_unsaved_workspace_drafts();
+    let workspace = state.workspace_label();
+
+    super::modal::render_backdrop(state, ctx, "leave_confirm_backdrop");
+
+    let has_save_error = save_error.is_some();
+    let title = if has_save_error {
+        "Could not save project"
+    } else if scratch {
+        "Save Scratch before leaving?"
+    } else {
+        "Save changes before leaving?"
+    };
+
+    let body = if let Some(error) = save_error.as_ref() {
+        format!("SilicoLab could not save {workspace}. {error}")
+    } else if scratch {
+        format!(
+            "Scratch is not stored after SilicoLab closes. Create a project to keep this workspace before you {}.",
+            intent.action_label()
+        )
+    } else if has_drafts {
+        format!(
+            "Save {workspace} before you {}. Open editors or task drafts that were not applied will be discarded.",
+            intent.action_label()
+        )
+    } else {
+        format!(
+            "Save the latest changes to {workspace} before you {}.",
+            intent.action_label()
+        )
+    };
+    let window_height = if has_save_error || scratch || has_drafts || body.chars().count() > 78 {
+        WINDOW_HEIGHT_WRAPPED
+    } else {
+        WINDOW_HEIGHT_SINGLE_LINE
+    };
+
+    let mut cancel = false;
+
+    egui::Window::new("leave_confirm")
+        .id(egui::Id::new("leave_confirm"))
+        .title_bar(false)
+        .resizable(false)
+        .collapsible(false)
+        .order(egui::Order::Foreground)
+        .frame(super::modal::window_frame(ctx, egui::Margin::same(18)))
+        .pivot(egui::Align2::CENTER_CENTER)
+        .default_pos(ctx.content_rect().center())
+        .fixed_size([WINDOW_WIDTH, window_height])
+        .show(ctx, |ui| {
+            ui.set_width(WINDOW_WIDTH);
+            let pal = crate::frontend::theme::palette(ui);
+
+            ui.horizontal(|ui| {
+                ui.heading(title);
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    if ui
+                        .button(RichText::new(egui_phosphor::regular::X))
+                        .on_hover_text("Cancel")
+                        .clicked()
+                    {
+                        cancel = true;
+                    }
+                });
+            });
+
+            ui.add_space(8.0);
+            ui.add(
+                egui::Label::new(RichText::new(body).color(pal.text_muted))
+                    .wrap_mode(egui::TextWrapMode::Wrap),
+            );
+            ui.add_space(18.0);
+
+            ui.allocate_ui_with_layout(
+                egui::vec2(ui.available_width(), BUTTON_ROW_HEIGHT),
+                Layout::right_to_left(Align::Center),
+                |ui| {
+                    let primary_label = if scratch {
+                        "Create Project"
+                    } else {
+                        intent.save_button_label()
+                    };
+                    if ui
+                        .add(
+                            Button::new(RichText::new(primary_label).color(Color32::WHITE))
+                                .fill(pal.status_blue),
+                        )
+                        .clicked()
+                    {
+                        actions.push(AppAction::SaveAndLeave);
+                    }
+
+                    let discard_label = if scratch { "Discard" } else { "Don't Save" };
+                    if ui
+                        .add(
+                            Button::new(RichText::new(discard_label).color(Color32::WHITE))
+                                .fill(pal.status_red),
+                        )
+                        .clicked()
+                    {
+                        actions.push(AppAction::DiscardAndLeave);
+                    }
+
+                    if ui.button("Cancel").clicked() {
+                        actions.push(AppAction::CancelLeave);
+                    }
+                },
+            );
+        });
+
+    if cancel || ctx.input(|input| input.key_pressed(egui::Key::Escape)) {
+        actions.push(AppAction::CancelLeave);
+    }
+}

--- a/src/frontend/ui/mod.rs
+++ b/src/frontend/ui/mod.rs
@@ -22,6 +22,7 @@ mod dock;
 mod execution;
 mod export_modal;
 pub(crate) mod gauge;
+mod leave_confirm;
 mod modal;
 mod notification;
 mod panel_bodies;
@@ -467,5 +468,6 @@ pub fn show_workbench(state: &mut AppState, ui: &mut egui::Ui, actions: &mut Vec
     render_text_viewer_window(state, &ctx);
     settings_modal::show(state, &ctx, actions);
     about::show(state, &ctx, actions);
+    leave_confirm::show(state, &ctx, actions);
     panel_bodies::render_monitor_popover(state, &ctx);
 }


### PR DESCRIPTION
Summary:
- Prompt before quitting, closing, or switching away with unsaved workspace state.
- Keep the app open when project save fails and surface the error in the dialog.
- Add focused state tests for the leave guard.

Checks:
- cargo pr-check