### PR TITLE
fix(project): persist assistant chat history

### DIFF
--- a/src/backend/storage.rs
+++ b/src/backend/storage.rs
@@ -5,6 +5,7 @@ use crate::{
     frontend::ViewportVisualState,
 };
 
+mod assistant;
 mod entries;
 mod history;
 pub mod jobs;
@@ -16,6 +17,7 @@ mod tasks;
 mod view_load;
 mod view_save;
 
+pub use assistant::*;
 pub(crate) use entries::*;
 pub(crate) use history::*;
 pub use project::*;
@@ -36,6 +38,8 @@ pub struct ProjectSnapshot {
     pub tasks: TaskManager,
     pub view: ProjectViewSettings,
     pub history: History,
+    pub assistant: ProjectAssistantSnapshot,
+    pub warnings: Vec<String>,
 }
 
 /// Borrowed view of the data a save reads. Saving only needs read access, so the
@@ -48,6 +52,7 @@ pub struct ProjectSnapshotRef<'a> {
     pub tasks: &'a TaskManager,
     pub view: &'a ProjectViewSettings,
     pub history: &'a History,
+    pub assistant: &'a ProjectAssistantSnapshot,
 }
 
 impl ProjectSnapshot {
@@ -58,6 +63,7 @@ impl ProjectSnapshot {
             tasks: &self.tasks,
             view: &self.view,
             history: &self.history,
+            assistant: &self.assistant,
         }
     }
 }

