### PR TITLE
feat(qm): anchor a run's results to the structure it computed

### DIFF
--- a/compute-core/src/engines/remote/launcher.rs
+++ b/compute-core/src/engines/remote/launcher.rs
@@ -138,13 +138,14 @@ pub struct LauncherObservation {
     pub console: ConsoleChunk,
 }
 
+/// Pull a finished job's `outcome.json` (and its exit marker) into `working_dir`.
+///
+/// The console is deliberately **not** downloaded: the caller accumulates it
+/// incrementally from each poll's byte offset, and overwriting that file with the
+/// remote copy would replay bytes the caller then appends again — the final chunk
+/// of a successful run ended up in the local console twice.
 pub fn retrieve_outcome(target: &RemoteTarget, working_dir: &Path) -> Result<Vec<u8>> {
-    super::sync_down(
-        target,
-        working_dir,
-        &[OUTCOME_FILE],
-        &[CONSOLE_FILE, EXIT_FILE],
-    )?;
+    super::sync_down(target, working_dir, &[OUTCOME_FILE], &[EXIT_FILE])?;
     let path = working_dir.join(OUTCOME_FILE);
     std::fs::read(&path).with_context(|| format!("read {}", path.display()))
 }

--- a/src/backend/entries.rs
+++ b/src/backend/entries.rs
@@ -8,9 +8,18 @@ pub struct EntryGroup {
     pub name: String,
 }
 
-/// Where an entry's structure came from. Drives provenance labelling in the UI
-/// (e.g. an "MD" badge) and feature availability (trajectory playback). New
-/// provenance kinds can be added as variants without disturbing existing ones.
+/// Where an entry's structure came from — provenance, fixed when the entry is
+/// created and never rewritten afterwards. It drives the origin badge and the
+/// features a provenance implies (trajectory playback for an MD run).
+///
+/// A variant carries a path only when that path cannot be recovered from the
+/// producing task run. `MdRun` does (the trajectory's file name varies by stage)
+/// and `DockRun` does (one run yields many pose entries, but a task run records
+/// only one result entry). A QM report always lives at a fixed name inside its
+/// run directory, so `QmRun` carries nothing: the report is resolved through
+/// [`crate::backend::tasks::TaskRun::anchor_entry_id`] instead. That is also what
+/// lets a single-point energy — which produces no new entry at all — surface its
+/// report on the structure it was computed from.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum EntryOrigin {
     /// Imported or created by the user (the default for normal entries).
