### PR TITLE
feat(remote): add current-source worker deployment

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
 [alias]
 pr-check = "run -q -p xtask -- pr-check"
 xtask = "run -q -p xtask --"
+
+[target.x86_64-unknown-linux-musl]
+linker = "rust-lld"
+rustflags = ["-C", "link-self-contained=yes"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,12 +99,13 @@ jobs:
           components: clippy
           linux-deps: 'true'
           cache: 'true'
-      - run: cargo clippy --workspace --all-targets --all-features
+      - name: Lint default-feature production build
+        run: cargo clippy --workspace --all-targets
+      - name: Lint workspace with all features
+        run: cargo clippy --workspace --all-targets --all-features
 
-  # Guard the worker's "self-contained static musl, pure Rust" invariant with a
-  # cheap dependency-graph query (no compilation). The real musl build runs only
-  # at release time; the common regression — a C dependency sneaking in — is
-  # exactly what this catches.
+  # Guard dependency purity separately from the cross-platform build matrix.
+  # This graph query identifies which native dependency caused the regression.
   worker-pure-rust:
     name: Worker is pure Rust
     needs: changes
@@ -124,6 +125,27 @@ jobs:
             echo "::error::silicolab-compute pulls a C-toolchain / native build dependency; keep it pure Rust"
             exit 1
           fi
+
+  worker-build:
+    name: Worker build (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-rust
+        with:
+          targets: x86_64-unknown-linux-musl
+          cache: 'true'
+      - name: Build and validate the development worker ELF
+        run: cargo xtask build-dev-worker
+      - name: Smoke-test the worker version command
+        if: runner.os == 'Linux'
+        run: ./target/x86_64-unknown-linux-musl/release/silicolab-compute --version
 
   # Enforce the .rules size cap: every Rust source file stays under 800 physical
   # lines. Plain line counting, no toolchain — keeps files small enough for an
@@ -168,6 +190,9 @@ jobs:
           linux-deps: 'true'
           cache: 'true'
       - run: cargo test --workspace --all-features
+      - name: Test production worker artifact path
+        if: runner.os == 'Linux'
+        run: cargo test --package compute-core --lib engines::remote::artifact
 
   # The single required status check; the branch ruleset requires only this
   # context. It decouples the merge gate from the job matrix: docs-only PRs skip
@@ -179,7 +204,7 @@ jobs:
   ci-complete:
     name: CI complete
     if: always()
-    needs: [changes, fmt, clippy, worker-pure-rust, file-size, test]
+    needs: [changes, fmt, clippy, worker-pure-rust, worker-build, file-size, test]
     runs-on: ubuntu-latest
     steps:
       - name: Require every upstream job to have succeeded or been skipped

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -163,19 +163,34 @@ locally. This is the same `compute-core` job machinery, transported:
 - A job is serialized to the **wire** contract (`compute-core/src/wire.rs`) with
   its `Structure` carried by the **payload** bridge (`payload.rs`); the host is
   described by `hosts`.
-- On first use the headless **worker** (`silicolab-compute`) is deployed to the
-  host by `engines/remote/deploy.rs`. Deployment is **fail-closed**: the binary
-  is pinned to this build's release tag, its published SHA-256 is verified
-  **before** it is made executable, and a version mismatch forces a redeploy —
-  a stale or unverifiable worker is never run.
+- The headless **worker** (`silicolab-compute`) has two explicitly separated
+  artifact sources. Ordinary builds resolve the asset from the exact GitHub
+  Release tag for their package version and verify its published SHA-256.
+  Contributor builds with `dev-worker` resolve a validated local musl binary,
+  identify its actual bytes as `dev:<sha256>`, and resolve that artifact without
+  contacting GitHub Releases or falling back to a released worker. Official
+  builds do not compile the local source path.
+- `engines/remote/deploy.rs` installs either artifact through one fail-closed
+  path: upload an identity-qualified binary, mark it executable, verify its
+  reported package version, and only then atomically replace the stable symlink.
+  The persisted `_worker` value is the deployment identity (a package version
+  for production or `dev:<sha256>` for development), not an assumption that a
+  path still exists. Even an identity cache hit is checked on the host; a
+  missing or invalid executable is redeployed and a stale or unverifiable
+  worker is never run. Jobs invoke the verified identity-qualified path rather
+  than the mutable stable symlink.
 - The worker executes the request and writes an outcome the client reads back.
   QM, docking, and GROMACS/MD all run through this path; jobs are bounded by the
   host's own CPU and RAM.
 
 **Why:** the wire/payload split keeps the GUI-free `compute-core` as the single
 implementation of each engine — local and remote runs share it, so behavior can
-not drift between them. Fail-closed deployment means a tampered or mismatched
-worker fails the job rather than silently producing wrong results.
+not drift between them. Separating production and development artifact sources
+keeps released deployment pinned and checksum-verified while allowing current
+source to be tested without weakening that invariant. Fail-closed deployment
+means a tampered, missing, or mismatched worker fails the job rather than
+silently producing wrong results. Contributor commands and host-test setup live
+in [docs/developing-remote-execution.md](docs/developing-remote-execution.md).
 
 ## Storage model
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,22 @@ Machine-specific acceptance tests â€” those that need an external tool inst
 are gated with `#[ignore]` so the default `cargo test` run stays hermetic. Run
 them explicitly, as shown above.
 
+## Remote execution development
+
+When a change affects the remote worker, a remote-capable engine, or the wire
+contract, run the current checkout through the development worker path:
+
+```powershell
+cargo xtask remote-dev
+```
+
+For an IDE pre-launch task, use `cargo xtask build-dev-worker`. Ordinary builds
+remain pinned to published, checksum-verified workers and cannot test
+unpublished source changes. See
+[Developing remote execution](docs/developing-remote-execution.md) for platform
+prerequisites, artifact overrides, IDE setup, deployment identities, and the
+opt-in SSH integration tests.
+
 ## Commit discipline
 
 Everything syncs straight to `main`. As a result:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,8 @@ pollster = "0.4"
 # no-op and `nvml-wrapper` is never compiled.
 default = ["nvidia"]
 nvidia = ["dep:nvml-wrapper"]
+# Contributor-only deployment of a worker built from the current checkout.
+dev-worker = ["compute-core/dev-worker"]
 
 # Live NVIDIA GPU stats (utilization / VRAM / temperature) via NVML, surfaced in
 # the hardware monitor. Optional + Windows/Linux only: NVML doesn't exist on

--- a/compute-core/Cargo.toml
+++ b/compute-core/Cargo.toml
@@ -31,8 +31,8 @@ self_update = { version = "0.42", optional = true, default-features = false, fea
     "compression-zip-deflate",
 ] }
 ureq = { version = "3.3.0", optional = true }
-# SHA-256 of the published worker asset, verified before install. Pure Rust (no C
-# toolchain) and used only by the client deploy path, so it rides `network`.
+# SHA-256 for release verification and local development deployment identities.
+# Pure Rust (no C toolchain), enabled only by the relevant client deploy feature.
 sha2 = { version = "0.10", optional = true }
 
 [features]
@@ -40,6 +40,9 @@ default = ["network"]
 # HTTP/TLS-backed IO: update checks, self-update, PDB fetch, the LLM transports,
 # and worker deployment. Off for the headless worker so it pulls no C toolchain.
 network = ["dep:ureq", "dep:self_update", "dep:sha2"]
+# Current-checkout worker deployment for contributors. This deliberately selects
+# the local artifact instead of compiling the release downloader alongside it.
+dev-worker = ["dep:sha2"]
 
 [dev-dependencies]
 # For the env-gated remote end-to-end integration test (skips unless a test SSH

--- a/compute-core/src/engines/remote/artifact.rs
+++ b/compute-core/src/engines/remote/artifact.rs
@@ -1,0 +1,335 @@
+#[cfg(feature = "dev-worker")]
+use std::{
+    ffi::OsString,
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+use sha2::{Digest, Sha256};
+
+#[cfg(all(feature = "network", not(feature = "dev-worker")))]
+use crate::io::update_check;
+
+#[cfg(feature = "dev-worker")]
+const DEV_WORKER_ENV: &str = "SILICOLAB_DEV_WORKER";
+#[cfg(feature = "dev-worker")]
+const DEV_WORKER_TARGET: &str = "target/x86_64-unknown-linux-musl/release/silicolab-compute";
+#[cfg(all(feature = "network", not(feature = "dev-worker")))]
+const RELEASE_ASSET_NAME: &str = "silicolab-compute-x86_64-unknown-linux-musl";
+
+pub(super) const MAX_WORKER_BYTES: u64 = 256 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArtifactSource {
+    #[cfg(all(feature = "network", not(feature = "dev-worker")))]
+    Release,
+    #[cfg(feature = "dev-worker")]
+    LocalDev,
+}
+
+fn selected_source() -> ArtifactSource {
+    #[cfg(feature = "dev-worker")]
+    {
+        ArtifactSource::LocalDev
+    }
+    #[cfg(all(feature = "network", not(feature = "dev-worker")))]
+    {
+        ArtifactSource::Release
+    }
+}
+
+#[derive(Debug)]
+pub(super) enum WorkerArtifact {
+    #[cfg(all(feature = "network", not(feature = "dev-worker")))]
+    Release { version: String },
+    #[cfg(feature = "dev-worker")]
+    LocalDev { bytes: Vec<u8>, digest: String },
+}
+
+impl WorkerArtifact {
+    pub(super) fn selected() -> Result<Self> {
+        match selected_source() {
+            #[cfg(all(feature = "network", not(feature = "dev-worker")))]
+            ArtifactSource::Release => Ok(Self::Release {
+                version: env!("CARGO_PKG_VERSION").to_string(),
+            }),
+            #[cfg(feature = "dev-worker")]
+            ArtifactSource::LocalDev => Self::read_local_dev(configured_local_dev_path()?),
+        }
+    }
+
+    pub(super) fn deployment_id(&self) -> String {
+        match self {
+            #[cfg(all(feature = "network", not(feature = "dev-worker")))]
+            Self::Release { version } => version.clone(),
+            #[cfg(feature = "dev-worker")]
+            Self::LocalDev { digest, .. } => format!("dev:{digest}"),
+        }
+    }
+
+    pub(super) fn remote_qualifier(&self) -> String {
+        match self {
+            #[cfg(all(feature = "network", not(feature = "dev-worker")))]
+            Self::Release { version } => version.clone(),
+            #[cfg(feature = "dev-worker")]
+            Self::LocalDev { digest, .. } => format!("dev-{digest}"),
+        }
+    }
+
+    pub(super) fn expected_version(&self) -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    pub(super) fn into_bytes(self) -> Result<Vec<u8>> {
+        match self {
+            #[cfg(all(feature = "network", not(feature = "dev-worker")))]
+            Self::Release { version } => download_release(&version),
+            #[cfg(feature = "dev-worker")]
+            Self::LocalDev { bytes, .. } => Ok(bytes),
+        }
+    }
+
+    #[cfg(feature = "dev-worker")]
+    fn read_local_dev(path: PathBuf) -> Result<Self> {
+        let metadata = std::fs::metadata(&path).with_context(|| {
+            format!(
+                "development worker {} is missing; run `cargo xtask build-dev-worker` first",
+                path.display()
+            )
+        })?;
+        if !metadata.is_file() {
+            bail!(
+                "development worker {} is not a regular file",
+                path.display()
+            );
+        }
+        validate_worker_size(metadata.len())?;
+
+        let file = File::open(&path)
+            .with_context(|| format!("failed to open development worker {}", path.display()))?;
+        let mut reader = file.take(MAX_WORKER_BYTES + 1);
+        let mut bytes = Vec::with_capacity(metadata.len() as usize);
+        reader
+            .read_to_end(&mut bytes)
+            .with_context(|| format!("failed to read development worker {}", path.display()))?;
+        validate_worker_size(bytes.len() as u64)?;
+        validate_linux_x86_64_elf(&bytes)
+            .with_context(|| format!("invalid development worker {}", path.display()))?;
+        let digest = sha256_hex(&bytes);
+        Ok(Self::LocalDev { bytes, digest })
+    }
+}
+
+#[cfg(all(feature = "network", not(feature = "dev-worker")))]
+fn download_release(version: &str) -> Result<Vec<u8>> {
+    let tag = format!("v{version}");
+    let bin_url = update_check::release_asset_url(&tag, RELEASE_ASSET_NAME)?;
+    let sum_url = update_check::release_asset_url(&tag, &format!("{RELEASE_ASSET_NAME}.sha256"))?;
+    let bytes = update_check::download_asset_bytes(&bin_url, MAX_WORKER_BYTES)?;
+    let expected = parse_sha256(&update_check::download_asset_text(&sum_url)?)?;
+    let actual = sha256_hex(&bytes);
+    if !actual.eq_ignore_ascii_case(&expected) {
+        bail!(
+            "worker checksum mismatch for {tag}: expected {expected}, got {actual}. \
+             The download is corrupt or tampered with; deployment aborted."
+        );
+    }
+    Ok(bytes)
+}
+
+#[cfg(feature = "dev-worker")]
+fn configured_local_dev_path() -> Result<PathBuf> {
+    local_dev_path(
+        std::env::var_os(DEV_WORKER_ENV),
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+    )
+}
+
+#[cfg(feature = "dev-worker")]
+fn local_dev_path(override_path: Option<OsString>, manifest_dir: &Path) -> Result<PathBuf> {
+    if let Some(path) = override_path {
+        if path.is_empty() {
+            bail!("{DEV_WORKER_ENV} is set but empty");
+        }
+        return Ok(PathBuf::from(path));
+    }
+    let workspace = manifest_dir
+        .parent()
+        .context("compute-core manifest has no workspace parent")?;
+    Ok(workspace.join(DEV_WORKER_TARGET))
+}
+
+#[cfg(feature = "dev-worker")]
+fn validate_worker_size(size: u64) -> Result<()> {
+    if size == 0 {
+        bail!("development worker is empty");
+    }
+    if size > MAX_WORKER_BYTES {
+        bail!("development worker is {size} bytes, exceeding the {MAX_WORKER_BYTES}-byte limit");
+    }
+    Ok(())
+}
+
+#[cfg(feature = "dev-worker")]
+fn validate_linux_x86_64_elf(bytes: &[u8]) -> Result<()> {
+    if bytes.len() < 64 {
+        bail!("file is too short to contain an ELF64 header");
+    }
+    if &bytes[..4] != b"\x7fELF" {
+        bail!("file is not an ELF executable");
+    }
+    if bytes[4] != 2 {
+        bail!("ELF class is not 64-bit");
+    }
+    if bytes[5] != 1 {
+        bail!("ELF byte order is not little-endian");
+    }
+    let elf_type = u16::from_le_bytes([bytes[16], bytes[17]]);
+    if !matches!(elf_type, 2 | 3) {
+        bail!("ELF type is not executable or position-independent executable");
+    }
+    let machine = u16::from_le_bytes([bytes[18], bytes[19]]);
+    if machine != 62 {
+        bail!("ELF machine is not x86-64");
+    }
+    Ok(())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(all(feature = "network", not(feature = "dev-worker")))]
+fn parse_sha256(text: &str) -> Result<String> {
+    let token = text
+        .split_whitespace()
+        .next()
+        .context("checksum file is empty")?
+        .to_ascii_lowercase();
+    if token.len() != 64 || !token.bytes().all(|b| b.is_ascii_hexdigit()) {
+        bail!("checksum file does not contain a SHA-256 digest");
+    }
+    Ok(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_matches_known_vector() {
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn artifact_source_selection_is_feature_isolated() {
+        #[cfg(feature = "dev-worker")]
+        assert_eq!(selected_source(), ArtifactSource::LocalDev);
+        #[cfg(all(feature = "network", not(feature = "dev-worker")))]
+        assert_eq!(selected_source(), ArtifactSource::Release);
+    }
+
+    #[cfg(all(feature = "network", not(feature = "dev-worker")))]
+    #[test]
+    fn release_checksum_parser_accepts_sum_format_and_rejects_invalid_text() {
+        let digest = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        assert_eq!(parse_sha256(digest).unwrap(), digest);
+        assert_eq!(parse_sha256(&format!("{digest}  worker")).unwrap(), digest);
+        assert_eq!(parse_sha256(&digest.to_uppercase()).unwrap(), digest);
+        assert!(parse_sha256("").is_err());
+        assert!(parse_sha256("not-a-hash").is_err());
+    }
+
+    #[cfg(feature = "dev-worker")]
+    fn elf_header() -> Vec<u8> {
+        let mut bytes = vec![0; 64];
+        bytes[..4].copy_from_slice(b"\x7fELF");
+        bytes[4] = 2;
+        bytes[5] = 1;
+        bytes[16..18].copy_from_slice(&2_u16.to_le_bytes());
+        bytes[18..20].copy_from_slice(&62_u16.to_le_bytes());
+        bytes
+    }
+
+    #[cfg(feature = "dev-worker")]
+    #[test]
+    fn local_path_prefers_nonempty_environment_override() {
+        let manifest = Path::new("/checkout/compute-core");
+        assert_eq!(
+            local_dev_path(Some(OsString::from("/tmp/custom-worker")), manifest).unwrap(),
+            PathBuf::from("/tmp/custom-worker")
+        );
+        assert!(local_dev_path(Some(OsString::new()), manifest).is_err());
+        assert_eq!(
+            local_dev_path(None, manifest).unwrap(),
+            PathBuf::from("/checkout").join(DEV_WORKER_TARGET)
+        );
+    }
+
+    #[cfg(feature = "dev-worker")]
+    #[test]
+    fn local_worker_rejects_missing_path_and_size_limits() {
+        let missing = std::env::temp_dir().join(format!(
+            "silicolab-missing-worker-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        assert!(WorkerArtifact::read_local_dev(missing).is_err());
+        assert!(validate_worker_size(0).is_err());
+        assert!(validate_worker_size(MAX_WORKER_BYTES).is_ok());
+        assert!(validate_worker_size(MAX_WORKER_BYTES + 1).is_err());
+    }
+
+    #[cfg(feature = "dev-worker")]
+    #[test]
+    fn elf_validation_checks_class_endianness_architecture_and_type() {
+        let valid = elf_header();
+        assert!(validate_linux_x86_64_elf(&valid).is_ok());
+
+        let mut wrong = valid.clone();
+        wrong[4] = 1;
+        assert!(validate_linux_x86_64_elf(&wrong).is_err());
+        wrong = valid.clone();
+        wrong[5] = 2;
+        assert!(validate_linux_x86_64_elf(&wrong).is_err());
+        wrong = valid.clone();
+        wrong[18..20].copy_from_slice(&183_u16.to_le_bytes());
+        assert!(validate_linux_x86_64_elf(&wrong).is_err());
+        wrong = valid;
+        wrong[16..18].copy_from_slice(&1_u16.to_le_bytes());
+        assert!(validate_linux_x86_64_elf(&wrong).is_err());
+    }
+
+    #[cfg(feature = "dev-worker")]
+    #[test]
+    fn local_artifact_identity_changes_with_binary() {
+        let suffix = uuid::Uuid::new_v4().simple();
+        let path_a = std::env::temp_dir().join(format!("silicolab-worker-a-{suffix}"));
+        let path_b = std::env::temp_dir().join(format!("silicolab-worker-b-{suffix}"));
+        let first = elf_header();
+        let mut changed = first.clone();
+        changed.push(1);
+        std::fs::write(&path_a, &first).unwrap();
+        std::fs::write(&path_b, &changed).unwrap();
+
+        let artifact_a = WorkerArtifact::read_local_dev(path_a.clone()).unwrap();
+        let artifact_a_again = WorkerArtifact::read_local_dev(path_a.clone()).unwrap();
+        let artifact_b = WorkerArtifact::read_local_dev(path_b.clone()).unwrap();
+        assert_eq!(artifact_a.deployment_id(), artifact_a_again.deployment_id());
+        assert_ne!(artifact_a.deployment_id(), artifact_b.deployment_id());
+        assert!(artifact_a.deployment_id().starts_with("dev:"));
+
+        std::fs::remove_file(path_a).unwrap();
+        std::fs::remove_file(path_b).unwrap();
+    }
+}

--- a/compute-core/src/engines/remote/deploy.rs
+++ b/compute-core/src/engines/remote/deploy.rs
@@ -1,72 +1,68 @@
-//! First-use deployment of the headless compute worker to a remote host.
+//! Fail-closed deployment of the headless compute worker to a remote host.
 //!
 //! The worker is **not** shipped in a job bundle; it is installed once per host
-//! and invoked by absolute path. Deployment is version- and hash-pinned and
+//! and invoked by absolute path. Production deployment is release/checksum-pinned;
+//! `dev-worker` deployment is pinned to a validated local binary's SHA-256. Both are
 //! **fail-closed**: a stale, missing, or checksum-mismatched worker is replaced,
 //! never run. The sequence is
 //!
 //! 1. probe `uname -m` — refuse anything but `x86_64` with an actionable message;
-//! 2. fetch the worker asset for this build's exact release tag, verify its
-//!    published SHA-256;
-//! 3. `scp` into `<work_root>/bin/silicolab-compute-<ver>`, `chmod +x`, then
-//!    `ln -sfn` the `silicolab-compute` symlink across atomically — retaining
-//!    prior versioned binaries so an in-flight job keeps the executable it
-//!    launched against;
-//! 4. verify the installed binary self-reports the expected `--version`.
+//! 2. resolve the selected release or local-development artifact;
+//! 3. `scp` into an identity-qualified path and `chmod +x`;
+//! 4. verify that binary self-reports the expected `--version`;
+//! 5. atomically replace the stable symlink, retaining prior binaries so an
+//!    in-flight job keeps the executable it launched against.
 //!
-//! The recorded version in [`RemoteHost::engine_versions`] is the fast path: when
-//! it already equals this build, deployment is a no-op. The SSH/SCP plumbing is
-//! the hardened layer in the parent module, reused verbatim.
+//! The recorded deployment identity in [`RemoteHost::engine_versions`] is a cache
+//! hint. Even on a match, the remote binary must run and report this package
+//! version before it is reused.
 
 use std::path::Path;
 use std::time::Duration;
 
-use anyhow::{Context, Result, bail};
-use sha2::{Digest, Sha256};
-
-use super::{RemoteTarget, validate_work_root};
+use super::{RemoteTarget, artifact::WorkerArtifact, validate_work_root};
 use crate::engines::process::{self, ProcessConfig};
 use crate::hosts::RemoteHost;
-use crate::io::update_check;
+use anyhow::{Context, Result, bail};
 
-/// `engine_versions` key recording the deployed worker's version. A leading
+/// `engine_versions` key recording the worker deployment identity. A leading
 /// underscore can never collide with an `EngineId` string (`uff` / `hartree` /
 /// `gromacs` / `docking`, and any future engine, are bare lowercase words).
-pub const WORKER_VERSION_KEY: &str = "_worker";
+pub const WORKER_DEPLOYMENT_KEY: &str = "_worker";
 
-/// Release-asset basename for the worker, matching `release.yml`. Version-less:
-/// the release tag already pins the version.
-pub const WORKER_ASSET_NAME: &str = "silicolab-compute-x86_64-unknown-linux-musl";
-
-/// Generous cap on the downloaded worker binary.
-const MAX_WORKER_BYTES: u64 = 256 * 1024 * 1024;
-
-/// A worker confirmed present on the remote host at a known version.
+/// A worker confirmed present on the remote host for a deployment identity.
 #[derive(Debug, Clone)]
 pub struct DeployedWorker {
-    /// The version the deployed binary reports (equals this build).
-    pub version: String,
-    /// Absolute remote path of the `silicolab-compute` symlink to invoke.
+    /// Release semver or `dev:<sha256>` for the exact local binary.
+    pub deployment_id: String,
+    /// Absolute identity-qualified remote executable path to invoke.
     pub remote_path: String,
 }
 
-/// Ensure the worker on `host` matches this build, deploying it on first use and
-/// redeploying on any version mismatch. Fail-closed: never returns success while
-/// a stale or unverifiable worker would be run.
-///
-/// When `host.engine_versions[`[`WORKER_VERSION_KEY`]`]` already equals this
-/// build, no network or SCP happens. After a fresh deploy the caller records the
-/// returned [`DeployedWorker::version`] under that key and persists the config.
+/// Ensure the selected worker is present, executable, and reports this package
+/// version. A stale, missing, or unverifiable cached worker is redeployed.
 pub fn ensure_worker_deployed(host: &RemoteHost, target: &RemoteTarget) -> Result<DeployedWorker> {
     super::ensure_ssh_available()?;
-    let current = env!("CARGO_PKG_VERSION");
-    let link = worker_link_path(host)?;
+    let artifact = WorkerArtifact::selected()?;
+    let deployment_id = artifact.deployment_id();
+    let expected_version = artifact.expected_version();
+    let qualifier = artifact.remote_qualifier();
+    let qualified = worker_qualified_path(host, &qualifier)?;
 
-    if !needs_redeploy(&host.engine_versions, current) {
-        return Ok(DeployedWorker {
-            version: current.to_string(),
-            remote_path: link,
-        });
+    if recorded_identity(&host.engine_versions) == Some(deployment_id.as_str()) {
+        let reported = run_checked(target, &format!("{qualified} --version")).ok();
+        if cache_hit_is_usable(
+            Some(deployment_id.as_str()),
+            &deployment_id,
+            reported.as_deref(),
+            expected_version,
+        ) {
+            publish_worker_link(host, target, &qualified)?;
+            return Ok(DeployedWorker {
+                deployment_id,
+                remote_path: qualified,
+            });
+        }
     }
 
     let arch = probe_arch(target)?;
@@ -74,44 +70,38 @@ pub fn ensure_worker_deployed(host: &RemoteHost, target: &RemoteTarget) -> Resul
         bail!("{}", arch_refusal_message(&host.label, &arch));
     }
 
-    let tag = format!("v{current}");
-    let bin_url = update_check::release_asset_url(&tag, WORKER_ASSET_NAME)?;
-    let sum_url = update_check::release_asset_url(&tag, &format!("{WORKER_ASSET_NAME}.sha256"))?;
-    let bytes = update_check::download_asset_bytes(&bin_url, MAX_WORKER_BYTES)?;
-    let expected = parse_sha256(&update_check::download_asset_text(&sum_url)?)?;
-    let actual = sha256_hex(&bytes);
-    if !actual.eq_ignore_ascii_case(&expected) {
-        bail!(
-            "worker checksum mismatch for {tag}: expected {expected}, got {actual}. \
-             The download is corrupt or tampered with; deployment aborted."
-        );
-    }
+    let bytes = artifact.into_bytes()?;
+    install_worker(host, target, &qualifier, &bytes)?;
 
-    install_worker(host, target, current, &bytes)?;
-
-    let reported = run_checked(target, &format!("{link} --version"))?;
+    let reported = run_checked(target, &format!("{qualified} --version"))?;
     let reported = reported.trim();
-    if reported != current {
+    if reported != expected_version {
         bail!(
-            "the deployed worker reports version `{reported}` but `{current}` was expected; \
+            "the deployed worker reports version `{reported}` but `{expected_version}` was expected; \
              refusing to run a mismatched worker."
         );
     }
+    publish_worker_link(host, target, &qualified)?;
 
     Ok(DeployedWorker {
-        version: current.to_string(),
-        remote_path: link,
+        deployment_id,
+        remote_path: qualified,
     })
 }
 
-/// Whether the worker must be (re)deployed: true when the recorded version is
-/// missing or differs from `current`. The pin is strict equality — an exact match
-/// is the only no-op; a newer recorded version still redeploys (fail-closed).
-fn needs_redeploy(
-    engine_versions: &std::collections::HashMap<String, String>,
-    current: &str,
+fn recorded_identity(engine_versions: &std::collections::HashMap<String, String>) -> Option<&str> {
+    engine_versions
+        .get(WORKER_DEPLOYMENT_KEY)
+        .map(String::as_str)
+}
+
+fn cache_hit_is_usable(
+    recorded: Option<&str>,
+    selected: &str,
+    reported: Option<&str>,
+    expected_version: &str,
 ) -> bool {
-    engine_versions.get(WORKER_VERSION_KEY).map(String::as_str) != Some(current)
+    recorded == Some(selected) && reported.map(str::trim) == Some(expected_version)
 }
 
 /// The actionable refusal for a non-x86_64 host. Names the offending arch and
@@ -123,8 +113,8 @@ fn arch_refusal_message(host_label: &str, arch: &str) -> String {
     )
 }
 
-/// `<work_root>/bin` — validated for shell-safety so the concatenated paths carry
-/// no metacharacters (the version and asset names are numeric/constant).
+/// `<work_root>/bin` — validated for shell-safety so concatenated paths carry no
+/// metacharacters. Artifact qualifiers are generated internally.
 fn worker_bin_dir(host: &RemoteHost) -> Result<String> {
     validate_work_root(&host.work_root)?;
     Ok(format!("{}/bin", host.work_root.trim_end_matches('/')))
@@ -134,9 +124,9 @@ fn worker_link_path(host: &RemoteHost) -> Result<String> {
     Ok(format!("{}/silicolab-compute", worker_bin_dir(host)?))
 }
 
-fn worker_versioned_path(host: &RemoteHost, version: &str) -> Result<String> {
+fn worker_qualified_path(host: &RemoteHost, qualifier: &str) -> Result<String> {
     Ok(format!(
-        "{}/silicolab-compute-{version}",
+        "{}/silicolab-compute-{qualifier}",
         worker_bin_dir(host)?
     ))
 }
@@ -146,30 +136,29 @@ fn probe_arch(target: &RemoteTarget) -> Result<String> {
     Ok(out.trim().to_string())
 }
 
-/// `mkdir -p` the bin dir, `scp` the bytes to the versioned path, then
-/// `chmod +x` and swap the symlink atomically (`ln -sfn`), retaining prior
-/// versioned binaries.
+/// Stage an identity-qualified binary and mark it executable. It is verified by
+/// the caller before [`publish_worker_link`] exposes it through the stable link.
 fn install_worker(
     host: &RemoteHost,
     target: &RemoteTarget,
-    version: &str,
+    qualifier: &str,
     bytes: &[u8],
 ) -> Result<()> {
     let bin_dir = worker_bin_dir(host)?;
-    let versioned = worker_versioned_path(host, version)?;
-    let link = worker_link_path(host)?;
+    let qualified = worker_qualified_path(host, qualifier)?;
 
     run_checked(target, &format!("mkdir -p {bin_dir}"))?;
 
-    let tmp = std::env::temp_dir().join(format!(
-        "silicolab-compute-{version}-{}",
-        uuid::Uuid::new_v4().simple()
-    ));
+    let nonce = uuid::Uuid::new_v4().simple();
+    let tmp = std::env::temp_dir().join(format!("silicolab-compute-{qualifier}-{nonce}"));
     std::fs::write(&tmp, bytes)
         .with_context(|| format!("failed to stage the worker at {}", tmp.display()))?;
-    let scp = scp_up(target, &tmp, &versioned);
+    let remote_stage = format!("{qualified}.upload-{nonce}");
+    let scp = scp_up(target, &tmp, &remote_stage);
     let result = process::run(scp);
-    let _ = std::fs::remove_file(&tmp);
+    if let Err(error) = std::fs::remove_file(&tmp) {
+        eprintln!("failed to remove staged worker {}: {error}", tmp.display());
+    }
     let result = result.context("failed to upload the worker binary over SSH")?;
     if !result.success() {
         bail!(
@@ -181,7 +170,21 @@ fn install_worker(
 
     run_checked(
         target,
-        &format!("chmod +x {versioned} && ln -sfn {versioned} {link}"),
+        &format!("chmod +x {remote_stage} && mv -f {remote_stage} {qualified}"),
+    )?;
+    Ok(())
+}
+
+fn publish_worker_link(host: &RemoteHost, target: &RemoteTarget, qualified: &str) -> Result<()> {
+    let link = worker_link_path(host)?;
+    let qualified_name = qualified
+        .rsplit('/')
+        .next()
+        .context("qualified worker path has no filename")?;
+    let next_link = format!("{link}.next-{}", uuid::Uuid::new_v4().simple());
+    run_checked(
+        target,
+        &format!("ln -s {qualified_name} {next_link} && mv -Tf {next_link} {link}"),
     )?;
     Ok(())
 }
@@ -203,72 +206,17 @@ fn run_checked(target: &RemoteTarget, script: &str) -> Result<String> {
     super::run_probe_command(target, script, Duration::from_secs(60))
 }
 
-fn sha256_hex(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    hasher
-        .finalize()
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect()
-}
-
-/// Parse the digest from a `sha256sum`-format line (`HEX  filename`) or a bare
-/// hex string. Rejects anything that is not a 64-hex-character SHA-256.
-fn parse_sha256(text: &str) -> Result<String> {
-    let token = text
-        .split_whitespace()
-        .next()
-        .context("checksum file is empty")?
-        .to_ascii_lowercase();
-    if token.len() != 64 || !token.bytes().all(|b| b.is_ascii_hexdigit()) {
-        bail!("checksum file does not contain a SHA-256 digest");
-    }
-    Ok(token)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn worker_version_key_cannot_collide_with_engine_ids() {
+    fn worker_deployment_key_cannot_collide_with_engine_ids() {
         // The reserved key must never be a real EngineId string.
         for id in ["uff", "hartree", "gromacs", "docking"] {
-            assert_ne!(WORKER_VERSION_KEY, id);
+            assert_ne!(WORKER_DEPLOYMENT_KEY, id);
         }
-        assert!(WORKER_VERSION_KEY.starts_with('_'));
-    }
-
-    #[test]
-    fn sha256_matches_known_vector() {
-        // SHA-256 of the empty input.
-        assert_eq!(
-            sha256_hex(b""),
-            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-        );
-    }
-
-    #[test]
-    fn parse_sha256_accepts_sum_format_and_bare_hex() {
-        let digest = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-        assert_eq!(parse_sha256(digest).unwrap(), digest);
-        assert_eq!(
-            parse_sha256(&format!(
-                "{digest}  silicolab-compute-x86_64-unknown-linux-musl"
-            ))
-            .unwrap(),
-            digest
-        );
-        // Uppercase is normalized.
-        assert_eq!(parse_sha256(&digest.to_uppercase()).unwrap(), digest);
-    }
-
-    #[test]
-    fn parse_sha256_rejects_non_digests() {
-        assert!(parse_sha256("").is_err());
-        assert!(parse_sha256("not-a-hash").is_err());
-        assert!(parse_sha256("abc123").is_err());
+        assert!(WORKER_DEPLOYMENT_KEY.starts_with('_'));
     }
 
     #[test]
@@ -280,21 +228,37 @@ mod tests {
     }
 
     #[test]
-    fn needs_redeploy_is_false_only_on_exact_match() {
-        use std::collections::HashMap;
-        let mut versions = HashMap::new();
+    fn cache_requires_matching_identity_and_successful_remote_verification() {
+        let version = "0.1.1";
+        let dev = "dev:0123456789abcdef";
 
-        // Missing key → redeploy.
-        assert!(needs_redeploy(&versions, "0.1.1"));
-
-        // Exact match → no redeploy.
-        versions.insert(WORKER_VERSION_KEY.to_string(), "0.1.1".to_string());
-        assert!(!needs_redeploy(&versions, "0.1.1"));
-
-        // Differing version (older or newer) → redeploy.
-        assert!(needs_redeploy(&versions, "0.1.2"));
-        versions.insert(WORKER_VERSION_KEY.to_string(), "0.2.0".to_string());
-        assert!(needs_redeploy(&versions, "0.1.1"));
+        assert!(cache_hit_is_usable(
+            Some(version),
+            version,
+            Some(version),
+            version
+        ));
+        assert!(cache_hit_is_usable(Some(dev), dev, Some(version), version));
+        assert!(!cache_hit_is_usable(None, version, Some(version), version));
+        assert!(!cache_hit_is_usable(
+            Some(version),
+            dev,
+            Some(version),
+            version
+        ));
+        assert!(!cache_hit_is_usable(
+            Some(dev),
+            version,
+            Some(version),
+            version
+        ));
+        assert!(!cache_hit_is_usable(Some(version), version, None, version));
+        assert!(!cache_hit_is_usable(
+            Some(version),
+            version,
+            Some("wrong"),
+            version
+        ));
     }
 
     #[test]
@@ -317,8 +281,12 @@ mod tests {
             "~/.silicolab/bin/silicolab-compute"
         );
         assert_eq!(
-            worker_versioned_path(&host, "0.1.1").unwrap(),
+            worker_qualified_path(&host, "0.1.1").unwrap(),
             "~/.silicolab/bin/silicolab-compute-0.1.1"
+        );
+        assert_eq!(
+            worker_qualified_path(&host, "dev-0123456789abcdef").unwrap(),
+            "~/.silicolab/bin/silicolab-compute-dev-0123456789abcdef"
         );
     }
 }

--- a/compute-core/src/engines/remote/launcher.rs
+++ b/compute-core/src/engines/remote/launcher.rs
@@ -42,9 +42,9 @@ pub struct RemoteExecution {
     pub launcher: Launcher,
     /// Local directory the bundle is staged from and outputs retrieve to.
     pub working_dir: PathBuf,
-    /// Absolute remote path of the `silicolab-compute` symlink to invoke
-    /// (`DeployedWorker::remote_path`). Safe to emit unquoted in `run.sh`: it is
-    /// `<work_root>/bin/silicolab-compute`, and `work_root` is metacharacter-free.
+    /// Absolute identity-qualified worker path (`DeployedWorker::remote_path`).
+    /// Safe to emit unquoted in `run.sh`: `work_root` is metacharacter-free and
+    /// the generated identity qualifier contains only safe ASCII characters.
     pub worker_path: String,
 }
 

--- a/compute-core/src/engines/remote/mod.rs
+++ b/compute-core/src/engines/remote/mod.rs
@@ -12,8 +12,10 @@
 //! detached [`launcher`] drives to deploy and run the pre-deployed headless worker
 //! on a host. A GROMACS launch travels with [`Compute`].
 
+#[cfg(any(feature = "network", feature = "dev-worker"))]
+mod artifact;
 pub mod bootstrap;
-#[cfg(feature = "network")]
+#[cfg(any(feature = "network", feature = "dev-worker"))]
 pub mod deploy;
 pub mod hardware;
 pub mod launcher;
@@ -269,6 +271,15 @@ pub fn validate_work_root(work_root: &str) -> Result<()> {
     let trimmed = work_root.trim();
     if trimmed.is_empty() {
         bail!("remote work directory cannot be empty");
+    }
+    if trimmed != work_root {
+        bail!("remote work directory cannot have leading or trailing whitespace");
+    }
+    if !(trimmed == "~"
+        || trimmed.starts_with("~/")
+        || (trimmed.starts_with('/') && trimmed.len() > 1))
+    {
+        bail!("remote work directory must be an absolute path or start with `~/`");
     }
     let ok = trimmed
         .chars()
@@ -574,7 +585,11 @@ mod tests {
     fn validate_work_root_rejects_metacharacters() {
         assert!(validate_work_root("~/.silicolab").is_ok());
         assert!(validate_work_root("/scratch/alice/sl").is_ok());
+        assert!(validate_work_root("~/scratch/sl/").is_ok());
         assert!(validate_work_root("").is_err());
+        assert!(validate_work_root("scratch/sl").is_err());
+        assert!(validate_work_root("/").is_err());
+        assert!(validate_work_root(" ~/.silicolab").is_err());
         assert!(validate_work_root("/scratch/my proj").is_err());
         assert!(validate_work_root("/scratch; rm -rf ~").is_err());
         assert!(validate_work_root("/scratch/$(whoami)").is_err());

--- a/compute-core/src/hosts.rs
+++ b/compute-core/src/hosts.rs
@@ -44,9 +44,9 @@ pub struct RemoteHost {
     /// normally empty (the remote shell, not a local launcher, runs it).
     #[serde(default)]
     pub engines: HashMap<String, EngineLaunch>,
-    /// Cached `<engine> --version` strings, keyed by engine id. Filled by the
-    /// settings "Detect" action so the panel shows versions without re-probing over
-    /// SSH on every open.
+    /// Cached `<engine> --version` strings, keyed by engine id, plus the reserved
+    /// `_worker` deployment identity. Engine entries let settings show versions
+    /// without re-probing over SSH on every open.
     #[serde(default)]
     pub engine_versions: HashMap<String, String>,
     /// Per-host default resource request. Only `cores` is consumed today — it caps

--- a/compute-core/tests/remote_direct.rs
+++ b/compute-core/tests/remote_direct.rs
@@ -1,22 +1,25 @@
+#![cfg(feature = "dev-worker")]
+
 //! End-to-end check of the Direct remote launcher against a real SSH host.
 //!
 //! `#[ignore]` — a developer-occasional test, not run by ordinary `cargo test`
-//! or CI. To exercise it against a host (e.g. a local WSL) with the worker
-//! pre-placed at `~/.silicolab/bin/silicolab-compute` and the app's dedicated key
-//! authorized for passwordless login:
+//! or CI. Build the current worker first, then exercise it against a host (e.g. a
+//! local WSL) with the app's dedicated key authorized for passwordless login:
 //!
 //! ```text
+//! cargo xtask build-dev-worker
 //! SILICOLAB_TEST_SSH_HOST=<ip> SILICOLAB_TEST_SSH_USER=<user> \
-//! cargo test -p compute-core --test remote_direct -- --ignored --nocapture
+//! cargo test -p compute-core --features dev-worker --test remote_direct -- --ignored --nocapture
 //! ```
 //!
-//! It asserts the remote worker's energy matches the in-process run to SCF
-//! tolerance (parity is bounded, never bit-for-bit).
+//! The test deploys the local development artifact through the normal SSH/SCP
+//! path and asserts its energy matches the in-process run to SCF tolerance
+//! (parity is bounded, never bit-for-bit).
 
 use compute_core::domain::{Atom, Structure};
 use compute_core::engines::qm::{QmJob, QmKind, QmMethod, QmOptions, QmRequest};
-use compute_core::engines::remote::RemoteTarget;
 use compute_core::engines::remote::launcher::{Launcher, RemoteExecution};
+use compute_core::engines::remote::{RemoteTarget, deploy};
 use compute_core::hosts::RemoteHost;
 use compute_core::wire::{
     Engine, EngineOutcome, EngineRequest, Executor, JobUpdate, Running, run_job,
@@ -62,16 +65,13 @@ fn drain(running: Running) -> EngineOutcome {
 }
 
 #[test]
-#[ignore = "requires an SSH host with a pre-placed worker (set SILICOLAB_TEST_SSH_HOST)"]
+#[ignore = "requires an SSH host (set SILICOLAB_TEST_SSH_HOST)"]
 fn direct_remote_qm_matches_in_process_within_tolerance() {
     let Ok(hostname) = std::env::var("SILICOLAB_TEST_SSH_HOST") else {
         eprintln!("skip: set SILICOLAB_TEST_SSH_HOST to run the remote end-to-end test");
         return;
     };
     let username = std::env::var("SILICOLAB_TEST_SSH_USER").unwrap_or_else(|_| "root".to_string());
-    let worker_path = std::env::var("SILICOLAB_TEST_WORKER")
-        .unwrap_or_else(|_| "~/.silicolab/bin/silicolab-compute".to_string());
-
     // Baseline: the same job in-process.
     let EngineOutcome::Qm(local) = drain(run_job(h2_single_point(), Executor::InProcess)) else {
         panic!("expected a QM outcome");
@@ -92,12 +92,18 @@ fn direct_remote_qm_matches_in_process_within_tolerance() {
     };
     let run_uuid = uuid::Uuid::new_v4().to_string();
     let target = RemoteTarget::for_run(&host, &run_uuid);
+    let deployed = deploy::ensure_worker_deployed(&host, &target)
+        .expect("deploy the current local development worker");
+    assert!(
+        deployed.deployment_id.starts_with("dev:"),
+        "the dev-worker test must never fall back to a release artifact"
+    );
     let working_dir = std::env::temp_dir().join(format!("sl-remote-direct-{run_uuid}"));
     let execution = RemoteExecution {
         target,
         launcher: Launcher::Direct,
         working_dir: working_dir.clone(),
-        worker_path,
+        worker_path: deployed.remote_path,
     };
 
     let EngineOutcome::Qm(remote) = drain(run_job(

--- a/docs-site/src/content/docs/getting-started/remote-execution.md
+++ b/docs-site/src/content/docs/getting-started/remote-execution.md
@@ -17,13 +17,19 @@ On first use, SilicoLab deploys a small self-contained worker to the host. The
 worker is pinned to the app version and verified against its published checksum
 before it runs.
 
+Testing remote changes from source is a contributor workflow; follow the
+[remote execution development guide](https://github.com/silicolab/silicolab/blob/main/docs/developing-remote-execution.md).
+Released builds always use the version-pinned, checksum-verified worker described
+above.
+
 ## Set up a host
 
 Open **Settings > Engines > Remote Hosts**.
 
 1. Select **Add host** and enter a label, hostname or IP address, username, and
    optionally a port and remote work directory. The default work directory is
-   `~/.silicolab`.
+   `~/.silicolab`. A custom work directory must be an absolute Linux path or
+   start with `~/`.
 2. Under **Setup commands**, enter the commands a fresh non-interactive SSH
    shell needs before engine commands are available. For example, use
    `module load gromacs` or `source /opt/gromacs/bin/GMXRC` to make `gmx`

--- a/docs-site/src/content/docs/zh/getting-started/remote-execution.md
+++ b/docs-site/src/content/docs/zh/getting-started/remote-execution.md
@@ -16,12 +16,17 @@ OpenSSH Client** 中启用。
 首次使用时，SilicoLab 会向主机部署一个小型自包含 worker。worker 会绑定到
 当前应用版本，并在运行前用发布的校验和验证。
 
+如需从源码测试远程执行变更，请参阅
+[远程执行开发指南](https://github.com/silicolab/silicolab/blob/main/docs/developing-remote-execution.md)。
+正式发布的版本始终使用与应用版本绑定并经过校验和验证的 worker。
+
 ## 配置主机
 
 打开 **Settings > Engines > Remote Hosts**。
 
 1. 选择 **Add host**，填写标签、主机名或 IP、用户名，并可选填写端口和远程
-   工作目录。默认工作目录是 `~/.silicolab`。
+   工作目录。默认工作目录是 `~/.silicolab`。自定义目录必须是 Linux 绝对路径，
+   或以 `~/` 开头。
 2. 在 **Setup commands** 中填写非交互 SSH shell 启动后需要执行的命令，让
    引擎命令可用。例如可用 `module load gromacs` 或
    `source /opt/gromacs/bin/GMXRC` 让 `gmx` 可运行。每行填写一条命令。

--- a/docs/adding-a-feature.md
+++ b/docs/adding-a-feature.md
@@ -9,7 +9,11 @@ them — read the named module for the current code.
 
 See [ARCHITECTURE.md](../ARCHITECTURE.md) for *why* the layers and the
 `AppAction → dispatch` flow exist, and [CONTRIBUTING.md](../CONTRIBUTING.md) for
-build/test/land. Layer order (lowest owns it) spans two crates: **compute-core**
+build/test/land. Changes to a remote-capable engine or the `wire`/`payload`
+contract must also follow
+[Developing remote execution](developing-remote-execution.md) so the current
+worker is rebuilt and exercised instead of a released worker. Layer order
+(lowest owns it) spans two crates: **compute-core**
 `domain → io → md → engines → workflows` (no GUI deps; also holds `hosts`/
 `payload`/`wire`; `md` is the engine-neutral molecular-dynamics model), then
 **silicolab** `backend → frontend` (depends on compute-core); the headless
@@ -23,7 +27,7 @@ below are relative to a crate: `md/`, `engines/`, `io/`, `workflows/` live under
 |---|---|---|
 | In-process pure-Rust compute | `engines/qm/` (+ `engines/forcefield/uff`) | Free functions, **no `Engine` trait**; register a built-in `EngineId` + capability in `engines/registry.rs`. |
 | External subprocess engine | `engines/gromacs/` (+ `engines/process`, `engines/remote`) | Declare an `EngineSpec` in `registry.rs`; runs on a `JobManager` thread, never the UI thread. |
-| Run an existing engine on a **remote** host | `engines/remote/` (`deploy`, `launcher`, `run_record`) + `frontend/dispatcher/` (`remote_jobs`, `builders`) | Mirror the `resolve_remote_compute_host → start_remote_engine → apply_remote_*_outcome` dispatch; the job crosses the `wire`/`payload` bridge to the deployed `silicolab-compute` worker. Reuses each engine's `compute-core` impl, so local and remote can't diverge. |
+| Run an existing engine on a **remote** host | `engines/remote/` (`deploy`, `launcher`, `run_record`) + `frontend/dispatcher/` (`remote_jobs`, `builders`) | Mirror the `resolve_remote_compute_host → start_remote_engine → apply_remote_*_outcome` dispatch; the job crosses the `wire`/`payload` bridge to the deployed `silicolab-compute` worker. Reuses each engine's `compute-core` impl, so local and remote can't diverge. Rebuild and test it with `cargo xtask remote-dev`. |
 | Background compute **task** (panel + result entries) | the `qm-energy` task, end-to-end — see the checklist | For a CPU loop that streams intermediate structures, also study `build-disordered-system`. |
 | Multi-entry picker panel | `disorder` | `SetDisorderComponentEntry`, `with_disorder_prompt`, and the `ensure_panel_form` seeding. |
 | Inline edit task (no panel, acts on the active structure) | `add-hydrogens` / `recompute-bonds` | Executor runs the op and marks the task complete; no prompt state. |
@@ -74,6 +78,12 @@ new `EntryOrigin` variant.
 
 ## Traps the compiler/tests won't catch
 
+- **A normal app launch does not test unpublished remote worker changes.** If a
+  remote-capable engine, `EngineRequest`, `EngineOutcome`, or the payload bridge
+  changes, rebuild and run the current worker with `cargo xtask remote-dev`.
+  Use `cargo xtask build-dev-worker` in an IDE pre-launch task and run the
+  relevant opt-in SSH test described in the
+  [remote development guide](developing-remote-execution.md).
 - **A new IO format = 4 sites, and one is not a `match`.** Touch
   `io/structure_format.rs` (the enum + the `READABLE_FORMATS`/`WRITABLE_FORMATS`
   arrays + `label`/`extension`/`from_extension`), `io/structure_codec.rs`,

--- a/docs/developing-remote-execution.md
+++ b/docs/developing-remote-execution.md
@@ -1,0 +1,293 @@
+# Developing remote execution
+
+Use this guide when a change must run through the remote worker before it has
+been published in a SilicoLab release. The standard entry point is:
+
+```text
+cargo xtask remote-dev
+```
+
+It cross-compiles the worker from the current checkout, validates the resulting
+Linux executable, and launches the application in development-worker mode. The
+remote host receives a binary; it does not need the source tree or a development
+toolchain.
+
+For released behavior and host setup, see the end-user
+[remote execution guide](../docs-site/src/content/docs/getting-started/remote-execution.md).
+
+## Production and development artifacts
+
+Remote deployment has two deliberately separate artifact sources:
+
+| Application build | Worker source | Deployment identity |
+|---|---|---|
+| Ordinary or official build | The `silicolab-compute-x86_64-unknown-linux-musl` asset from the GitHub Release whose tag exactly matches the application package version, plus that release's published SHA-256 | The package version |
+| Build with the contributor-only `dev-worker` feature | A validated local `x86_64-unknown-linux-musl` worker | `dev:<full SHA-256 of the binary>` |
+
+Production remains fail-closed. It will not use an unverified download, a
+different release tag, or a local development artifact. Development worker
+resolution reads the selected local file without contacting GitHub Releases and
+never falls back to a released worker.
+
+`remote-dev` also suppresses the application's automatic startup release check,
+so the development workflow makes no incidental GitHub Releases request.
+
+Both sources use the same installation sequence: upload an identity-qualified
+file, make it executable, check its reported package version, and only then
+atomically update the stable `silicolab-compute` symlink.
+The host's persisted `_worker` value is a deployment identity: production
+deployments store the package version, while development deployments store the
+`dev:<sha256>` form.
+
+The identity is derived from the bytes that will actually run. Rebuilding
+without changing the binary reuses the verified remote artifact; changing the
+binary produces a new identity and filename. A matching cached identity is only
+a fast-path hint: SilicoLab still checks that the remote executable exists and
+runs, and redeploys it if that verification fails. Switching between a release
+build and a development build also changes the identity, so neither can reuse
+the other's worker accidentally.
+
+Each job launches the verified identity-qualified path directly. The stable
+symlink is published only after verification and does not decide which bytes an
+already-submitted job runs, so concurrent checkouts cannot swap workers under
+one another.
+
+## Prerequisites
+
+On the development machine, install:
+
+- the repository's normal Rust toolchain through `rustup`;
+- Cargo; and
+- the operating system's OpenSSH client (`ssh`, `scp`, and `ssh-keygen`).
+
+`cargo xtask` checks for the `x86_64-unknown-linux-musl` Rust standard-library
+target and runs `rustup target add` when it is missing. The repository configures
+that target to link with the Rust toolchain's `rust-lld` in self-contained mode.
+The worker's dependencies are pure Rust, so no Docker, WSL, musl C compiler, or
+cross-compilation SDK is required.
+
+Platform notes:
+
+- **Windows:** use a rustup-managed Rust installation. Windows 11 provides
+  OpenSSH Client under **Settings > Apps > Optional features**. WSL is not part
+  of the build path.
+- **macOS:** the system OpenSSH client is sufficient. The worker still builds as
+  a Linux executable; it is not run on the Mac.
+- **Linux:** the system OpenSSH client is sufficient. The same cross-target
+  command is used even when the development machine is already x86_64 Linux.
+
+The remote machine must run **x86_64 Linux** and accept passwordless login
+through SilicoLab's host-key-verified SSH configuration. ARM64/aarch64 hosts are
+not supported by this worker. The remote machine needs no Rust toolchain,
+container runtime, source checkout, compiler, or operating-system changes.
+GROMACS jobs still require a working `gmx` on the remote host; QM and docking do
+not.
+
+## Standard workflows
+
+Launch the GUI with the current-source worker:
+
+```text
+cargo xtask remote-dev
+```
+
+Pass normal application arguments after `--`. For example, to run a script
+headlessly:
+
+```text
+cargo xtask remote-dev -- path/to/workflow.sls --name value
+```
+
+The command performs these steps in order:
+
+1. ensure the musl Rust target is installed;
+2. run the release-profile build of `silicolab-compute` for that target;
+3. validate that the output is an ELF64, little-endian, x86-64 executable; and
+4. launch SilicoLab with `dev-worker` enabled and the artifact selected.
+
+The default artifact is:
+
+```text
+target/x86_64-unknown-linux-musl/release/silicolab-compute
+```
+
+There is no `.exe` suffix, including when the development machine is Windows,
+because the file targets Linux.
+
+For an IDE pre-launch task or a build-only check, run:
+
+```text
+cargo xtask build-dev-worker
+```
+
+This performs the target check, release build, and ELF validation without
+starting SilicoLab.
+
+### Use an explicit local artifact
+
+`SILICOLAB_DEV_WORKER` overrides the default artifact path when the
+`dev-worker` feature is enabled. The file must satisfy the same size and ELF
+validation as the default build. Relative paths are resolved from the process's
+working directory, so prefer an absolute path in IDE settings.
+
+PowerShell:
+
+```powershell
+$env:SILICOLAB_DEV_WORKER = 'C:\path\to\silicolab-compute'
+cargo run --release --features dev-worker
+```
+
+macOS or Linux shell:
+
+```sh
+SILICOLAB_DEV_WORKER=/path/to/silicolab-compute \
+  cargo run --release --features dev-worker
+```
+
+The override is contributor-only: builds without `dev-worker` neither inspect
+nor honor it. Prefer `cargo xtask remote-dev` when testing the current checkout;
+the manual launch is mainly useful for a known custom artifact. `remote-dev`
+preserves an existing override, so unset `SILICOLAB_DEV_WORKER` when you want it
+to select the worker it just built at the default path.
+
+## IDE pre-launch setup
+
+Keep worker compilation as a separate pre-launch task so every IDE run uses the
+current worker bytes.
+
+### RustRover
+
+1. Add a Cargo run configuration named **Build development worker** with command
+   `xtask build-dev-worker`.
+2. Add a Cargo run configuration for SilicoLab with command
+   `run --release --features dev-worker`.
+3. Set its environment variable
+   `SILICOLAB_DEV_WORKER=$ProjectFileDir$/target/x86_64-unknown-linux-musl/release/silicolab-compute`.
+4. In **Before launch**, add **Run Another Configuration** and select
+   **Build development worker**.
+
+Arguments intended for SilicoLab belong after `--` in the application Cargo
+configuration.
+
+### VS Code
+
+Add a build task to `.vscode/tasks.json` (or merge it into the existing file):
+
+```json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "silicolab: build development worker",
+      "type": "process",
+      "command": "cargo",
+      "args": ["xtask", "build-dev-worker"],
+      "options": { "cwd": "${workspaceFolder}" },
+      "problemMatcher": ["$rustc"]
+    }
+  ]
+}
+```
+
+Reference it from the Rust launch configuration and select the artifact:
+
+```json
+{
+  "preLaunchTask": "silicolab: build development worker",
+  "env": {
+    "SILICOLAB_DEV_WORKER": "${workspaceFolder}/target/x86_64-unknown-linux-musl/release/silicolab-compute"
+  }
+}
+```
+
+The launch configuration itself must build or run the `silicolab` binary with
+`--release --features dev-worker`. The exact remaining fields depend on the
+installed Rust debugger extension.
+
+## Opt-in SSH integration tests
+
+These tests deploy the current local worker themselves. Do not pre-place a
+worker or forge the host's `_worker` cache value.
+
+First build and validate the artifact:
+
+```text
+cargo xtask build-dev-worker
+```
+
+Configure a reachable x86_64 Linux host with SilicoLab's dedicated SSH key
+authorized for passwordless login, then set the test environment. In
+PowerShell:
+
+```powershell
+$env:SILICOLAB_TEST_SSH_HOST = 'host-or-ip'
+$env:SILICOLAB_TEST_SSH_USER = 'username'
+```
+
+In a macOS or Linux shell:
+
+```sh
+export SILICOLAB_TEST_SSH_HOST=host-or-ip
+export SILICOLAB_TEST_SSH_USER=username
+```
+
+Run the direct QM parity test:
+
+```text
+cargo test -p compute-core --features dev-worker --test remote_direct -- --ignored --nocapture
+```
+
+The detached frontend tests exercise QM, docking, and GROMACS:
+
+```text
+cargo test -p silicolab --features dev-worker --lib -- --ignored remote_qm_submit_then_refresh --nocapture
+cargo test -p silicolab --features dev-worker --lib -- --ignored remote_docking_submit_then_refresh --nocapture
+cargo test -p silicolab --features dev-worker --lib -- --ignored remote_gromacs_submit_then_refresh --nocapture
+```
+
+The GROMACS test requires `gmx` on the host. If a non-interactive SSH shell must
+source an environment first, set `SILICOLAB_TEST_GMX_PRELUDE` to that one shell
+line. `SILICOLAB_DEV_WORKER` is optional for all of these tests and selects a
+non-default local artifact when set.
+
+The tests are ignored by default because they mutate the configured host's
+SilicoLab work directory and require real SSH access. They leave production
+release resolution disabled by selecting the local development artifact.
+
+## Troubleshooting
+
+**`rustup` or the musl target is unavailable.** Confirm that `rustup` manages the
+active toolchain with `rustup show`, then retry `cargo xtask build-dev-worker`.
+The xtask prints the failing `rustup target add` command when automatic
+installation fails.
+
+**The build cannot find a linker.** Run the command from this repository so
+`.cargo/config.toml` selects `rust-lld` and self-contained linking. Remove local
+Cargo or environment overrides that replace the target linker. A system musl
+toolchain should not be necessary.
+
+**The artifact is missing or rejected as ELF.** Re-run
+`cargo xtask build-dev-worker`. If `SILICOLAB_DEV_WORKER` is set, check that it
+points to the Linux cross-target output rather than the host application's
+executable. The validator rejects oversized files, truncated files, ELF32,
+big-endian ELF, and non-x86-64 machine types before SSH deployment begins.
+
+**Deployment tries to access GitHub Releases.** The application was not started
+through the development path. Use `cargo xtask remote-dev`, or ensure a manual
+launch enables `dev-worker` and selects a valid local artifact. Development mode
+does not fall back to a release download.
+
+**The remote host reports `aarch64` or another architecture.** Select an x86_64
+Linux host. Cross-compiling the local worker does not make it portable to a
+different remote CPU architecture.
+
+**A cached worker is missing, corrupt, or no longer executable.** No manual cache
+editing is needed. SilicoLab verifies a cache hit remotely and redeploys the
+selected artifact when the executable is absent or fails its version check. If
+redeployment also fails, inspect SSH permissions and free space under the
+host's configured work root.
+
+**SSH setup or host-key verification fails.** Follow the end-user
+[remote host setup](../docs-site/src/content/docs/getting-started/remote-execution.md#set-up-a-host).
+The development path reuses the same hardened SSH/SCP transport and does not
+weaken host-key checks.

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -45,6 +45,7 @@ pub fn run(structure: Structure, source_path: Option<PathBuf>) -> Result<()> {
             // Kick off the once-per-launch release check (a single background
             // HTTP request); `poll_jobs` drains the result. Honors the
             // "Check for updates" setting, on by default.
+            #[cfg(not(feature = "dev-worker"))]
             if app.state.config.check_updates {
                 app.state.jobs.update_check = Some(crate::frontend::jobs::spawn_update_check());
             }

--- a/src/frontend/dispatcher/remote_jobs.rs
+++ b/src/frontend/dispatcher/remote_jobs.rs
@@ -103,8 +103,8 @@ fn remote_engine_name(engine: &crate::wire::Engine) -> &'static str {
 }
 
 /// Drain a finished detached-remote submission (any engine): record the durable
-/// row in `jobs.db`, persist the deployed worker version on the host (so the next
-/// run skips redeploy), and mark the task running or failed.
+/// row in `jobs.db`, persist the worker deployment identity on the host (so the
+/// next run can verify its cache entry), and mark the task running or failed.
 pub(crate) fn poll_remote_submit(state: &mut AppState, ctx: &egui::Context) {
     use crate::frontend::remote_jobs::RemoteSubmitOutcome;
     let Some(submit) = state.jobs.remote_submit.take() else {
@@ -123,17 +123,17 @@ pub(crate) fn poll_remote_submit(state: &mut AppState, ctx: &egui::Context) {
                 job_kind,
                 project_root,
                 local_run_dir,
-                deployed_version,
+                deployment_id,
             } = *submitted;
             if let Some(host) = state.config.remote_hosts.get_mut(&host_id) {
                 host.engine_versions.insert(
-                    crate::engines::remote::deploy::WORKER_VERSION_KEY.to_string(),
-                    deployed_version,
+                    crate::engines::remote::deploy::WORKER_DEPLOYMENT_KEY.to_string(),
+                    deployment_id,
                 );
                 if let Err(error) = save_config(&state.config) {
-                    state
-                        .output_log
-                        .push(format!("could not persist worker version: {error}"));
+                    state.output_log.push(format!(
+                        "could not persist worker deployment identity: {error}"
+                    ));
                 }
             }
             let row = registry::RemoteJob {

--- a/src/frontend/remote_jobs.rs
+++ b/src/frontend/remote_jobs.rs
@@ -25,8 +25,8 @@ pub struct RemoteSubmitted {
     pub job_kind: String,
     pub project_root: Option<String>,
     pub local_run_dir: PathBuf,
-    /// The worker version `ensure_worker_deployed` confirmed on the host.
-    pub deployed_version: String,
+    /// The exact worker deployment identity confirmed on the host.
+    pub deployment_id: String,
 }
 
 /// Result of an off-thread detached remote submission. The success payload is
@@ -195,7 +195,7 @@ pub fn spawn_remote_submit(
                 job_kind,
                 project_root,
                 local_run_dir: local_run_dir.clone(),
-                deployed_version: deployed.version,
+                deployment_id: deployed.deployment_id,
             })))
         })();
         let _ = sender

--- a/src/frontend/remote_jobs/tests.rs
+++ b/src/frontend/remote_jobs/tests.rs
@@ -74,27 +74,24 @@ fn remote_memory_rejection_names_host_and_advises() {
     assert!(remote_qm_memory_rejection(&MemoryVerdict::Ok, "cluster").is_none());
 }
 
-/// End-to-end check of the detached frontend path (deploy fast-path → submit
-/// → opt-in refresh → retrieve) against a real SSH host. `#[ignore]`: a
+/// End-to-end check of the detached frontend path (deploy → submit → opt-in
+/// refresh → retrieve) against a real SSH host. `#[ignore]`: a
 /// developer-occasional test requiring an SSH host (e.g. a local WSL) with
-/// the worker pre-placed at `~/.silicolab/bin/silicolab-compute` and
-/// passwordless login configured. Run with:
+/// passwordless login configured. Build the current worker first, then run:
 ///
 /// ```text
+/// cargo xtask build-dev-worker
 /// SILICOLAB_TEST_SSH_HOST=<ip> SILICOLAB_TEST_SSH_USER=<user> \
-/// cargo test -p silicolab --lib -- --ignored remote_qm_submit_then_refresh
+/// cargo test -p silicolab --features dev-worker --lib -- --ignored remote_qm_submit_then_refresh
 /// ```
-///
-/// The host records the current worker version, so `ensure_worker_deployed`
-/// takes its no-network fast path (the GitHub asset only exists post-release).
+#[cfg(feature = "dev-worker")]
 #[test]
-#[ignore = "requires an SSH host with a pre-placed worker (set SILICOLAB_TEST_SSH_HOST)"]
+#[ignore = "requires an SSH host (set SILICOLAB_TEST_SSH_HOST)"]
 fn remote_qm_submit_then_refresh_against_ssh_host() {
     use crate::backend::config::RemoteHost;
     use crate::backend::storage::jobs::{RemoteJob, RemoteJobStatus};
     use crate::domain::{Atom, Structure};
     use crate::engines::qm::{QmKind, QmMethod, QmOptions, QmRequest};
-    use crate::engines::remote::deploy::WORKER_VERSION_KEY;
     use nalgebra::Point3;
     use std::time::Duration;
 
@@ -104,11 +101,6 @@ fn remote_qm_submit_then_refresh_against_ssh_host() {
     };
     let username = std::env::var("SILICOLAB_TEST_SSH_USER").unwrap_or_else(|_| "root".to_string());
 
-    let mut engine_versions = std::collections::HashMap::new();
-    engine_versions.insert(
-        WORKER_VERSION_KEY.to_string(),
-        env!("CARGO_PKG_VERSION").to_string(),
-    );
     let host = RemoteHost {
         id: "wsl".to_string(),
         label: "WSL".to_string(),
@@ -118,7 +110,7 @@ fn remote_qm_submit_then_refresh_against_ssh_host() {
         work_root: "~/.silicolab".to_string(),
         prelude: Vec::new(),
         engines: Default::default(),
-        engine_versions,
+        engine_versions: Default::default(),
         resources: Default::default(),
     };
 
@@ -164,6 +156,10 @@ fn remote_qm_submit_then_refresh_against_ssh_host() {
         RemoteSubmitOutcome::Submitted(submitted) => *submitted,
         RemoteSubmitOutcome::Failed(error) => panic!("remote submit failed: {error}"),
     };
+    assert!(
+        submitted.deployment_id.starts_with("dev:"),
+        "the dev-worker test must never fall back to a release artifact"
+    );
 
     let row = RemoteJob {
         run_uuid: submitted.run_uuid,
@@ -208,20 +204,21 @@ fn remote_qm_submit_then_refresh_against_ssh_host() {
 /// The detached docking path against a real SSH host, mirroring the QM E2E
 /// above: submit a `ScoreOnly` job (one fast evaluation), refresh until it
 /// finishes, and assert a pose came back through the payload bridge. `#[ignore]`
-/// for the same reason — it needs a host with a pre-placed worker. Run with:
+/// requires an SSH host. Build the current worker first, then run:
 ///
 /// ```text
+/// cargo xtask build-dev-worker
 /// SILICOLAB_TEST_SSH_HOST=<ip> SILICOLAB_TEST_SSH_USER=<user> \
-/// cargo test -p silicolab --lib -- --ignored remote_docking_submit_then_refresh
+/// cargo test -p silicolab --features dev-worker --lib -- --ignored remote_docking_submit_then_refresh
 /// ```
+#[cfg(feature = "dev-worker")]
 #[test]
-#[ignore = "requires an SSH host with a pre-placed worker (set SILICOLAB_TEST_SSH_HOST)"]
+#[ignore = "requires an SSH host (set SILICOLAB_TEST_SSH_HOST)"]
 fn remote_docking_submit_then_refresh_against_ssh_host() {
     use crate::backend::config::RemoteHost;
     use crate::backend::storage::jobs::{RemoteJob, RemoteJobStatus};
     use crate::domain::{Atom, Bond, BondType, Structure};
     use crate::engines::docking::{DockingConfig, DockingInput, DockingKind, DockingRequest};
-    use crate::engines::remote::deploy::WORKER_VERSION_KEY;
     use nalgebra::Point3;
     use std::time::Duration;
 
@@ -231,11 +228,6 @@ fn remote_docking_submit_then_refresh_against_ssh_host() {
     };
     let username = std::env::var("SILICOLAB_TEST_SSH_USER").unwrap_or_else(|_| "root".to_string());
 
-    let mut engine_versions = std::collections::HashMap::new();
-    engine_versions.insert(
-        WORKER_VERSION_KEY.to_string(),
-        env!("CARGO_PKG_VERSION").to_string(),
-    );
     let host = RemoteHost {
         id: "wsl".to_string(),
         label: "WSL".to_string(),
@@ -245,7 +237,7 @@ fn remote_docking_submit_then_refresh_against_ssh_host() {
         work_root: "~/.silicolab".to_string(),
         prelude: Vec::new(),
         engines: Default::default(),
-        engine_versions,
+        engine_versions: Default::default(),
         resources: Default::default(),
     };
 
@@ -295,6 +287,10 @@ fn remote_docking_submit_then_refresh_against_ssh_host() {
         RemoteSubmitOutcome::Submitted(submitted) => *submitted,
         RemoteSubmitOutcome::Failed(error) => panic!("remote docking submit failed: {error}"),
     };
+    assert!(
+        submitted.deployment_id.starts_with("dev:"),
+        "the dev-worker test must never fall back to a release artifact"
+    );
 
     let row = RemoteJob {
         run_uuid: submitted.run_uuid,
@@ -340,23 +336,24 @@ fn remote_docking_submit_then_refresh_against_ssh_host() {
 /// submit a tiny single-stage `gmx` Run (energy-minimize a hermetic 8-atom
 /// argon box with an inline topology), let the worker run the whole pipeline in
 /// one allocation, then refresh until it finishes and assert the structure +
-/// stage report came back in `EngineOutcome::Gromacs`. `#[ignore]` — it needs a
-/// host with a pre-placed worker AND a working `gmx`. Set the optional
+/// stage report came back in `EngineOutcome::Gromacs`. `#[ignore]` — it needs an
+/// SSH host with a working `gmx`. Set the optional
 /// `SILICOLAB_TEST_GMX_PRELUDE` to a shell line (e.g. `. /usr/local/gromacs/bin/GMXRC`)
-/// when `gmx` needs its environment sourced first. Run with:
+/// when `gmx` needs its environment sourced first. Build the current worker, then run:
 ///
 /// ```text
+/// cargo xtask build-dev-worker
 /// SILICOLAB_TEST_SSH_HOST=<ip> SILICOLAB_TEST_SSH_USER=<user> \
-/// cargo test -p silicolab --lib -- --ignored remote_gromacs_submit_then_refresh
+/// cargo test -p silicolab --features dev-worker --lib -- --ignored remote_gromacs_submit_then_refresh
 /// ```
+#[cfg(feature = "dev-worker")]
 #[test]
-#[ignore = "requires an SSH host with a pre-placed worker and a working gmx (set SILICOLAB_TEST_SSH_HOST)"]
+#[ignore = "requires an SSH host with a working gmx (set SILICOLAB_TEST_SSH_HOST)"]
 fn remote_gromacs_submit_then_refresh_against_ssh_host() {
     use crate::backend::config::RemoteHost;
     use crate::backend::storage::jobs::{RemoteJob, RemoteJobStatus};
     use crate::domain::{Atom, Structure, UnitCell};
     use crate::engines::gromacs::{MdpSettings, StageLinks, StageSpec};
-    use crate::engines::remote::deploy::WORKER_VERSION_KEY;
     use crate::workflows::gromacs::{GromacsJob, GromacsRunRequest, WireTopology};
     use nalgebra::Point3;
     use std::time::Duration;
@@ -393,11 +390,6 @@ AR  8
         .map(|line| vec![line])
         .unwrap_or_default();
 
-    let mut engine_versions = std::collections::HashMap::new();
-    engine_versions.insert(
-        WORKER_VERSION_KEY.to_string(),
-        env!("CARGO_PKG_VERSION").to_string(),
-    );
     let host = RemoteHost {
         id: "wsl".to_string(),
         label: "WSL".to_string(),
@@ -407,7 +399,7 @@ AR  8
         work_root: "~/.silicolab".to_string(),
         prelude,
         engines: Default::default(),
-        engine_versions,
+        engine_versions: Default::default(),
         resources: Default::default(),
     };
 
@@ -462,6 +454,10 @@ AR  8
         RemoteSubmitOutcome::Submitted(submitted) => *submitted,
         RemoteSubmitOutcome::Failed(error) => panic!("remote GROMACS submit failed: {error}"),
     };
+    assert!(
+        submitted.deployment_id.starts_with("dev:"),
+        "the dev-worker test must never fall back to a release artifact"
+    );
 
     let row = RemoteJob {
         run_uuid: submitted.run_uuid,

--- a/xtask/src/dev_worker.rs
+++ b/xtask/src/dev_worker.rs
@@ -1,0 +1,277 @@
+use std::{
+    env, fs,
+    io::Read,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use super::{print_command_failure, repo_root};
+
+const TARGET: &str = "x86_64-unknown-linux-musl";
+const ARTIFACT_ENV: &str = "SILICOLAB_DEV_WORKER";
+
+pub fn run(app_args: &[String]) -> Result<(), String> {
+    let repo_root = repo_root()?;
+    let built_worker = build()?;
+    let worker = env::var_os(ARTIFACT_ENV)
+        .map(PathBuf::from)
+        .unwrap_or(built_worker);
+
+    println!("Launching SilicoLab with {}", worker.display());
+    let status = Command::new("cargo")
+        .args([
+            "run",
+            "--package",
+            "silicolab",
+            "--features",
+            "dev-worker",
+            "--",
+        ])
+        .args(app_args)
+        .current_dir(&repo_root)
+        .env(ARTIFACT_ENV, &worker)
+        .status()
+        .map_err(|error| format!("failed to launch SilicoLab: {error}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("SilicoLab exited with {status}."))
+    }
+}
+
+pub fn build() -> Result<PathBuf, String> {
+    let repo_root = repo_root()?;
+    ensure_rust_target(&repo_root)?;
+    let rust_lld = bundled_rust_lld(&repo_root)?;
+    let linker_dir = rust_lld
+        .parent()
+        .ok_or_else(|| format!("could not resolve parent of {}", rust_lld.display()))?;
+
+    println!("Building silicolab-compute for {TARGET}");
+    let mut command = Command::new("cargo");
+    command
+        .args([
+            "build",
+            "--release",
+            "--package",
+            "silicolab-compute",
+            "--target",
+            TARGET,
+        ])
+        .current_dir(&repo_root)
+        .env("CARGO_TARGET_DIR", repo_root.join("target"));
+    prepend_path(&mut command, linker_dir)?;
+    let status = command
+        .status()
+        .map_err(|error| format!("failed to build development worker: {error}"))?;
+    if !status.success() {
+        return Err(format!("development worker build failed with {status}."));
+    }
+
+    let worker = repo_root
+        .join("target")
+        .join(TARGET)
+        .join("release")
+        .join("silicolab-compute");
+    validate_linux_x86_64_elf(&worker)?;
+    println!("Development worker: {}", worker.display());
+    Ok(worker)
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+pub fn smoke_test_version(worker: &Path) -> Result<(), String> {
+    let output = Command::new(worker)
+        .arg("--version")
+        .output()
+        .map_err(|error| format!("failed to run worker {}: {error}", worker.display()))?;
+    if !output.status.success() {
+        return Err(format!(
+            "worker version smoke test failed with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let reported = String::from_utf8(output.stdout)
+        .map_err(|error| format!("worker produced non-UTF-8 version output: {error}"))?;
+    let expected = env!("CARGO_PKG_VERSION");
+    if reported.trim() != expected {
+        return Err(format!(
+            "worker reports version `{}` but `{expected}` was expected",
+            reported.trim()
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_rust_target(repo_root: &Path) -> Result<(), String> {
+    let args = ["target", "list", "--installed"];
+    let output = Command::new("rustup")
+        .args(args)
+        .current_dir(repo_root)
+        .output()
+        .map_err(|error| format!("failed to run rustup {}: {error}", args.join(" ")))?;
+    if !output.status.success() {
+        print_command_failure("rustup", &args, &output);
+        return Err(format!(
+            "rustup target query failed with {}.",
+            output.status
+        ));
+    }
+
+    let targets = String::from_utf8(output.stdout)
+        .map_err(|error| format!("rustup produced non-UTF-8 target output: {error}"))?;
+    if targets.lines().any(|target| target.trim() == TARGET) {
+        return Ok(());
+    }
+
+    println!("Installing Rust target {TARGET}");
+    let status = Command::new("rustup")
+        .args(["target", "add", TARGET])
+        .current_dir(repo_root)
+        .status()
+        .map_err(|error| format!("failed to install Rust target {TARGET}: {error}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("rustup target installation failed with {status}."))
+    }
+}
+
+fn bundled_rust_lld(repo_root: &Path) -> Result<PathBuf, String> {
+    let sysroot = command_stdout(repo_root, "rustc", &["--print", "sysroot"])?;
+    let version = command_stdout(repo_root, "rustc", &["-vV"])?;
+    let host = version
+        .lines()
+        .find_map(|line| line.strip_prefix("host: "))
+        .ok_or_else(|| "rustc -vV did not report its host toolchain".to_owned())?;
+    let linker = Path::new(sysroot.trim())
+        .join("lib")
+        .join("rustlib")
+        .join(host)
+        .join("bin")
+        .join(format!("rust-lld{}", env::consts::EXE_SUFFIX));
+    if linker.is_file() {
+        Ok(linker)
+    } else {
+        Err(format!(
+            "the active Rust toolchain does not contain its bundled linker at {}",
+            linker.display()
+        ))
+    }
+}
+
+fn command_stdout(repo_root: &Path, program: &str, args: &[&str]) -> Result<String, String> {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(repo_root)
+        .output()
+        .map_err(|error| format!("failed to run {program} {}: {error}", args.join(" ")))?;
+    if !output.status.success() {
+        print_command_failure(program, args, &output);
+        return Err(format!(
+            "{program} {} failed with {}.",
+            args.join(" "),
+            output.status
+        ));
+    }
+    String::from_utf8(output.stdout)
+        .map_err(|error| format!("{program} produced non-UTF-8 output: {error}"))
+}
+
+fn prepend_path(command: &mut Command, directory: &Path) -> Result<(), String> {
+    let current_path = env::var_os("PATH").unwrap_or_default();
+    let paths = std::iter::once(directory.to_path_buf()).chain(env::split_paths(&current_path));
+    let path = env::join_paths(paths)
+        .map_err(|error| format!("could not add {} to PATH: {error}", directory.display()))?;
+    command.env("PATH", path);
+    Ok(())
+}
+
+fn validate_linux_x86_64_elf(path: &Path) -> Result<(), String> {
+    let mut file = fs::File::open(path)
+        .map_err(|error| format!("failed to open worker {}: {error}", path.display()))?;
+    let mut header = [0_u8; 64];
+    file.read_exact(&mut header)
+        .map_err(|error| format!("failed to read ELF header from {}: {error}", path.display()))?;
+    validate_elf_header(&header)
+        .map_err(|error| format!("worker {} is invalid: {error}", path.display()))
+}
+
+fn validate_elf_header(header: &[u8]) -> Result<(), String> {
+    if header.len() < 64 || header.get(..4) != Some(b"\x7fELF") {
+        return Err("expected an ELF executable".to_owned());
+    }
+    if header[4] != 2 {
+        return Err(format!("expected ELF64 class, found {}", header[4]));
+    }
+    if header[5] != 1 {
+        return Err(format!(
+            "expected little-endian ELF data, found {}",
+            header[5]
+        ));
+    }
+    let object_type = u16::from_le_bytes([header[16], header[17]]);
+    if !matches!(object_type, 2 | 3) {
+        return Err(format!(
+            "expected an executable or position-independent executable, found ELF type {object_type}"
+        ));
+    }
+    let machine = u16::from_le_bytes([header[18], header[19]]);
+    if machine != 62 {
+        return Err(format!(
+            "expected x86-64 architecture, found ELF machine {machine}"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_elf_header;
+
+    fn elf_header(object_type: u16) -> [u8; 64] {
+        let mut header = [0_u8; 64];
+        header[..4].copy_from_slice(b"\x7fELF");
+        header[4] = 2;
+        header[5] = 1;
+        header[6] = 1;
+        header[16..18].copy_from_slice(&object_type.to_le_bytes());
+        header[18..20].copy_from_slice(&62_u16.to_le_bytes());
+        header
+    }
+
+    #[test]
+    fn accepts_x86_64_executable_and_static_pie_headers() {
+        assert!(validate_elf_header(&elf_header(2)).is_ok());
+        assert!(validate_elf_header(&elf_header(3)).is_ok());
+    }
+
+    #[test]
+    fn rejects_wrong_elf_format_or_architecture() {
+        let mut header = elf_header(2);
+        header[4] = 1;
+        assert!(validate_elf_header(&header).unwrap_err().contains("ELF64"));
+
+        let mut header = elf_header(2);
+        header[5] = 2;
+        assert!(
+            validate_elf_header(&header)
+                .unwrap_err()
+                .contains("little-endian")
+        );
+
+        let mut header = elf_header(2);
+        header[18..20].copy_from_slice(&183_u16.to_le_bytes());
+        assert!(validate_elf_header(&header).unwrap_err().contains("x86-64"));
+    }
+
+    #[test]
+    fn rejects_non_executable_or_truncated_input() {
+        assert!(
+            validate_elf_header(&elf_header(1))
+                .unwrap_err()
+                .contains("executable")
+        );
+        assert!(validate_elf_header(b"\x7fELF").is_err());
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,6 +6,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+mod dev_worker;
+
 fn main() {
     if let Err(error) = run() {
         eprintln!("error: {error}");
@@ -22,6 +24,22 @@ fn run() -> Result<(), String> {
             }
             pr_check()
         }
+        Some("build-dev-worker") => {
+            if args.next().is_some() {
+                return Err("usage: cargo xtask build-dev-worker".to_owned());
+            }
+            dev_worker::build().map(|_| ())
+        }
+        Some("remote-dev") => {
+            let app_args = match args.next() {
+                Some(separator) if separator == "--" => args.collect(),
+                Some(_) => {
+                    return Err("usage: cargo xtask remote-dev [-- <app args>]".to_owned());
+                }
+                None => Vec::new(),
+            };
+            dev_worker::run(&app_args)
+        }
         Some(command) => Err(format!("unknown xtask command: {command}")),
         None => Err("usage: cargo xtask <command>".to_owned()),
     }
@@ -36,7 +54,7 @@ fn pr_check() -> Result<(), String> {
     run_cargo_step(
         &repo_root,
         1,
-        5,
+        8,
         "fmt",
         &["fmt", "--all", "--check", "--quiet"],
         Warnings::Allow,
@@ -44,7 +62,7 @@ fn pr_check() -> Result<(), String> {
     run_cargo_step(
         &repo_root,
         2,
-        5,
+        8,
         "clippy",
         &[
             "clippy",
@@ -55,14 +73,38 @@ fn pr_check() -> Result<(), String> {
         ],
         Warnings::Deny,
     )?;
-    assert_worker_pure_rust(&repo_root, 3, 5)?;
-    assert_rust_file_sizes(&repo_root, 4, 5)?;
     run_cargo_step(
         &repo_root,
-        5,
-        5,
+        3,
+        8,
+        "default-feature clippy",
+        &["clippy", "--workspace", "--all-targets", "--quiet"],
+        Warnings::Deny,
+    )?;
+    assert_worker_pure_rust(&repo_root, 4, 8)?;
+    build_dev_worker_step(5, 8)?;
+    assert_rust_file_sizes(&repo_root, 6, 8)?;
+    run_cargo_step(
+        &repo_root,
+        7,
+        8,
         "test",
         &["test", "--workspace", "--all-features", "--quiet"],
+        Warnings::Allow,
+    )?;
+    run_cargo_step(
+        &repo_root,
+        8,
+        8,
+        "production worker deploy tests",
+        &[
+            "test",
+            "--package",
+            "compute-core",
+            "--lib",
+            "engines::remote::artifact",
+            "--quiet",
+        ],
         Warnings::Allow,
     )?;
 
@@ -70,6 +112,19 @@ fn pr_check() -> Result<(), String> {
         "ok PR checks passed ({})",
         format_duration(started_at.elapsed())
     );
+    Ok(())
+}
+
+fn build_dev_worker_step(index: usize, total: usize) -> Result<(), String> {
+    let started_at = Instant::now();
+    print_step(index, total, "development worker build");
+    println!();
+    let worker = dev_worker::build()?;
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    dev_worker::smoke_test_version(&worker)?;
+    #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+    let _ = worker;
+    println!("ok ({})", format_duration(started_at.elapsed()));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- add `cargo xtask remote-dev [-- <app args>]` and `cargo xtask build-dev-worker` for cross-platform current-checkout worker builds
- add the contributor-only `dev-worker` artifact source with ELF validation and `dev:<sha256>` deployment identities
- keep production deployment pinned to the exact release asset and published checksum
- verify and launch identity-qualified remote executables, publishing the stable symlink only after the version smoke test
- add cross-platform worker CI, opt-in SSH coverage, and contributor documentation

## Safety and deployment invariants

- development mode never falls back to GitHub Release artifacts and suppresses the startup release check
- production mode never inspects a local development artifact
- cache hits verify the selected identity-qualified executable before reuse
- remote jobs invoke the immutable qualified path, avoiding cross-checkout symlink races
- remote workers remain limited to x86_64 Linux and require no Rust toolchain or container runtime on the host

## Automated verification

- [x] `cargo pr-check`
- [x] warning-denied default-feature and all-feature Clippy
- [x] workspace tests and production artifact tests
- [x] worker pure-Rust dependency gate
- [x] `cargo xtask build-dev-worker` on Windows
- [x] `cargo xtask remote-dev -- --help`
- [x] ignored SSH test targets compile and skip cleanly without host configuration

## Manual acceptance required before release

- [ ] application engineer configures a real x86_64 Linux SSH host and verifies passwordless login
- [ ] remote H2 RHF/STO-3G single-point calculation converges and returns a result in the application
- [ ] direct QM local/remote parity test passes on the acceptance host
- [ ] detached remote QM and docking submission/refresh tests pass
- [ ] remote GROMACS test passes when GROMACS support is in the release scope
- [ ] deployment on the host resolves to `silicolab-compute-dev-<sha256>`
- [ ] reviewer approves this PR after inspecting the implementation and acceptance evidence

## Documentation

See `docs/developing-remote-execution.md` for prerequisites, IDE setup, artifact overrides, troubleshooting, and the exact SSH acceptance commands.