--- a/src/backend/storage/assistant.rs
+++ b/src/backend/storage/assistant.rs
@@ -1,0 +1,211 @@
+use std::{
+    hash::{Hash, Hasher},
+    io::{Read, Write},
+};
+
+use anyhow::{Context, Result, bail};
+use flate2::{Compression, read::ZlibDecoder, write::ZlibEncoder};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+
+pub const ASSISTANT_STATE_FORMAT: i64 = 1;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProjectAssistantSnapshot {
+    pub version: u32,
+    #[serde(default)]
+    pub active_conversation: u64,
+    #[serde(default)]
+    pub next_conversation_id: u64,
+    #[serde(default)]
+    pub next_conversation_number: u64,
+    #[serde(default)]
+    pub conversations: Vec<PersistedAssistantConversation>,
+}
+
+impl Default for ProjectAssistantSnapshot {
+    fn default() -> Self {
+        Self {
+            version: ASSISTANT_STATE_FORMAT as u32,
+            active_conversation: 0,
+            next_conversation_id: 1,
+            next_conversation_number: 1,
+            conversations: Vec::new(),
+        }
+    }
+}
+
+impl ProjectAssistantSnapshot {
+    pub fn fingerprint(&self) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        match serde_json::to_vec(self) {
+            Ok(bytes) => bytes.hash(&mut hasher),
+            Err(_) => self.conversations.len().hash(&mut hasher),
+        }
+        hasher.finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PersistedAssistantConversation {
+    pub id: u64,
+    pub title: String,
+    #[serde(default)]
+    pub history: Vec<PersistedChatMessage>,
+    #[serde(default)]
+    pub transcript: Vec<PersistedTranscriptEntry>,
+    #[serde(default)]
+    pub input: String,
+    #[serde(default)]
+    pub session_usage: PersistedUsage,
+    #[serde(default)]
+    pub last_usage: Option<PersistedUsage>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PersistedRole {
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PersistedChatMessage {
+    pub role: PersistedRole,
+    #[serde(default)]
+    pub content: Vec<PersistedContentBlock>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PersistedContentBlock {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+        is_error: bool,
+    },
+    OpaqueReasoning {
+        reasoning: PersistedReasoningBlob,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PersistedReasoningBlob {
+    None,
+    Anthropic { blocks: Vec<serde_json::Value> },
+    OpenAiCompat { reasoning_content: Option<String> },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PersistedTranscriptEntry {
+    User {
+        text: String,
+    },
+    Assistant {
+        text: String,
+    },
+    Tool {
+        summary: String,
+        result: Option<String>,
+        is_error: bool,
+    },
+    Notice {
+        text: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersistedUsage {
+    #[serde(default)]
+    pub input: u32,
+    #[serde(default)]
+    pub output: u32,
+    #[serde(default)]
+    pub cache_read: u32,
+    #[serde(default)]
+    pub cache_write: u32,
+}
+
+pub(crate) fn save_assistant_state(
+    db: &Connection,
+    snapshot: &ProjectAssistantSnapshot,
+) -> Result<()> {
+    let json = serde_json::to_vec(snapshot).context("serialize assistant state")?;
+    let payload = compress(&json)?;
+    db.execute("delete from assistant_state", [])?;
+    db.execute(
+        "insert into assistant_state (id, format, payload, uncompressed_len, updated_at_ms) values (1, ?1, ?2, ?3, ?4)",
+        params![
+            ASSISTANT_STATE_FORMAT,
+            payload,
+            json.len() as i64,
+            now_ms(),
+        ],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn load_assistant_state(db: &Connection) -> Result<ProjectAssistantSnapshot> {
+    let Some((format, payload, uncompressed_len)) = db
+        .query_row(
+            "select format, payload, uncompressed_len from assistant_state where id = 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, i64>(2)? as usize,
+                ))
+            },
+        )
+        .optional()?
+    else {
+        return Ok(ProjectAssistantSnapshot::default());
+    };
+    if format != ASSISTANT_STATE_FORMAT {
+        bail!("unsupported assistant state format {format}");
+    }
+    let json = decompress(&payload, uncompressed_len)?;
+    let snapshot: ProjectAssistantSnapshot =
+        serde_json::from_slice(&json).context("deserialize assistant state")?;
+    if snapshot.version > ASSISTANT_STATE_FORMAT as u32 {
+        bail!("unsupported assistant state version {}", snapshot.version);
+    }
+    Ok(snapshot)
+}
+
+fn compress(json: &[u8]) -> Result<Vec<u8>> {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(json)
+        .context("compress assistant state")?;
+    encoder.finish().context("finish assistant compression")
+}
+
+fn decompress(bytes: &[u8], uncompressed_len: usize) -> Result<Vec<u8>> {
+    let mut decoder = ZlibDecoder::new(bytes);
+    let mut out = Vec::with_capacity(uncompressed_len);
+    decoder
+        .read_to_end(&mut out)
+        .context("decompress assistant state")?;
+    Ok(out)
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or(0)
+}

--- a/src/backend/storage/project.rs
+++ b/src/backend/storage/project.rs
@@ -44,6 +44,13 @@ pub fn load_project_snapshot(session: &ProjectSession) -> Result<ProjectSnapshot
     let view = load_project_view_settings(&project_db)?;
     let mut history = load_history(&project_db)?;
     history.set_active_entry(entries.active_entry_id());
+    let (assistant, warnings) = match load_assistant_state(&project_db) {
+        Ok(assistant) => (assistant, Vec::new()),
+        Err(error) => (
+            ProjectAssistantSnapshot::default(),
+            vec![format!("Assistant history could not be restored: {error}")],
+        ),
+    };
 
     Ok(ProjectSnapshot {
         name,
@@ -51,6 +58,8 @@ pub fn load_project_snapshot(session: &ProjectSession) -> Result<ProjectSnapshot
         tasks,
         view,
         history,
+        assistant,
+        warnings,
     })
 }
 
@@ -201,6 +210,7 @@ pub fn save_project_snapshot_ref(
         )?;
     }
     save_project_view_settings(&project_tx, snapshot.view)?;
+    save_assistant_state(&project_tx, snapshot.assistant)?;
 
     if persist_history {
         save_history(&project_tx, snapshot.history)?;

--- a/src/backend/storage/schema.rs
+++ b/src/backend/storage/schema.rs
@@ -65,6 +65,13 @@ pub(crate) fn create_project_schema(db: &Connection) -> Result<()> {
             uncompressed_len integer not null,
             primary key (entry_id, stack, position)
         );
+        create table if not exists assistant_state (
+            id integer primary key check (id = 1),
+            format integer not null,
+            payload blob not null,
+            uncompressed_len integer not null,
+            updated_at_ms integer not null
+        );
         ",
     )?;
     ensure_task_run_columns(db)?;

--- a/src/backend/storage/tests.rs
+++ b/src/backend/storage/tests.rs
@@ -9,8 +9,11 @@ use crate::{
         history::{EditSnapshot, History},
         project::ProjectSession,
         storage::{
-            ProjectSnapshot, ProjectViewSettings, initialize_project_databases,
-            load_project_snapshot, load_structure_for_compound, save_project_snapshot,
+            ASSISTANT_STATE_FORMAT, PersistedAssistantConversation, PersistedChatMessage,
+            PersistedContentBlock, PersistedRole, PersistedTranscriptEntry, PersistedUsage,
+            ProjectAssistantSnapshot, ProjectSnapshot, ProjectViewSettings,
+            initialize_project_databases, load_project_snapshot, load_structure_for_compound,
+            save_project_snapshot,
         },
         tasks::TaskManager,
     },
@@ -51,6 +54,8 @@ fn structure_roundtrips_through_project_databases() {
         tasks: TaskManager::default(),
         view: ProjectViewSettings::default(),
         history: History::default(),
+        assistant: ProjectAssistantSnapshot::default(),
+        warnings: Vec::new(),
     };
 
     save_project_snapshot(&session, &snapshot, true).unwrap();
@@ -92,6 +97,8 @@ fn entry_origin_roundtrips_through_project_databases() {
         tasks: TaskManager::default(),
         view: ProjectViewSettings::default(),
         history: History::default(),
+        assistant: ProjectAssistantSnapshot::default(),
+        warnings: Vec::new(),
     };
 
     save_project_snapshot(&session, &snapshot, true).unwrap();
@@ -133,6 +140,8 @@ END
         tasks: TaskManager::default(),
         view: ProjectViewSettings::default(),
         history: History::default(),
+        assistant: ProjectAssistantSnapshot::default(),
+        warnings: Vec::new(),
     };
 
     save_project_snapshot(&session, &snapshot, true).unwrap();
@@ -243,6 +252,8 @@ fn project_view_settings_roundtrip_surface_overrides() {
             tasks: TaskManager::default(),
             view,
             history: History::default(),
+            assistant: ProjectAssistantSnapshot::default(),
+            warnings: Vec::new(),
         },
         true,
     )
@@ -320,6 +331,8 @@ fn entry_view_settings_roundtrip_without_leaking_to_other_entries() {
             tasks: TaskManager::default(),
             view,
             history: History::default(),
+            assistant: ProjectAssistantSnapshot::default(),
+            warnings: Vec::new(),
         },
         true,
     )
@@ -371,6 +384,8 @@ fn entries_without_open_tabs_are_loaded_lazily() {
             tasks: TaskManager::default(),
             view: ProjectViewSettings::default(),
             history: History::default(),
+            assistant: ProjectAssistantSnapshot::default(),
+            warnings: Vec::new(),
         },
         true,
     )
@@ -406,6 +421,8 @@ fn unchanged_compounds_are_not_rewritten() {
         tasks: TaskManager::default(),
         view: ProjectViewSettings::default(),
         history: History::default(),
+        assistant: ProjectAssistantSnapshot::default(),
+        warnings: Vec::new(),
     };
     save_project_snapshot(&session, &snapshot, true).unwrap();
 
@@ -456,6 +473,8 @@ fn undo_history_survives_save_and_load() {
             tasks: TaskManager::default(),
             view: ProjectViewSettings::default(),
             history,
+            assistant: ProjectAssistantSnapshot::default(),
+            warnings: Vec::new(),
         },
         true,
     )