@@ -21,11 +30,10 @@ pub enum EntryOrigin {
     /// the task run directory (never copied into the project database) and is
     /// read on demand for playback.
     MdRun { trajectory: Option<PathBuf> },
-    /// Produced by a quantum-mechanics calculation. `output`, when present, is
-    /// the run's saved output report (e.g. `runs/qm-optimize-1/output.txt`)
-    /// *relative to the project root*; clicking the entry's "QM" badge opens it.
-    QmRun { output: Option<PathBuf> },
-    /// Produced by a molecular docking run. `poses`, when present, is the run's
+    /// Produced by a quantum-mechanics calculation (an optimization or a
+    /// transition-state search — the runs that yield a new geometry).
+    QmRun,
+    /// One pose of a molecular docking run. `poses`, when present, is the run's
     /// saved multi-pose `.pdbqt` artifact (e.g. `runs/dock-ligand-1/poses.pdbqt`)
     /// *relative to the project root*; clicking the entry's "Dock" badge opens it.
     DockRun { poses: Option<PathBuf> },
@@ -37,7 +45,7 @@ impl EntryOrigin {
         match self {
             Self::User => "user",
             Self::MdRun { .. } => "md",
-            Self::QmRun { .. } => "qm",
+            Self::QmRun => "qm",
             Self::DockRun { .. } => "dock",
         }
     }
@@ -46,14 +54,6 @@ impl EntryOrigin {
     pub fn trajectory(&self) -> Option<&Path> {
         match self {
             Self::MdRun { trajectory } => trajectory.as_deref(),
-            _ => None,
-        }
-    }
-
-    /// Project-relative QM output-report path, when this origin carries one.
-    pub fn qm_output(&self) -> Option<&Path> {
-        match self {
-            Self::QmRun { output } => output.as_deref(),
             _ => None,
         }
     }
@@ -67,14 +67,12 @@ impl EntryOrigin {
     }
 
     /// The path persisted alongside the kind in the `entries.origin_trajectory`
-    /// column: the MD trajectory, the QM output report, or the docking poses file,
-    /// depending on the kind.
+    /// column: the MD trajectory or the docking poses file, depending on the kind.
     pub fn stored_path(&self) -> Option<&Path> {
         match self {
             Self::MdRun { trajectory } => trajectory.as_deref(),
-            Self::QmRun { output } => output.as_deref(),
             Self::DockRun { poses } => poses.as_deref(),
-            Self::User => None,
+            Self::QmRun | Self::User => None,
         }
     }
 
@@ -84,10 +82,9 @@ impl EntryOrigin {
         matches!(self, Self::MdRun { .. })
     }
 
-    /// Whether this entry is the output of a QM calculation (used for the badge
-    /// and to open the saved output report).
+    /// Whether this entry's geometry was produced by a QM calculation.
     pub fn is_qm_run(&self) -> bool {
-        matches!(self, Self::QmRun { .. })
+        matches!(self, Self::QmRun)
     }
 
     /// Whether this entry is a docking pose (used for the badge and to open the
@@ -97,12 +94,13 @@ impl EntryOrigin {
     }
 
     /// Rebuild an origin from its persisted `(origin_kind, origin_trajectory)`
-    /// columns (the path column holds the trajectory for MD runs, the output
-    /// report for QM runs, and the poses file for docking runs).
+    /// columns (the path column holds the trajectory for MD runs and the poses
+    /// file for docking runs). A `qm` row written before the report path moved
+    /// into the task run directory still carries one; it is ignored.
     pub fn from_storage(kind: Option<&str>, path: Option<PathBuf>) -> Self {
         match kind {
             Some("md") => Self::MdRun { trajectory: path },
-            Some("qm") => Self::QmRun { output: path },
+            Some("qm") => Self::QmRun,
             Some("dock") => Self::DockRun { poses: path },
             _ => Self::User,
         }
@@ -313,8 +311,15 @@ impl EntryStore {
         id
     }
 
-    /// Record the provenance of an existing entry (e.g. mark it as the output of
-    /// an MD run once the run's trajectory path is known).
+    /// Record the provenance of an entry once its producing run is known (e.g.
+    /// mark it as the output of an MD run once the trajectory path is known).
+    ///
+    /// This overwrites unconditionally, so it must only ever be called on an entry
+    /// the run itself just created. Calling it on a pre-existing entry would
+    /// silently discard that entry's own provenance — and, for `MdRun`/`DockRun`,
+    /// the trajectory or poses path stored with it. To attach a *result* to an
+    /// existing structure, anchor a task run to it instead (see
+    /// [`crate::backend::tasks::TaskRun::anchor_entry_id`]).
     pub fn set_entry_origin(&mut self, entry_id: u64, origin: EntryOrigin) {
         if let Some(entry) = self.entry_mut(entry_id) {
             entry.origin = origin;
@@ -476,10 +481,11 @@ mod tests {
             EntryOrigin::MdRun {
                 trajectory: Some(PathBuf::from("runs/run-md-1/prod.xtc")),
             },
-            EntryOrigin::QmRun {
-                output: Some(PathBuf::from("runs/qm-optimize-1/output.txt")),
+            EntryOrigin::MdRun { trajectory: None },
+            EntryOrigin::QmRun,
+            EntryOrigin::DockRun {
+                poses: Some(PathBuf::from("runs/dock-ligand-1/poses.pdbqt")),
             },
-            EntryOrigin::QmRun { output: None },
         ] {
             let restored = EntryOrigin::from_storage(
                 Some(origin.kind_token()),
@@ -487,6 +493,20 @@ mod tests {
             );
             assert_eq!(restored, origin);
         }
+    }
+
+    #[test]
+    fn legacy_qm_row_drops_its_stored_report_path() {
+        // Projects written before the QM report moved into the task run directory
+        // persisted `('qm', 'runs/qm-optimize-1/output.txt')`. The path is now
+        // resolved from the run, so the stale column value must be ignored rather
+        // than resurrect a second source of truth.
+        let restored = EntryOrigin::from_storage(
+            Some("qm"),
+            Some(PathBuf::from("runs/qm-optimize-1/output.txt")),
+        );
+        assert_eq!(restored, EntryOrigin::QmRun);
+        assert_eq!(restored.stored_path(), None);
     }
 
     #[test]

--- a/src/backend/tasks.rs
+++ b/src/backend/tasks.rs
@@ -23,6 +23,21 @@ pub enum TaskKind {
     ModifyProteinPtm,
 }
 
+impl TaskKind {
+    /// Whether this task runs the QM engine, and so writes an `output.txt`
+    /// report (and, when it has a trace to plot, a `series.json`) into its run
+    /// directory.
+    pub fn is_qm(self) -> bool {
+        matches!(
+            self,
+            Self::RunQmEnergy
+                | Self::RunQmOptimize
+                | Self::RunQmFrequencies
+                | Self::RunQmTransitionState
+        )
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TaskPanelKind {
     None,
@@ -442,6 +457,15 @@ pub struct TaskRun {
 }
 
 impl TaskRun {
+    /// The entry this run's artifacts describe: the entry it produced, or — for a
+    /// run that yields no new geometry, such as a single-point energy or a
+    /// frequency calculation — the entry it was launched from. This is what makes
+    /// a report reachable from the structure it belongs to without duplicating
+    /// that structure into a second entry.
+    pub fn anchor_entry_id(&self) -> Option<u64> {
+        self.result_entry_id.or(self.source_entry_id)
+    }
+
     pub fn from_controller(id: u64, controller: TaskController) -> Self {
         Self {
             id,
@@ -520,6 +544,21 @@ impl TaskManager {
     /// reconnected through), rather than the in-memory `id` handle.
     pub fn task_run_by_uuid(&self, run_uuid: &str) -> Option<&TaskRun> {
         self.tasks.iter().find(|task| task.run_uuid == run_uuid)
+    }
+
+    /// The newest completed QM run whose artifacts belong to `entry_id` (see
+    /// [`TaskRun::anchor_entry_id`]), or `None` when the entry has no QM results.
+    /// An entry that was the input to several runs surfaces the most recent one.
+    pub fn latest_qm_run_for_entry(&self, entry_id: u64) -> Option<&TaskRun> {
+        self.tasks
+            .iter()
+            .filter(|task| {
+                task.kind.is_qm()
+                    && task.status == TaskStatus::Completed
+                    && task.run_dir.is_some()
+                    && task.anchor_entry_id() == Some(entry_id)
+            })
+            .max_by_key(|task| task.finished_at_ms.unwrap_or(task.created_at_ms))
     }
 
     pub fn mark_status(&mut self, task_run_id: u64, status: TaskStatus) {

--- a/src/frontend/actions.rs
+++ b/src/frontend/actions.rs
@@ -434,9 +434,13 @@ pub enum AppAction {
     SetTrajectoryFrame(usize),
     /// Close trajectory playback, returning the viewport to the static entry.
     StopTrajectory,
-    /// Open the saved QM output report of the given QM-produced entry in a
-    /// viewer window (triggered by clicking the entry's "QM" badge).
+    /// Open the saved QM output report belonging to the given entry in a viewer
+    /// window (triggered by clicking the entry's "QM" badge). The entry may be
+    /// the run's output, or the structure a single-point run was computed from.
     ShowQmOutput(u64),
+    /// Open the saved multi-pose `.pdbqt` of the given docking-pose entry in a
+    /// viewer window (triggered by clicking the entry's "Dock" badge).
+    ShowDockPoses(u64),
     /// Load a run's saved series data into the Plot panel and reveal it. The
     /// target is an entry (chart button on a QM-produced entry row) or a task
     /// run (completed-task panels; single-point runs produce no entry).

--- a/src/frontend/agent/loop_driver/heavy.rs
+++ b/src/frontend/agent/loop_driver/heavy.rs
@@ -325,6 +325,29 @@ fn drain_docking(state: &mut AppState, running: &RunningDockingJob) -> Option<(S
     completion
 }
 
+/// Write an agent-driven QM run's report and series into its run directory,
+/// creating the directory on demand. The agent registers its task run without an
+/// active-task binding, so the run dir is resolved by id rather than through
+/// `ensure_active_task_run_dir`.
+fn save_agent_qm_artifacts(
+    state: &mut AppState,
+    task_run_id: u64,
+    outcome: &crate::engines::qm::QmOutcome,
+) {
+    let Some(kind) = state.tasks.task_run(task_run_id).map(|task| task.kind) else {
+        return;
+    };
+    if !kind.is_qm() {
+        return;
+    }
+    match crate::frontend::dispatcher::ensure_task_run_dir(state, task_run_id, kind, None) {
+        Ok(run_dir) => crate::frontend::dispatcher::save_qm_artifacts(state, &run_dir, outcome),
+        Err(error) => state
+            .output_log
+            .push(format!("failed to create QM run directory: {error}")),
+    }
+}
+
 fn drain_qm(
     state: &mut AppState,
     running: &mut RunningQmJob,
@@ -343,19 +366,25 @@ fn drain_qm(
                     continue;
                 }
                 let outcome = *outcome;
+                // Persist the report and series into the run directory before any
+                // new entry is added, so the run anchors to the input structure —
+                // the same ordering, and the same writer, as the local and remote
+                // QM paths. Without this an agent-driven run had no artifacts at
+                // all, and so no report or chart on either surface.
+                save_agent_qm_artifacts(state, task_run_id, &outcome);
                 if let Some(optimized) = outcome.optimized_structure {
                     let save_path = default_structure_save_path(&optimized, None);
                     let entry_id = state.entries.add_entry(optimized, None, save_path);
                     state.show_entry(entry_id);
-                    state
-                        .entries
-                        .set_entry_origin(entry_id, EntryOrigin::QmRun { output: None });
+                    state.entries.set_entry_origin(entry_id, EntryOrigin::QmRun);
                     crate::frontend::dispatcher::record_task_result_entry(
                         state,
                         task_run_id,
                         entry_id,
                     );
                 }
+                state.ui.chart_availability.clear();
+                state.ui.task_chart_thumbnails.remove(&task_run_id);
                 state.set_message(outcome.summary.clone());
                 completion = Some((outcome.summary, false));
             }

--- a/src/frontend/agent/tools.rs
+++ b/src/frontend/agent/tools.rs
@@ -619,7 +619,7 @@ pub fn inspect(state: &AppState, _query: Option<&str>) -> String {
             // Provenance: mark MD-run / QM-run outputs and trajectory availability.
             if active.origin.trajectory().is_some() {
                 let _ = writeln!(out, "provenance: MD-run output (trajectory available)");
-            } else if active.origin.qm_output().is_some() {
+            } else if active.origin.is_qm_run() {
                 let _ = writeln!(out, "provenance: QM-run output (report saved)");
             }
         }

--- a/src/frontend/dispatcher/builders/qm.rs
+++ b/src/frontend/dispatcher/builders/qm.rs
@@ -99,6 +99,7 @@ pub(crate) fn start_pending_qm(state: &mut AppState) {
         // job registry and the opt-in refresh — not the in-process worker.
         Some(host) => start_remote_qm(state, job, host, prompt.prefs.job_resources()),
         None => {
+            reserve_qm_run_dir(state);
             let running = spawn_qm_job(job, Some(qm_thread_count(state, &prompt.prefs)));
             state.jobs.set_qm(running);
             if let Some(task_run_id) = state.active_task_run {
@@ -106,6 +107,27 @@ pub(crate) fn start_pending_qm(state: &mut AppState) {
             }
             state.set_message("QM calculation running; press Esc to stop".to_string());
         }
+    }
+}
+
+/// Create the active QM task's run directory up front, which also records the
+/// entry the run was launched from. A single-point energy surfaces its report on
+/// that entry, so the anchor must be taken now: resolving it when the run
+/// finishes would attach the report to whatever entry the user had activated by
+/// then. The remote path gets this for free — it stages into the run directory
+/// before submitting. Failures are logged, not fatal; the calculation still runs.
+fn reserve_qm_run_dir(state: &mut AppState) {
+    let kind = state
+        .active_task_run
+        .and_then(|task_run_id| state.tasks.task_run(task_run_id))
+        .map(|task| task.kind);
+    let Some(kind) = kind.filter(|kind| kind.is_qm()) else {
+        return;
+    };
+    if let Err(error) = ensure_active_task_run_dir(state, kind, None) {
+        state
+            .output_log
+            .push(format!("failed to create QM run directory: {error}"));
     }
 }
 

--- a/src/frontend/dispatcher/chart.rs
+++ b/src/frontend/dispatcher/chart.rs
@@ -54,18 +54,13 @@ pub(crate) fn datasets_from_series(series: &QmSeries) -> Vec<ChartSpec> {
     datasets
 }
 
-/// Resolve an entry's `series.json` (sibling of its saved QM output report,
-/// which is stored project-root-relative). `None` when the entry is not a QM
-/// run or never saved a report.
+/// Resolve an entry's `series.json` from the QM run its results belong to.
+/// `None` when the entry has no QM results — including a structure that has only
+/// ever been an input to a non-QM run.
 pub(crate) fn entry_series_path(state: &AppState, entry_id: u64) -> Option<(String, PathBuf)> {
-    let entry = state.entries.entry(entry_id)?;
-    let name = entry.name.clone();
-    let relative = entry.origin.qm_output()?.parent()?.join(SERIES_FILE);
-    let absolute = match state.workspace.project() {
-        Some(project) => project.root.join(&relative),
-        None => relative,
-    };
-    Some((name, absolute))
+    let name = state.entries.entry(entry_id)?.name.clone();
+    let run_dir = super::entry_qm_run_dir(state, entry_id)?;
+    Some((name, run_dir.join(SERIES_FILE)))
 }
 
 fn task_series_path(state: &AppState, task_run_id: u64) -> Option<(String, PathBuf)> {

--- a/src/frontend/dispatcher/jobs.rs
+++ b/src/frontend/dispatcher/jobs.rs
@@ -142,25 +142,70 @@ pub(crate) fn set_md_run_origin(state: &mut AppState, entry_id: u64, trajectory:
 /// File name of the saved QM output report inside a QM task's run directory.
 pub(crate) const QM_OUTPUT_FILE: &str = "output.txt";
 
-/// Mark an entry as the output of a QM run. Like [`set_md_run_origin`], the
-/// report path is stored relative to the project root so it survives the
-/// project being moved; the badge tracks the origin, not the path, so the
-/// entry is marked even when saving the report failed.
-pub(crate) fn set_qm_run_origin(state: &mut AppState, entry_id: u64, output: Option<PathBuf>) {
-    let project_root = state
-        .workspace
-        .project()
-        .map(|project| project.root.clone());
-    let output = output.map(|path| match project_root.as_deref() {
-        Some(root) => path
-            .strip_prefix(root)
-            .map(Path::to_path_buf)
-            .unwrap_or(path),
-        None => path,
-    });
+/// Write a finished QM calculation's report and chart series into its task run
+/// directory. Every QM path — local, detached-remote, agent-driven — goes through
+/// here, so a run's results are discoverable the same way however it was launched.
+/// Failures are logged, never fatal: the calculation itself succeeded.
+pub(crate) fn save_qm_artifacts(
+    state: &mut AppState,
+    run_dir: &Path,
+    outcome: &crate::engines::qm::QmOutcome,
+) {
+    if let Err(error) = std::fs::create_dir_all(run_dir) {
+        state
+            .output_log
+            .push(format!("failed to create QM run directory: {error}"));
+        return;
+    }
+
+    let path = run_dir.join(QM_OUTPUT_FILE);
+    let mut text = outcome.summary.clone();
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
+    match std::fs::write(&path, text) {
+        Ok(()) => state
+            .output_log
+            .push(format!("QM output saved to {}", path.display())),
+        Err(error) => state
+            .output_log
+            .push(format!("failed to save QM output: {error}")),
+    }
+
+    let series = crate::backend::runs::QmSeries::from_outcome(outcome);
+    if series.is_empty() {
+        return;
+    }
+    match crate::backend::runs::save_qm_series_file(run_dir, &series) {
+        Ok(path) => state
+            .output_log
+            .push(format!("QM series saved to {}", path.display())),
+        Err(error) => state
+            .output_log
+            .push(format!("failed to save QM series: {error}")),
+    }
+}
+
+/// Mark an entry as the output of a QM run (the provenance badge). The report
+/// itself is found through the run, so nothing is stored on the entry and a run
+/// whose report failed to save is still marked.
+pub(crate) fn set_qm_run_origin(state: &mut AppState, entry_id: u64) {
+    state.entries.set_entry_origin(entry_id, EntryOrigin::QmRun);
+}
+
+/// The run directory of the newest completed QM run whose results belong to
+/// `entry_id` — the run that produced this geometry, or, when the run produced no
+/// geometry at all (a single-point energy, a frequency calculation), the run this
+/// structure was the input to. `None` when the entry has no QM results.
+///
+/// This is the one place the entry → QM artifact link is resolved; the report,
+/// the chart series, and the badge all go through it.
+pub(crate) fn entry_qm_run_dir(state: &AppState, entry_id: u64) -> Option<PathBuf> {
     state
-        .entries
-        .set_entry_origin(entry_id, EntryOrigin::QmRun { output });
+        .tasks
+        .latest_qm_run_for_entry(entry_id)?
+        .run_dir
+        .clone()
 }
 
 /// Open the saved QM output report of `entry_id` in the shared text viewer.
@@ -172,8 +217,34 @@ pub(crate) fn show_qm_output(state: &mut AppState, entry_id: u64) {
         return;
     };
     let entry_name = entry.name.clone();
-    let Some(relative) = entry.origin.qm_output().map(Path::to_path_buf) else {
+    let Some(path) = entry_qm_run_dir(state, entry_id).map(|dir| dir.join(QM_OUTPUT_FILE)) else {
         state.set_message("This entry has no saved QM output".to_string());
+        return;
+    };
+    match std::fs::read_to_string(&path) {
+        Ok(text) => {
+            state.ui.text_viewer = Some(crate::frontend::state::TextViewer {
+                title: format!("QM Output — {entry_name}"),
+                text,
+            });
+        }
+        Err(error) => state.set_message(format!(
+            "Could not read QM output {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+/// Open the saved multi-pose `.pdbqt` of a docking pose entry in the shared text
+/// viewer. Unlike a QM report, the poses file is named on the entry: one docking
+/// run yields many pose entries, and a task run records only one of them.
+pub(crate) fn show_dock_poses(state: &mut AppState, entry_id: u64) {
+    let Some(entry) = state.entries.entry(entry_id) else {
+        return;
+    };
+    let entry_name = entry.name.clone();
+    let Some(relative) = entry.origin.dock_poses().map(Path::to_path_buf) else {
+        state.set_message("This entry has no saved docking poses".to_string());
         return;
     };
     // Stored relative to the project root (absolute when the run directory
@@ -185,12 +256,12 @@ pub(crate) fn show_qm_output(state: &mut AppState, entry_id: u64) {
     match std::fs::read_to_string(&absolute) {
         Ok(text) => {
             state.ui.text_viewer = Some(crate::frontend::state::TextViewer {
-                title: format!("QM Output — {entry_name}"),
+                title: format!("Docking Poses — {entry_name}"),
                 text,
             });
         }
         Err(error) => state.set_message(format!(
-            "Could not read QM output {}: {error}",
+            "Could not read docking poses {}: {error}",
             absolute.display()
         )),
     }

--- a/src/frontend/dispatcher/jobs/compute.rs
+++ b/src/frontend/dispatcher/jobs/compute.rs
@@ -1,91 +1,23 @@
 use super::super::*;
 
-/// Persist a finished QM calculation's output report to the active task's run
-/// directory (creating it on demand) and return the written path. Failures are
-/// logged to the Output tab and reported as `None` — they never abort result
-/// handling, since the in-memory output log already holds the report.
-fn save_qm_output(state: &mut AppState, summary: &str) -> Option<PathBuf> {
-    let task_run_id = state.active_task_run?;
-    let kind = state.tasks.task_run(task_run_id)?.kind;
-    if !matches!(
-        kind,
-        TaskKind::RunQmEnergy
-            | TaskKind::RunQmOptimize
-            | TaskKind::RunQmFrequencies
-            | TaskKind::RunQmTransitionState
-    ) {
-        return None;
-    }
-    let run_dir = match ensure_active_task_run_dir(state, kind, None) {
-        Ok(run_dir) => run_dir,
-        Err(error) => {
-            state
-                .output_log
-                .push(format!("failed to create QM run directory: {error}"));
-            return None;
-        }
-    };
-    let path = run_dir.join(QM_OUTPUT_FILE);
-    let mut text = summary.to_string();
-    if !text.ends_with('\n') {
-        text.push('\n');
-    }
-    match std::fs::write(&path, text) {
-        Ok(()) => {
-            state
-                .output_log
-                .push(format!("QM output saved to {}", path.display()));
-            Some(path)
-        }
-        Err(error) => {
-            state
-                .output_log
-                .push(format!("failed to save QM output: {error}"));
-            None
-        }
-    }
-}
-
-/// Persist the machine-readable series data beside the output report so charts
-/// can be rebuilt after restart. Mirrors [`save_qm_output`]: failures are
-/// logged to the Output tab and swallowed. Outcomes with no plottable data
-/// (pre-trace workers) write nothing.
-pub(crate) fn save_qm_series(state: &mut AppState, outcome: &crate::engines::qm::QmOutcome) {
-    let series = crate::backend::runs::QmSeries::from_outcome(outcome);
-    if series.is_empty() {
-        return;
-    }
+/// Persist a locally-run QM calculation's artifacts into the active task's run
+/// directory, creating it on demand. A no-op when there is no active QM task run
+/// to anchor them to.
+pub(crate) fn save_qm_run_artifacts(state: &mut AppState, outcome: &crate::engines::qm::QmOutcome) {
     let Some(task_run_id) = state.active_task_run else {
         return;
     };
     let Some(kind) = state.tasks.task_run(task_run_id).map(|task| task.kind) else {
         return;
     };
-    if !matches!(
-        kind,
-        TaskKind::RunQmEnergy
-            | TaskKind::RunQmOptimize
-            | TaskKind::RunQmFrequencies
-            | TaskKind::RunQmTransitionState
-    ) {
+    if !kind.is_qm() {
         return;
     }
-    let run_dir = match ensure_active_task_run_dir(state, kind, None) {
-        Ok(run_dir) => run_dir,
-        Err(error) => {
-            state
-                .output_log
-                .push(format!("failed to create QM run directory: {error}"));
-            return;
-        }
-    };
-    match crate::backend::runs::save_qm_series_file(&run_dir, &series) {
-        Ok(path) => state
-            .output_log
-            .push(format!("QM series saved to {}", path.display())),
+    match ensure_active_task_run_dir(state, kind, None) {
+        Ok(run_dir) => save_qm_artifacts(state, &run_dir, outcome),
         Err(error) => state
             .output_log
-            .push(format!("failed to save QM series: {error}")),
+            .push(format!("failed to create QM run directory: {error}")),
     }
     state.ui.task_chart_thumbnails.remove(&task_run_id);
 }
@@ -302,8 +234,7 @@ pub(crate) fn poll_qm_job(state: &mut AppState, ctx: &egui::Context) {
                 // Persist the raw report to the task's run directory before any
                 // new entry is added, so the run's source entry is the input
                 // structure, not the optimized result.
-                let output_path = save_qm_output(state, &outcome.summary);
-                save_qm_series(state, &outcome);
+                save_qm_run_artifacts(state, &outcome);
                 // A QM run is a heavy calculation; its optimized geometry is
                 // surfaced as a new entry (the original structure is preserved),
                 // matching the convention for entry-producing tasks.
@@ -313,10 +244,14 @@ pub(crate) fn poll_qm_job(state: &mut AppState, ctx: &egui::Context) {
                     if let Some(task_run_id) = task_run_id {
                         record_task_result_entry(state, task_run_id, entry_id);
                     }
-                    set_qm_run_origin(state, entry_id, output_path);
-                    state.ui.chart_availability.remove(&entry_id);
+                    set_qm_run_origin(state, entry_id);
                     changed = true;
                 }
+                // The run just became the newest QM result of whichever entry it
+                // anchors to — the new geometry, or the input structure when there
+                // is none. Either way the memoized per-entry chart availability is
+                // now stale.
+                state.ui.chart_availability.clear();
                 state.set_message(format!(
                     "QM complete: energy {:.6} Eh{}",
                     outcome.energy_hartree,

--- a/src/frontend/dispatcher/jobs/tests.rs
+++ b/src/frontend/dispatcher/jobs/tests.rs
@@ -157,7 +157,7 @@ fn esc_still_requests_qm_cancel_with_stage_boundary_message() {
 }
 
 #[test]
-fn save_qm_series_writes_next_to_the_run_output() {
+fn save_qm_run_artifacts_writes_report_and_series_into_the_run_dir() {
     use crate::backend::runs::{SERIES_FILE, load_qm_series_file};
     use crate::backend::tasks::task_controller_by_id;
 
@@ -175,7 +175,7 @@ fn save_qm_series_writes_next_to_the_run_output() {
         opt_trace: Vec::new(),
         frequencies: Vec::new(),
     };
-    save_qm_series(&mut state, &outcome);
+    save_qm_run_artifacts(&mut state, &outcome);
 
     let run_dir = state
         .tasks
@@ -184,8 +184,11 @@ fn save_qm_series_writes_next_to_the_run_output() {
         .expect("run dir created on demand");
     let series = load_qm_series_file(&run_dir.join(SERIES_FILE)).expect("series saved");
     assert_eq!(series.scf_trace, vec![-74.1, -74.96]);
+    let report = std::fs::read_to_string(run_dir.join(QM_OUTPUT_FILE)).expect("report saved");
+    assert!(report.starts_with("E = -74.96 Eh"));
 
-    // An all-empty outcome (e.g. from a pre-trace remote worker) writes nothing.
+    // An outcome with no plottable trace (e.g. a frequency-only run) still writes
+    // its report, but no series file for a chart that would have no data.
     let controller = *task_controller_by_id("qm-energy").unwrap();
     let empty_task = state.tasks.create_task_run(controller);
     state.active_task_run = Some(empty_task);
@@ -195,12 +198,141 @@ fn save_qm_series_writes_next_to_the_run_output() {
         frequencies: Vec::new(),
         ..outcome
     };
-    save_qm_series(&mut state, &empty);
+    save_qm_run_artifacts(&mut state, &empty);
     let empty_dir = state
         .tasks
         .task_run(empty_task)
-        .and_then(|task| task.run_dir.clone());
-    assert!(empty_dir.is_none_or(|dir| !dir.join(SERIES_FILE).exists()));
+        .and_then(|task| task.run_dir.clone())
+        .expect("run dir created on demand");
+    assert!(empty_dir.join(QM_OUTPUT_FILE).is_file());
+    assert!(!empty_dir.join(SERIES_FILE).exists());
+}
+
+/// Reproduces the shape of a real single-point run as it is persisted: a
+/// completed `qm-energy` task run whose `source_entry_id` is the input structure
+/// and whose run directory holds the report and the series. Both entry-list chips
+/// and the report viewer must resolve through it.
+#[test]
+fn single_point_entry_surfaces_its_report_and_chart() {
+    use crate::backend::runs::{QmSeries, save_qm_series_file};
+    use crate::backend::tasks::{TaskStatus, task_controller_by_id};
+
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    let entry_id = state
+        .entries
+        .add_entry(crate::domain::Structure::empty(), None, PathBuf::new());
+
+    // A structure nothing has been computed on carries no QM chip.
+    assert!(entry_qm_run_dir(&state, entry_id).is_none());
+    assert!(!entry_chart_available(&mut state, entry_id));
+
+    let run_dir = std::env::temp_dir().join("silicolab-single-point-surface");
+    std::fs::create_dir_all(&run_dir).unwrap();
+    std::fs::write(run_dir.join(QM_OUTPUT_FILE), "total energy: -232.337 Eh\n").unwrap();
+    let outcome = crate::engines::qm::QmOutcome {
+        energy_hartree: -232.337,
+        converged: true,
+        optimized_structure: None,
+        summary: "total energy: -232.337 Eh".to_string(),
+        scf_trace: vec![-233.6, -232.337],
+        opt_trace: Vec::new(),
+        frequencies: Vec::new(),
+    };
+    save_qm_series_file(&run_dir, &QmSeries::from_outcome(&outcome)).unwrap();
+
+    let controller = *task_controller_by_id("qm-energy").expect("qm-energy controller");
+    let task_id = state.tasks.create_task_run(controller);
+    state.tasks.set_source_entry_id(task_id, Some(entry_id));
+    state.tasks.set_run_dir(task_id, run_dir.clone());
+    state.tasks.mark_status(task_id, TaskStatus::Completed);
+
+    // `entry_chart_available` memoizes per entry, and the entry was rendered as
+    // chartless before this run existed. Completing a QM run therefore has to
+    // invalidate that memo — every QM completion handler does exactly this, and
+    // omitting it leaves the finished run's chart chip permanently hidden.
+    assert!(
+        !entry_chart_available(&mut state, entry_id),
+        "a stale memo must survive until it is explicitly cleared"
+    );
+    state.ui.chart_availability.clear();
+
+    assert_eq!(
+        entry_qm_run_dir(&state, entry_id).as_deref(),
+        Some(&*run_dir)
+    );
+    assert!(
+        entry_chart_available(&mut state, entry_id),
+        "the input structure's chart chip must find the run's series.json"
+    );
+
+    show_qm_output(&mut state, entry_id);
+    let viewer = state.ui.text_viewer.as_ref().expect("report opened");
+    assert!(viewer.text.contains("-232.337 Eh"));
+
+    let _ = std::fs::remove_dir_all(&run_dir);
+}
+
+#[test]
+fn single_point_run_anchors_its_report_to_the_input_entry() {
+    use crate::backend::tasks::{TaskStatus, task_controller_by_id};
+
+    // The regression this whole path exists for: a single-point energy produces no
+    // new entry, so its results must be reachable from the structure it was
+    // computed from rather than being stranded in the run directory.
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    let entry_id = state
+        .entries
+        .add_entry(crate::domain::Structure::empty(), None, PathBuf::new());
+
+    let controller = *task_controller_by_id("qm-energy").expect("qm-energy controller");
+    let task_id = state.tasks.create_task_run(controller);
+    state.tasks.set_source_entry_id(task_id, Some(entry_id));
+    state
+        .tasks
+        .set_run_dir(task_id, std::env::temp_dir().join("silicolab-anchor-test"));
+
+    // Only a *completed* run surfaces results.
+    assert!(state.tasks.latest_qm_run_for_entry(entry_id).is_none());
+    state.tasks.mark_status(task_id, TaskStatus::Completed);
+    assert_eq!(
+        state
+            .tasks
+            .latest_qm_run_for_entry(entry_id)
+            .map(|task| task.id),
+        Some(task_id)
+    );
+
+    // An optimization anchors to the geometry it produced, not to its input, so
+    // the input structure is not claimed by a run whose result lives elsewhere.
+    let optimize = *task_controller_by_id("qm-optimize").expect("qm-optimize controller");
+    let opt_task = state.tasks.create_task_run(optimize);
+    let result_id =
+        state
+            .entries
+            .add_entry(crate::domain::Structure::empty(), None, PathBuf::new());
+    state.tasks.set_source_entry_id(opt_task, Some(entry_id));
+    state.tasks.set_result_entry_id(opt_task, Some(result_id));
+    state.tasks.set_run_dir(
+        opt_task,
+        std::env::temp_dir().join("silicolab-anchor-test-2"),
+    );
+    state.tasks.mark_status(opt_task, TaskStatus::Completed);
+
+    assert_eq!(
+        state
+            .tasks
+            .latest_qm_run_for_entry(result_id)
+            .map(|task| task.id),
+        Some(opt_task)
+    );
+    assert_eq!(
+        state
+            .tasks
+            .latest_qm_run_for_entry(entry_id)
+            .map(|task| task.id),
+        Some(task_id),
+        "the optimize run must not steal its input entry's single-point result"
+    );
 }
 
 #[test]

--- a/src/frontend/dispatcher/mod.rs
+++ b/src/frontend/dispatcher/mod.rs
@@ -428,6 +428,7 @@ pub fn dispatch(state: &mut AppState, action: AppAction, ctx: &egui::Context) {
         AppAction::SetTrajectoryFrame(frame) => set_trajectory_frame(state, frame),
         AppAction::StopTrajectory => stop_trajectory(state),
         AppAction::ShowQmOutput(entry_id) => show_qm_output(state, entry_id),
+        AppAction::ShowDockPoses(entry_id) => show_dock_poses(state, entry_id),
         AppAction::OpenChart(target) => open_chart(state, target, ctx),
         AppAction::SelectChartDataset(index) => select_chart_dataset(state, index),
         AppAction::SetChartAxisLabel { axis, label } => set_chart_axis_label(state, axis, label),

--- a/src/frontend/dispatcher/remote_jobs.rs
+++ b/src/frontend/dispatcher/remote_jobs.rs
@@ -439,22 +439,7 @@ fn apply_remote_qm_outcome(
         state.output_log.push(line.to_string());
     }
     let run_dir = PathBuf::from(&row.local_run_dir);
-    let _ = std::fs::create_dir_all(&run_dir);
-    let mut text = outcome.summary.clone();
-    if !text.ends_with('\n') {
-        text.push('\n');
-    }
-    let output_path = std::fs::write(run_dir.join(QM_OUTPUT_FILE), text)
-        .ok()
-        .map(|()| run_dir.join(QM_OUTPUT_FILE));
-    let series = crate::backend::runs::QmSeries::from_outcome(&outcome);
-    if !series.is_empty()
-        && let Err(error) = crate::backend::runs::save_qm_series_file(&run_dir, &series)
-    {
-        state
-            .output_log
-            .push(format!("failed to save QM series: {error}"));
-    }
+    save_qm_artifacts(state, &run_dir, &outcome);
 
     let belongs_here = outcome_belongs_to_current_workspace(state, row);
     let task_id = state
@@ -468,9 +453,12 @@ fn apply_remote_qm_outcome(
         if let Some(task_id) = task_id {
             record_task_result_entry(state, task_id, entry_id);
         }
-        set_qm_run_origin(state, entry_id, output_path);
-        state.ui.chart_availability.remove(&entry_id);
+        set_qm_run_origin(state, entry_id);
     }
+    // The run is now the newest QM result of whichever entry it anchors to, so
+    // the memoized per-entry chart availability is stale — including for a
+    // single-point energy, whose result lands on its input structure.
+    state.ui.chart_availability.clear();
     if let Some(task_id) = task_id {
         mark_task_status(state, task_id, TaskStatus::Completed);
         state.ui.task_chart_thumbnails.remove(&task_id);

--- a/src/frontend/dispatcher/tasks.rs
+++ b/src/frontend/dispatcher/tasks.rs
@@ -106,6 +106,19 @@ pub(crate) fn ensure_active_task_run_dir(
     let task_run_id = state
         .active_task_run
         .ok_or_else(|| anyhow!("no active task run"))?;
+    ensure_task_run_dir(state, task_run_id, kind, desired_name)
+}
+
+/// Create (once) the run directory of a specific task run and record the entry it
+/// was launched from. Both are written only on first creation, so the run stays
+/// anchored to the structure that was actually computed even if the user
+/// activates a different entry while it is still running.
+pub(crate) fn ensure_task_run_dir(
+    state: &mut AppState,
+    task_run_id: u64,
+    kind: TaskKind,
+    desired_name: Option<&str>,
+) -> anyhow::Result<PathBuf> {
     let task = state
         .tasks
         .task_run(task_run_id)

--- a/src/frontend/ui/entry_item.rs
+++ b/src/frontend/ui/entry_item.rs
@@ -68,22 +68,42 @@ pub(crate) fn render_entry_list_item(
 
         let text_rect = rect.shrink2(egui::vec2(6.0, 0.0));
 
-        // A small chip marks entries produced by a run ("MD" or "QM"). Lay
-        // them out first so the name reserves room. The QM chip is clickable
-        // (opens the saved output report); QM runs with saved series data get
-        // a second, chart chip.
-        let chip_label = state.entries.entry(entry_id).and_then(|entry| {
-            if entry.origin.is_md_run() {
-                Some("MD")
-            } else if entry.origin.is_qm_run() {
-                Some("QM")
-            } else {
-                None
-            }
-        });
-        let is_qm = chip_label == Some("QM");
+        // A chip marks an entry a run has results for; lay it out first so the name
+        // reserves room. "MD" and "Dock" are provenance — the entry *is* that run's
+        // output. "QM" is resolved from the task run, so a single-point energy,
+        // which produces no entry of its own, still marks the structure it was
+        // computed from. Provenance wins the one chip slot; a QM report on an MD or
+        // docking entry stays reachable through the context menu.
+        let has_qm_run = crate::frontend::dispatcher::entry_qm_run_dir(state, entry_id).is_some();
+        let chip_label = state
+            .entries
+            .entry(entry_id)
+            .and_then(|entry| {
+                if entry.origin.is_md_run() {
+                    Some("MD")
+                } else if entry.origin.is_dock_run() {
+                    Some("Dock")
+                } else {
+                    None
+                }
+            })
+            .or(has_qm_run.then_some("QM"));
+        // The chip doubles as a button opening the run's saved artifact.
+        let chip_action = match chip_label {
+            Some("QM") => Some((
+                "qm-output-chip",
+                "View QM output",
+                AppAction::ShowQmOutput(entry_id),
+            )),
+            Some("Dock") => Some((
+                "dock-poses-chip",
+                "View docking poses",
+                AppAction::ShowDockPoses(entry_id),
+            )),
+            _ => None,
+        };
         let chart_available =
-            is_qm && crate::frontend::dispatcher::entry_chart_available(state, entry_id);
+            has_qm_run && crate::frontend::dispatcher::entry_chart_available(state, entry_id);
         let layout_chip = |ui: &egui::Ui, label: &str| {
             let galley = ui.painter().fonts_mut(|fonts| {
                 fonts.layout_no_wrap(
@@ -144,18 +164,13 @@ pub(crate) fn render_entry_list_item(
             );
             ui.painter().galley(chip_pos, chip_galley, pal.accent);
 
-            // The QM chip doubles as a button: it opens the run's saved output
-            // report. Registered after the row, so it wins the overlap.
-            if is_qm {
+            // Registered after the row, so the chip wins the overlap.
+            if let Some((id_salt, hover, action)) = chip_action {
                 let chip_response = ui
-                    .interact(
-                        chip_rect,
-                        ui.id().with(("qm-output-chip", entry_id)),
-                        Sense::click(),
-                    )
-                    .on_hover_text("View QM output");
+                    .interact(chip_rect, ui.id().with((id_salt, entry_id)), Sense::click())
+                    .on_hover_text(hover);
                 if chip_response.clicked() {
-                    actions.push(AppAction::ShowQmOutput(entry_id));
+                    actions.push(action);
                 }
             }
         }
@@ -255,6 +270,11 @@ pub(crate) fn render_entry_list_item(
             .cloned()
             .collect();
         response.context_menu(|ui| {
+            // Reaches the report when the chip slot went to provenance instead.
+            if has_qm_run && ui.button("View QM output").clicked() {
+                actions.push(AppAction::ShowQmOutput(entry_id));
+                ui.close();
+            }
             if ui.button("Rename").clicked() {
                 state.ui.entry_list.renaming_entry_id = Some(entry_id);
                 state.ui.entry_list.rename_buffer = name.to_string();


### PR DESCRIPTION
## Problem

A single-point energy produces no new geometry, so it created no entry — and with the report path living on `EntryOrigin::QmRun { output }`, an entry was the only place a QM result could be attached. The report, the SCF chart, and the badge were therefore unreachable from the workspace: they existed only as files in the run directory, and the run appeared to return nothing.

## Approach

Split provenance from artifacts. `EntryOrigin` goes back to meaning only "how this entry came to be", fixed at creation; `QmRun` loses its payload. A run's results resolve instead through `TaskRun::anchor_entry_id` — `result_entry_id.or(source_entry_id)` — so an optimization anchors to the geometry it produced and a single point anchors to the structure it was computed from. `task_runs` already recorded both links; nothing new is persisted.

`MdRun` and `DockRun` keep their payloads. Neither is derivable from the run: a trajectory's file name varies by stage, and one docking run yields many pose entries while a task run records a single result entry.

`entry_qm_run_dir` becomes the one place the entry → QM artifact link is resolved, behind the badge, the chart chip, and the report viewer. Provenance still wins the single chip slot, so an MD frame or docking pose later handed to a QM calculation reaches its report through the context menu. The Dock badge its doc comment had promised for three releases now exists.

## Defects fixed along the way

- The local QM path first created its run directory at completion, so `source_entry_id` recorded whichever entry was active by then rather than the one submitted. It now reserves the directory at launch, as the remote path always has.
- `entry_chart_available` memoizes per entry, so a finished run's chart chip stayed hidden behind the `false` cached while it was still running. Every QM completion handler now clears that memo.
- The agent path wrote neither `output.txt` nor `series.json`, so an agent-driven QM run could never show a report or a chart on either surface. The three copies of the artifact writer are folded into `save_qm_artifacts`, which the agent path now uses too. The remote path also swallowed its write error and never logged where the report went.
- `retrieve_outcome` downloaded `run.console`, but the caller accumulates the console incrementally from each poll's byte offset — overwriting it with the remote copy replayed bytes that were then appended again, duplicating the final chunk of every successful run.

## Compatibility

Old `('qm', <path>)` rows keep loading; the stale report path is ignored rather than left as a second source of truth.

## Testing

Manually exercised locally: single-point and optimization runs, local and remote, report/chart/badge reachable from the workspace in each case.