### PR TITLE
fix(process): suppress the console window spawned engines pop up on Windows

### DIFF
--- a/compute-core/src/engines/process.rs
+++ b/compute-core/src/engines/process.rs
@@ -188,6 +188,8 @@ pub fn spawn_with_cancel(config: ProcessConfig, cancel: Arc<AtomicBool>) -> Resu
         command.env(key, value);
     }
 
+    suppress_console(&mut command);
+
     let mut child = command.spawn().with_context(|| {
         format!(
             "failed to spawn {} in {}",
@@ -292,6 +294,23 @@ pub fn spawn_with_cancel(config: ProcessConfig, cancel: Arc<AtomicBool>) -> Resu
 pub fn run(config: ProcessConfig) -> Result<ProcessResult> {
     spawn(config)?.join()
 }
+
+/// A GUI-subsystem process has no console, so Windows allocates a fresh console
+/// *window* for every console-subsystem child it spawns (`wsl.exe`, `ssh.exe`,
+/// `gmx.exe`). This layer always pipes the child's stdio, so that window can
+/// never carry anything: suppressing it is a property of the layer, not a knob.
+///
+/// `creation_flags` overwrites the flag word rather than OR-ing into it; any
+/// future flag must be folded in here rather than set at a second call site.
+#[cfg(windows)]
+fn suppress_console(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    command.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(windows))]
+fn suppress_console(_command: &mut Command) {}
 
 #[derive(Debug, Clone, Copy)]
 enum StreamKind {

--- a/compute-core/tests/subprocess_spawn_guard.rs
+++ b/compute-core/tests/subprocess_spawn_guard.rs
@@ -1,0 +1,55 @@
+//! Every external process in `compute-core` must be spawned through
+//! `engines::process`, which suppresses the console window Windows pops up for a
+//! console-subsystem child of a GUI process. A stray `Command::new` bypasses that
+//! and reintroduces the flicker — invisibly, since the app crate is
+//! `windows_subsystem = "windows"` only on Windows and CI runs headless Linux.
+
+use std::path::Path;
+
+/// The only sanctioned `Command::new` outside `engines/process.rs`: a call that
+/// launches our own executable, which is GUI-subsystem and never gets a console.
+const SELF_LAUNCHING: &[&str] = &["wire.rs", "io/self_update.rs"];
+
+#[test]
+fn subprocesses_are_spawned_only_through_engines_process() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders = Vec::new();
+
+    visit_rust_files(&src, &mut |path| {
+        let relative = path
+            .strip_prefix(&src)
+            .expect("walked path is under src")
+            .to_string_lossy()
+            .replace('\\', "/");
+        if relative == "engines/process.rs" || SELF_LAUNCHING.contains(&relative.as_str()) {
+            return;
+        }
+        let text = std::fs::read_to_string(path).expect("read source file");
+        for (index, line) in text.lines().enumerate() {
+            if line.contains("Command::new") {
+                offenders.push(format!("{relative}:{}", index + 1));
+            }
+        }
+    });
+
+    assert!(
+        offenders.is_empty(),
+        "`Command::new` outside `engines::process`:\n  {}\n\n\
+         Build a `ProcessConfig` and call `engines::process::run`/`spawn` instead. \
+         Spawning a console program directly from the GUI pops up a console window \
+         on Windows. If the call launches our own executable, add it to \
+         `SELF_LAUNCHING` in this test.",
+        offenders.join("\n  ")
+    );
+}
+
+fn visit_rust_files(dir: &Path, visitor: &mut dyn FnMut(&Path)) {
+    for entry in std::fs::read_dir(dir).expect("read source directory") {
+        let path = entry.expect("read directory entry").path();
+        if path.is_dir() {
+            visit_rust_files(&path, visitor);
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+            visitor(&path);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

On Windows, running a compute job or polling remote hardware flashes a console
window that disappears a moment later. Remote GPU monitoring samples over `ssh`
every 30 seconds, so the flicker repeats for as long as the panel is open.

The app crate is `windows_subsystem = "windows"` (`src/main.rs:3`) and therefore
has no console of its own. Windows gives every console-subsystem child of such a
process a brand-new console window, regardless of the parent redirecting the
child's stdout and stderr into pipes. `CREATE_NO_WINDOW` appeared nowhere in the
tree, so every external command paid the cost.

## Fix

Every engine, remote, and probe subprocess already funnels through the one
`command.spawn()` in `compute-core::engines::process`, so the flag is set there
and nowhere else.

It is set unconditionally rather than behind a `ProcessConfig` option. This layer
pipes the child's stdio on every path and never inherits it, so a console window
attached to one of its children can never carry input or output. That makes "no
console" a property of the layer, and a knob with zero callers would only open a
second path through it.

## Keeping it fixed

A stray `Command::new` elsewhere would silently bring the flicker back: the
`#[cfg(windows)]` arm never compiles in CI, which runs headless Linux, and a
developer on macOS or Linux would never see the window. `tests/subprocess_spawn_guard.rs`
fails on any `Command::new` in `compute-core` outside `engines/process.rs`.

The allowlist holds two entries, `wire.rs` and `io/self_update.rs`, which
collapse into one rule rather than two special cases: the only sanctioned direct
spawn is one that launches our own executable, which is GUI-subsystem and so
never gets a console either way.

Beyond this bug, the guard promotes "all external processes go through
`engines::process`" from an invariant that currently holds by coincidence to one
the build enforces.

## Verification

`cargo pr-check` passes all eight gates, including the linux-musl worker build
that exercises the non-Windows arm. The guard was checked against an injected
`Command::new` and correctly failed with the offending file and line, ruling out
a vacuous scan.

The absence of the window itself cannot be asserted from a test: a test binary is
a console process, so its children never pop a window either way.