@@ -468,4 +487,145 @@ fn undo_history_survives_save_and_load() {
     let snapshot = restored.take_undo().expect("undo snapshot restored");
     assert_eq!(snapshot.structure.title, "before-edit");
     assert_eq!(snapshot.selection.ordered_indices(), vec![0]);
+}
+
+#[test]
+fn assistant_history_survives_save_and_load() {
+    let root = PathBuf::from("target/test-project-assistant-history");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join(".silicolab")).unwrap();
+    let session = ProjectSession::from_root(root, "Assistant".to_string());
+    initialize_project_databases(&session).unwrap();
+
+    let assistant = ProjectAssistantSnapshot {
+        version: ASSISTANT_STATE_FORMAT as u32,
+        active_conversation: 2,
+        next_conversation_id: 3,
+        next_conversation_number: 3,
+        conversations: vec![PersistedAssistantConversation {
+            id: 2,
+            title: "Protein setup".to_string(),
+            history: vec![
+                PersistedChatMessage {
+                    role: PersistedRole::User,
+                    content: vec![PersistedContentBlock::Text {
+                        text: "prepare 1ubq".to_string(),
+                    }],
+                },
+                PersistedChatMessage {
+                    role: PersistedRole::Assistant,
+                    content: vec![PersistedContentBlock::Text {
+                        text: "Loaded it.".to_string(),
+                    }],
+                },
+            ],
+            transcript: vec![
+                PersistedTranscriptEntry::User {
+                    text: "prepare 1ubq".to_string(),
+                },
+                PersistedTranscriptEntry::Assistant {
+                    text: "Loaded it.".to_string(),
+                },
+                PersistedTranscriptEntry::Tool {
+                    summary: "fetch 1ubq".to_string(),
+                    result: Some("Created entry #1".to_string()),
+                    is_error: false,
+                },
+            ],
+            input: "next step".to_string(),
+            session_usage: PersistedUsage {
+                input: 12,
+                output: 5,
+                cache_read: 2,
+                cache_write: 1,
+            },
+            last_usage: Some(PersistedUsage {
+                input: 7,
+                output: 3,
+                cache_read: 0,
+                cache_write: 0,
+            }),
+        }],
+    };
+
+    save_project_snapshot(
+        &session,
+        &ProjectSnapshot {
+            name: "Assistant".to_string(),
+            entries: EntryStore::new_empty(),
+            tasks: TaskManager::default(),
+            view: ProjectViewSettings::default(),
+            history: History::default(),
+            assistant: assistant.clone(),
+            warnings: Vec::new(),
+        },
+        true,
+    )
+    .unwrap();
+
+    let loaded = load_project_snapshot(&session).unwrap();
+    assert!(loaded.warnings.is_empty());
+    assert_eq!(loaded.assistant, assistant);
+}
+
+#[test]
+fn old_project_without_assistant_state_loads_default_assistant() {
+    let root = PathBuf::from("target/test-project-no-assistant-state");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join(".silicolab")).unwrap();
+    let session = ProjectSession::from_root(root, "Legacy".to_string());
+    initialize_project_databases(&session).unwrap();
+
+    let loaded = load_project_snapshot(&session).unwrap();
+
+    assert!(loaded.warnings.is_empty());
+    assert!(loaded.assistant.conversations.is_empty());
+}
+
+#[test]
+fn corrupt_assistant_state_warns_but_project_loads() {
+    let root = PathBuf::from("target/test-project-corrupt-assistant");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join(".silicolab")).unwrap();
+    let session = ProjectSession::from_root(root, "CorruptAssistant".to_string());
+    initialize_project_databases(&session).unwrap();
+
+    save_project_snapshot(
+        &session,
+        &ProjectSnapshot {
+            name: "CorruptAssistant".to_string(),
+            entries: EntryStore::new_empty(),
+            tasks: TaskManager::default(),
+            view: ProjectViewSettings::default(),
+            history: History::default(),
+            assistant: ProjectAssistantSnapshot {
+                conversations: vec![PersistedAssistantConversation {
+                    id: 1,
+                    title: "Chat".to_string(),
+                    history: Vec::new(),
+                    transcript: Vec::new(),
+                    input: String::new(),
+                    session_usage: PersistedUsage::default(),
+                    last_usage: None,
+                }],
+                ..ProjectAssistantSnapshot::default()
+            },
+            warnings: Vec::new(),
+        },
+        true,
+    )
+    .unwrap();
+    let db = Connection::open(&session.project_db).unwrap();
+    db.execute(
+        "update assistant_state set payload = ?1, uncompressed_len = ?2 where id = 1",
+        params![vec![0u8, 1, 2], 16i64],
+    )
+    .unwrap();
+    drop(db);
+
+    let loaded = load_project_snapshot(&session).unwrap();
+
+    assert!(loaded.assistant.conversations.is_empty());
+    assert_eq!(loaded.warnings.len(), 1);
+    assert!(loaded.warnings[0].contains("Assistant history"));
 }

--- a/src/frontend/agent/session.rs
+++ b/src/frontend/agent/session.rs
@@ -9,6 +9,8 @@ use std::ops::{Deref, DerefMut};
 use crate::frontend::console::RiskLevel;
 use crate::io::llm::types::{ChatMessage, ContentBlock, ToolCall, Usage};
 
+mod persistence;
+
 /// Where the session is in the turn cycle.
 ///
 /// ```text
@@ -94,6 +96,10 @@ pub struct AssistantConversationId(u64);
 impl AssistantConversationId {
     pub fn new(raw: u64) -> Self {
         Self(raw)
+    }
+
+    pub fn raw(self) -> u64 {
+        self.0
     }
 }
 
@@ -567,6 +573,49 @@ mod tests {
         assert_eq!(session.input, "second draft");
         assert_eq!(session.session_usage.output, 11);
         assert_eq!(session.history.len(), 1);
+    }
+
+    #[test]
+    fn project_snapshot_restores_conversations_without_runtime_state() {
+        let mut session = AgentSession::default();
+        let first = session.active_conversation;
+        session.start_new_conversation();
+        session
+            .transcript
+            .push(TranscriptEntry::Assistant("second".to_string()));
+        let active = session.active_conversation;
+        session.switch_conversation(first);
+        session.history.push(ChatMessage::user_text("prepare 1ubq"));
+        session
+            .transcript
+            .push(TranscriptEntry::User("prepare 1ubq".to_string()));
+        session.input = "draft".to_string();
+        session.session_usage.input = 9;
+        session.phase = AgentPhase::AwaitingApproval;
+        session.pending_calls.push_back(ToolCall {
+            id: "call_1".to_string(),
+            name: "run_command".to_string(),
+            input: serde_json::json!({ "command": "fetch 1ubq" }),
+        });
+        session.active_conversation = active;
+
+        let snapshot = session.project_snapshot();
+        let restored = AgentSession::from_project_snapshot(snapshot);
+
+        assert_eq!(restored.active_conversation, active);
+        assert_eq!(restored.conversations.len(), 2);
+        let first_restored = restored
+            .conversations
+            .iter()
+            .find(|conversation| conversation.id == first)
+            .expect("first conversation restored");
+        assert_eq!(first_restored.input, "draft");
+        assert_eq!(first_restored.session_usage.input, 9);
+        assert!(first_restored.pending_calls.is_empty());
+        assert_eq!(first_restored.phase, AgentPhase::Done);
+        assert!(first_restored.transcript.iter().any(
+            |entry| matches!(entry, TranscriptEntry::Notice(text) if text.contains("interrupted"))
+        ));
     }
 
     #[test]

--- a/src/frontend/agent/session/persistence.rs
+++ b/src/frontend/agent/session/persistence.rs
@@ -1,0 +1,280 @@
+use std::collections::HashMap;
+
+use crate::backend::storage::{
+    PersistedAssistantConversation, PersistedChatMessage, PersistedContentBlock,
+    PersistedReasoningBlob, PersistedRole, PersistedTranscriptEntry, PersistedUsage,
+    ProjectAssistantSnapshot,
+};
+use crate::io::llm::types::{ChatMessage, ContentBlock, ReasoningBlob, Role, Usage};
+
+use super::{
+    AgentPhase, AgentSession, AssistantConversation, AssistantConversationId, ModelFetchStatus,
+    TranscriptEntry, normalize_title,
+};
+
+impl AgentSession {
+    pub fn project_snapshot(&self) -> ProjectAssistantSnapshot {
+        let conversations = self
+            .conversations
+            .iter()
+            .map(persist_conversation)
+            .collect();
+        ProjectAssistantSnapshot {
+            version: crate::backend::storage::ASSISTANT_STATE_FORMAT as u32,
+            active_conversation: self.active_conversation.raw(),
+            next_conversation_id: self.next_conversation_id,
+            next_conversation_number: self.next_conversation_number,
+            conversations,
+        }
+    }
+
+    pub fn from_project_snapshot(snapshot: ProjectAssistantSnapshot) -> Self {
+        if snapshot.conversations.is_empty() {
+            return Self::default();
+        }
+        let mut conversations: Vec<AssistantConversation> = snapshot
+            .conversations
+            .into_iter()
+            .filter(|conversation| conversation.id != 0)
+            .map(restore_conversation)
+            .collect();
+        if conversations.is_empty() {
+            return Self::default();
+        }
+        conversations.sort_by_key(|conversation| conversation.id.raw());
+        let active_conversation = conversations
+            .iter()
+            .find(|conversation| conversation.id.raw() == snapshot.active_conversation)
+            .map(|conversation| conversation.id)
+            .unwrap_or(conversations[0].id);
+        let max_id = conversations
+            .iter()
+            .map(|conversation| conversation.id.raw())
+            .max()
+            .unwrap_or(1);
+        let next_conversation_id = snapshot.next_conversation_id.max(max_id + 1).max(2);
+        let next_conversation_number = snapshot
+            .next_conversation_number
+            .max(conversations.len() as u64 + 1)
+            .max(2);
+        Self {
+            conversations,
+            active_conversation,
+            skills: Vec::new(),
+            skills_loaded: false,
+            next_conversation_id,
+            next_conversation_number,
+            renaming_conversation: None,
+            rename_buffer: String::new(),
+            key_available: None,
+            fetched_models: HashMap::new(),
+            model_fetch: ModelFetchStatus::Idle,
+        }
+    }
+}
+
+fn persist_conversation(conversation: &AssistantConversation) -> PersistedAssistantConversation {
+    let mut resumable = conversation.clone();
+    let interrupted = !matches!(conversation.phase, AgentPhase::Idle | AgentPhase::Done)
+        || !conversation.streaming_text.is_empty()
+        || !conversation.pending_calls.is_empty()
+        || !conversation.collected_results.is_empty();
+    resumable.truncate_to_resumable();
+    let mut transcript = resumable
+        .transcript
+        .iter()
+        .map(persist_transcript_entry)
+        .collect::<Vec<_>>();
+    if interrupted {
+        transcript.push(PersistedTranscriptEntry::Notice {
+            text: "Previous assistant turn was interrupted before it could be restored."
+                .to_string(),
+        });
+    }
+    PersistedAssistantConversation {
+        id: conversation.id.raw(),
+        title: conversation.title.clone(),
+        history: resumable.history.iter().map(persist_message).collect(),
+        transcript,
+        input: conversation.input.clone(),
+        session_usage: persist_usage(conversation.session_usage),
+        last_usage: conversation.last_usage.map(persist_usage),
+    }
+}
+
+fn restore_conversation(payload: PersistedAssistantConversation) -> AssistantConversation {
+    let id = AssistantConversationId::new(payload.id);
+    let title = normalize_title(&payload.title);
+    let mut conversation = AssistantConversation::new(id, title);
+    conversation.history = payload.history.into_iter().map(restore_message).collect();
+    conversation.transcript = payload
+        .transcript
+        .into_iter()
+        .map(restore_transcript_entry)
+        .collect();
+    conversation.input = payload.input;
+    conversation.session_usage = restore_usage(payload.session_usage);
+    conversation.last_usage = payload.last_usage.map(restore_usage);
+    conversation.phase = if conversation.has_activity() {
+        AgentPhase::Done
+    } else {
+        AgentPhase::Idle
+    };
+    conversation
+}
+
+fn persist_message(message: &ChatMessage) -> PersistedChatMessage {
+    PersistedChatMessage {
+        role: persist_role(message.role),
+        content: message.content.iter().map(persist_content_block).collect(),
+    }
+}
+
+fn restore_message(message: PersistedChatMessage) -> ChatMessage {
+    ChatMessage {
+        role: restore_role(message.role),
+        content: message
+            .content
+            .into_iter()
+            .map(restore_content_block)
+            .collect(),
+    }
+}
+
+fn persist_role(role: Role) -> PersistedRole {
+    match role {
+        Role::System => PersistedRole::System,
+        Role::User => PersistedRole::User,
+        Role::Assistant => PersistedRole::Assistant,
+        Role::Tool => PersistedRole::Tool,
+    }
+}
+
+fn restore_role(role: PersistedRole) -> Role {
+    match role {
+        PersistedRole::System => Role::System,
+        PersistedRole::User => Role::User,
+        PersistedRole::Assistant => Role::Assistant,
+        PersistedRole::Tool => Role::Tool,
+    }
+}
+
+fn persist_content_block(block: &ContentBlock) -> PersistedContentBlock {
+    match block {
+        ContentBlock::Text(text) => PersistedContentBlock::Text { text: text.clone() },
+        ContentBlock::ToolUse { id, name, input } => PersistedContentBlock::ToolUse {
+            id: id.clone(),
+            name: name.clone(),
+            input: input.clone(),
+        },
+        ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+        } => PersistedContentBlock::ToolResult {
+            tool_use_id: tool_use_id.clone(),
+            content: content.clone(),
+            is_error: *is_error,
+        },
+        ContentBlock::OpaqueReasoning(reasoning) => PersistedContentBlock::OpaqueReasoning {
+            reasoning: persist_reasoning(reasoning),
+        },
+    }
+}
+
+fn restore_content_block(block: PersistedContentBlock) -> ContentBlock {
+    match block {
+        PersistedContentBlock::Text { text } => ContentBlock::Text(text),
+        PersistedContentBlock::ToolUse { id, name, input } => {
+            ContentBlock::ToolUse { id, name, input }
+        }
+        PersistedContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+        } => ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+        },
+        PersistedContentBlock::OpaqueReasoning { reasoning } => {
+            ContentBlock::OpaqueReasoning(restore_reasoning(reasoning))
+        }
+    }
+}
+
+fn persist_reasoning(reasoning: &ReasoningBlob) -> PersistedReasoningBlob {
+    match reasoning {
+        ReasoningBlob::None => PersistedReasoningBlob::None,
+        ReasoningBlob::Anthropic(blocks) => PersistedReasoningBlob::Anthropic {
+            blocks: blocks.clone(),
+        },
+        ReasoningBlob::OpenAiCompat { reasoning_content } => PersistedReasoningBlob::OpenAiCompat {
+            reasoning_content: reasoning_content.clone(),
+        },
+    }
+}
+
+fn restore_reasoning(reasoning: PersistedReasoningBlob) -> ReasoningBlob {
+    match reasoning {
+        PersistedReasoningBlob::None => ReasoningBlob::None,
+        PersistedReasoningBlob::Anthropic { blocks } => ReasoningBlob::Anthropic(blocks),
+        PersistedReasoningBlob::OpenAiCompat { reasoning_content } => {
+            ReasoningBlob::OpenAiCompat { reasoning_content }
+        }
+    }
+}
+
+fn persist_transcript_entry(entry: &TranscriptEntry) -> PersistedTranscriptEntry {
+    match entry {
+        TranscriptEntry::User(text) => PersistedTranscriptEntry::User { text: text.clone() },
+        TranscriptEntry::Assistant(text) => {
+            PersistedTranscriptEntry::Assistant { text: text.clone() }
+        }
+        TranscriptEntry::Tool {
+            summary,
+            result,
+            is_error,
+        } => PersistedTranscriptEntry::Tool {
+            summary: summary.clone(),
+            result: result.clone(),
+            is_error: *is_error,
+        },
+        TranscriptEntry::Notice(text) => PersistedTranscriptEntry::Notice { text: text.clone() },
+    }
+}
+
+fn restore_transcript_entry(entry: PersistedTranscriptEntry) -> TranscriptEntry {
+    match entry {
+        PersistedTranscriptEntry::User { text } => TranscriptEntry::User(text),
+        PersistedTranscriptEntry::Assistant { text } => TranscriptEntry::Assistant(text),
+        PersistedTranscriptEntry::Tool {
+            summary,
+            result,
+            is_error,
+        } => TranscriptEntry::Tool {
+            summary,
+            result,
+            is_error,
+        },
+        PersistedTranscriptEntry::Notice { text } => TranscriptEntry::Notice(text),
+    }
+}
+
+fn persist_usage(usage: Usage) -> PersistedUsage {
+    PersistedUsage {
+        input: usage.input,
+        output: usage.output,
+        cache_read: usage.cache_read,
+        cache_write: usage.cache_write,
+    }
+}
+
+fn restore_usage(usage: PersistedUsage) -> Usage {
+    Usage {
+        input: usage.input,
+        output: usage.output,
+        cache_read: usage.cache_read,
+        cache_write: usage.cache_write,
+    }
+}

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -461,6 +461,12 @@ impl SilicoLabApp {
                         let _ =
                             remember_opened_project(&mut config, &mut recent_projects, &project);
                         let recovered_from_crash = housekeeping::acquire_lock(&project);
+                        if !snapshot.warnings.is_empty() {
+                            startup_message = Some(append_message(
+                                startup_message.take(),
+                                &snapshot.warnings.join(" — "),
+                            ));
+                        }
                         let mut state = AppState::new(
                             structure,
                             source_path,

--- a/src/frontend/dispatcher/jobs/poll.rs
+++ b/src/frontend/dispatcher/jobs/poll.rs
@@ -211,9 +211,18 @@ pub fn poll_jobs(state: &mut AppState, ctx: &egui::Context) {
     ensure_remote_jobs_loaded(state);
     poll_remote_submit(state, ctx);
     poll_remote_jobs_refresh(state, ctx);
+    let assistant_before = (state.workspace.is_project()
+        && (state.jobs.agent.is_some() || !state.jobs.agent_jobs.is_empty()))
+    .then(|| state.assistant_fingerprint());
     crate::frontend::agent::poll_agent_turn(state, ctx);
     crate::frontend::agent::poll_agent_jobs(state, ctx);
     crate::frontend::agent::poll_model_fetch(state, ctx);
+    if let Some(before) = assistant_before
+        && state.assistant_fingerprint() != before
+    {
+        let now = ctx.input(|input| input.time);
+        state.request_autosave(now, super::super::AUTOSAVE_DEBOUNCE_SECS);
+    }
 }
 
 /// Drain a finished Remote Hosts probe (passwordless check / GROMACS detect) and

--- a/src/frontend/dispatcher/mod.rs
+++ b/src/frontend/dispatcher/mod.rs
@@ -110,6 +110,8 @@ pub fn dispatch(state: &mut AppState, action: AppAction, ctx: &egui::Context) {
     // selection, active tab) don't move this fingerprint and are saved at exit
     // instead, so navigating or restyling never schedules a save.
     let fingerprint_before = (!manages_own_persistence).then(|| state.entries_fingerprint());
+    let assistant_fingerprint_before = (!manages_own_persistence && state.workspace.is_project())
+        .then(|| state.assistant_fingerprint());
     match action {
         AppAction::CreateProject => create_project_action(state),
         AppAction::OpenProject => request_leave(state, LeaveIntent::OpenProject, ctx),
@@ -446,6 +448,12 @@ pub fn dispatch(state: &mut AppState, action: AppAction, ctx: &egui::Context) {
         // pauses (see `flush_pending_autosave`). The flush still skips
         // re-serializing the (large) undo/redo history; that is persisted only at
         // explicit checkpoints (save, open, close, shutdown).
+        let now = ctx.input(|input| input.time);
+        state.request_autosave(now, AUTOSAVE_DEBOUNCE_SECS);
+    }
+    if let Some(before) = assistant_fingerprint_before
+        && state.assistant_fingerprint() != before
+    {
         let now = ctx.input(|input| input.time);
         state.request_autosave(now, AUTOSAVE_DEBOUNCE_SECS);
     }

--- a/src/frontend/dispatcher/project.rs
+++ b/src/frontend/dispatcher/project.rs
@@ -46,14 +46,16 @@ pub(crate) fn persist_project(state: &mut AppState, persist_history: bool) -> an
     // Save from borrowed references into the live state rather than cloning the
     // whole workspace: in an entry-heavy project (e.g. a 20-model NMR ensemble)
     // the clone dominated and made every interaction lag. `view` is the only
-    // small owned value the snapshot needs.
+    // small owned values the snapshot needs.
     let view = state.project_view_settings();
+    let assistant = state.ui.agent.project_snapshot();
     let snapshot = ProjectSnapshotRef {
         name: project.name.as_str(),
         entries: &state.entries,
         tasks: &state.tasks,
         view: &view,
         history: &state.history,
+        assistant: &assistant,
     };
     match save_project_ref(project, &snapshot, persist_history) {
         Ok(()) => {
@@ -112,6 +114,9 @@ pub(crate) fn replace_workspace_from_project(
     project: ProjectSession,
     snapshot: ProjectSnapshot,
 ) {
+    let assistant = snapshot.assistant.clone();
+    let warnings = snapshot.warnings.clone();
+    cancel_agent_runtime(state);
     // Release the lock on the project we are leaving, then take the new one.
     if let Some(previous) = state.workspace.project() {
         housekeeping::release_lock(previous);
@@ -127,6 +132,7 @@ pub(crate) fn replace_workspace_from_project(
     state.ui.project_viewport = snapshot.view.viewport;
     state.ui.viewport = state.ui.project_viewport.clone();
     state.ui.entry_viewports = snapshot.view.entry_viewports;
+    state.ui.agent = crate::frontend::agent::AgentSession::from_project_snapshot(assistant);
     state.ui.entry_list.selected_entry_ids.clear();
     if let Some(id) = state.entries.active_entry_id() {
         state.ui.entry_list.selected_entry_ids.insert(id);
@@ -156,6 +162,9 @@ pub(crate) fn replace_workspace_from_project(
             project.name
         ));
     }
+    if !warnings.is_empty() {
+        state.set_message(format!("{} — {}", state.message, warnings.join(" — ")));
+    }
 }
 
 pub(crate) fn create_project_action(state: &mut AppState) {
@@ -183,6 +192,8 @@ pub(crate) fn create_project_action(state: &mut AppState) {
             tasks: state.tasks.clone(),
             view: state.project_view_settings(),
             history: state.history.clone(),
+            assistant: state.ui.agent.project_snapshot(),
+            warnings: Vec::new(),
         });
         let snapshot = ProjectSnapshot {
             name: project.name.clone(),
@@ -217,6 +228,7 @@ fn open_project_path_without_persist(state: &mut AppState, path: PathBuf) {
 }
 
 fn close_project_without_persist(state: &mut AppState, run_maintenance: bool) {
+    cancel_agent_runtime(state);
     // Compact the databases and release the lock now that we are leaving cleanly.
     if let Some(project) = state.workspace.project().cloned() {
         if run_maintenance && let Err(error) = housekeeping::run_maintenance(&project) {
@@ -230,6 +242,7 @@ fn close_project_without_persist(state: &mut AppState, run_maintenance: bool) {
     state.ui.project_viewport = Default::default();
     state.ui.viewport = Default::default();
     state.ui.entry_viewports.clear();
+    state.ui.agent = crate::frontend::agent::AgentSession::default();
     state.config.closed_to_scratch = true;
     state.config.last_project_path = None;
     if let Err(error) = save_config(&state.config) {
@@ -243,6 +256,15 @@ fn close_project_without_persist(state: &mut AppState, run_maintenance: bool) {
     reset_chart_caches(state);
     state.clear_history();
     state.mark_project_saved();
+}
+
+fn cancel_agent_runtime(state: &mut AppState) {
+    if let Some(job) = state.jobs.agent.take() {
+        job.cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+    for tracked in state.jobs.agent_jobs.drain(..) {
+        tracked.job.cancel();
+    }
 }
 
 pub(crate) fn save_project(state: &mut AppState) {

--- a/src/frontend/state/app.rs
+++ b/src/frontend/state/app.rs
@@ -54,6 +54,7 @@ pub struct AppState {
     workspace_save_path: PathBuf,
     last_logged_message: String,
     last_saved_entries_fingerprint: u64,
+    last_saved_assistant_fingerprint: u64,
     project_save_error: Option<String>,
     /// egui time (seconds) at which a coalesced autosave should flush, or `None`
     /// when no project change is pending. Set by the dispatcher after a
@@ -118,6 +119,7 @@ impl AppState {
             workspace_save_path: save_path,
             last_logged_message: message,
             last_saved_entries_fingerprint: 0,
+            last_saved_assistant_fingerprint: 0,
             project_save_error: None,
             autosave_deadline: None,
             layout_save_deadline: None,
@@ -141,6 +143,9 @@ impl AppState {
             state
                 .history
                 .set_active_entry(state.entries.active_entry_id());
+            state.ui.agent = crate::frontend::agent::AgentSession::from_project_snapshot(
+                snapshot.assistant.clone(),
+            );
         }
         state.load_viewport_for_active_entry();
         state.ui.entry_list.selected_entry_ids.clear();
@@ -337,6 +342,7 @@ impl AppState {
 
     pub fn mark_project_saved(&mut self) {
         self.last_saved_entries_fingerprint = self.entries_fingerprint();
+        self.last_saved_assistant_fingerprint = self.assistant_fingerprint();
         self.project_save_error = None;
     }
 
@@ -352,6 +358,7 @@ impl AppState {
         self.workspace.is_project()
             && (self.autosave_deadline.is_some()
                 || self.entries_fingerprint() != self.last_saved_entries_fingerprint
+                || self.assistant_fingerprint() != self.last_saved_assistant_fingerprint
                 || self.project_save_error.is_some())
     }
 
@@ -427,7 +434,13 @@ impl AppState {
             tasks: self.tasks.clone(),
             view: self.project_view_settings(),
             history: self.history.clone(),
+            assistant: self.ui.agent.project_snapshot(),
+            warnings: Vec::new(),
         })
+    }
+
+    pub fn assistant_fingerprint(&self) -> u64 {
+        self.ui.agent.project_snapshot().fingerprint()
     }
 
     /// Materialize an entry's geometry if it was lazily left unloaded when the

--- a/src/frontend/state/app/tests.rs
+++ b/src/frontend/state/app/tests.rs
@@ -78,3 +78,33 @@ fn project_saved_fingerprint_tracks_leave_confirmation() {
     assert!(state.has_project_changes_to_save());
     assert!(state.needs_leave_confirmation());
 }
+
+#[test]
+fn project_saved_fingerprint_tracks_assistant_history() {
+    let project =
+        ProjectSession::from_root(PathBuf::from("target/test-assistant-dirty"), "test".into());
+    let mut state = AppState::new(
+        Structure::empty(),
+        None,
+        WorkspaceSession::Project(project),
+        Default::default(),
+        Vec::new(),
+        None,
+    );
+
+    assert!(!state.has_project_changes_to_save());
+
+    state
+        .ui
+        .agent
+        .transcript
+        .push(crate::frontend::agent::TranscriptEntry::User(
+            "hello".to_string(),
+        ));
+
+    assert!(state.has_project_changes_to_save());
+
+    state.mark_project_saved();
+
+    assert!(!state.has_project_changes_to_save());
+}


### PR DESCRIPTION
## Summary
- Persist assistant conversation history in the project SQLite database.
- Restore per-project chats on open/switch and include assistant changes in dirty/autosave tracking.
- Tolerate legacy/corrupt assistant state and cancel old assistant runtime on project changes.

## Tests
- cargo pr-check