### PR TITLE
fix(md): support dry biomolecule GPU runs

### DIFF
--- a/compute-core/src/engines/gromacs/realize.rs
+++ b/compute-core/src/engines/gromacs/realize.rs
@@ -387,6 +387,28 @@ mod tests {
         }
     }
 
+    #[test]
+    fn dry_biomolecular_preset_renders_only_the_system_coupling_group() {
+        let mut ctx = amber_protein_context();
+        ctx.water_token = None;
+        let eff = ctx.with_overrides(SystemTypeOverrides::default());
+        let stages = PresetId::StandardBiomolecule.build(&eff, &PresetParams::default());
+        let specs = stage_specs_from_md_stages(&stages, ForceFieldFamily::Amber, None);
+
+        for spec in specs
+            .iter()
+            .filter(|spec| !spec.settings.integrator.is_minimization())
+        {
+            let mdp = render_mdp(&spec.settings);
+            assert!(
+                mdp.contains("tc-grps                  = System"),
+                "dry stage '{}' must couple the whole system, got:\n{mdp}",
+                spec.stage_name
+            );
+            assert!(!mdp.contains("Non-Protein"));
+        }
+    }
+
     /// The legacy path is preserved: a non-biomolecular (framework / generic)
     /// system still realizes to plain cut-off, never PME. PME is a new path, not a
     /// rewrite of the old one.

--- a/compute-core/src/engines/gromacs/runner.rs
+++ b/compute-core/src/engines/gromacs/runner.rs
@@ -301,7 +301,12 @@ where
     let mdrun = run_subprocess(
         request.compute.launch.to_process_config(
             working_dir.clone(),
-            mdrun_args(&stage, &out_name, request.compute.resources),
+            mdrun_args(
+                &stage,
+                &out_name,
+                request.compute.resources,
+                request.settings.integrator,
+            ),
             Some(remaining),
         ),
         Arc::clone(&cancel),
@@ -397,12 +402,16 @@ where
 /// Assemble the `gmx mdrun` argument vector from the requested resources. With no
 /// explicit request (`cores`/`gpu` both 0) it emits only the I/O flags and lets gmx
 /// pick its own thread/GPU defaults (its all-cores, auto-GPU behaviour). A GPU
-/// request offloads the nonbonded, PME, bonded, and update work and runs one
-/// thread-MPI rank per GPU — adding a dedicated PME rank once there is more than
-/// one (GPU PME requires `-npme 1`) and letting gmx map ranks to the available
-/// GPUs. A CPU-only core request maps to `-nt`; under a GPU rank cores map to
-/// `-ntomp`.
-fn mdrun_args(stage: &str, out_name: &str, resources: ComputeResources) -> Vec<String> {
+/// request runs one thread-MPI rank per GPU. Dynamical stages explicitly offload
+/// nonbonded, PME, bonded, and update work; minimization only forces nonbonded
+/// work onto the GPU because GPU PME does not support non-dynamical integrators.
+/// A CPU-only core request maps to `-nt`; under a GPU rank cores map to `-ntomp`.
+fn mdrun_args(
+    stage: &str,
+    out_name: &str,
+    resources: ComputeResources,
+    integrator: input::Integrator,
+) -> Vec<String> {
     let mut args = vec![
         "mdrun".to_string(),
         "-deffnm".to_string(),
@@ -412,13 +421,11 @@ fn mdrun_args(stage: &str, out_name: &str, resources: ComputeResources) -> Vec<S
     ];
     if resources.gpu >= 1 {
         args.extend(["-ntmpi".to_string(), resources.gpu.to_string()]);
-        args.extend(
-            [
-                "-nb", "gpu", "-pme", "gpu", "-bonded", "gpu", "-update", "gpu",
-            ]
-            .map(String::from),
-        );
-        if resources.gpu > 1 {
+        args.extend(["-nb".to_string(), "gpu".to_string()]);
+        if !integrator.is_minimization() {
+            args.extend(["-pme", "gpu", "-bonded", "gpu", "-update", "gpu"].map(String::from));
+        }
+        if !integrator.is_minimization() && resources.gpu > 1 {
             // GPU PME across multiple ranks needs one dedicated PME rank; gmx maps
             // the ranks onto the available GPUs itself. We deliberately do not emit
             // `-gpu_id` — its single-digit-per-device form can't express ids >= 10.

--- a/compute-core/src/engines/gromacs/runner/tests.rs
+++ b/compute-core/src/engines/gromacs/runner/tests.rs
@@ -10,7 +10,14 @@ use crate::domain::{Atom, UnitCell};
 
 #[test]
 fn mdrun_args_map_resources_to_gmx_flags() {
-    let args = |cores, gpu| mdrun_args("nvt", "out.gro", ComputeResources { cores, gpu });
+    let args = |cores, gpu| {
+        mdrun_args(
+            "nvt",
+            "out.gro",
+            ComputeResources { cores, gpu },
+            input::Integrator::Leapfrog,
+        )
+    };
     let has =
         |a: &[String], flag: &str, val: &str| a.windows(2).any(|w| w[0] == flag && w[1] == val);
 
@@ -32,6 +39,8 @@ fn mdrun_args_map_resources_to_gmx_flags() {
     let gpu1 = args(8, 1);
     assert!(has(&gpu1, "-ntmpi", "1"));
     assert!(has(&gpu1, "-nb", "gpu"));
+    assert!(has(&gpu1, "-pme", "gpu"));
+    assert!(has(&gpu1, "-bonded", "gpu"));
     assert!(has(&gpu1, "-update", "gpu"));
     assert!(has(&gpu1, "-ntomp", "8"));
     assert!(!gpu1.iter().any(|a| a == "-npme"));
@@ -48,6 +57,25 @@ fn mdrun_args_map_resources_to_gmx_flags() {
     let gpu12 = args(0, 12);
     assert!(has(&gpu12, "-ntmpi", "12"));
     assert!(!gpu12.iter().any(|a| a == "-gpu_id"));
+}
+
+#[test]
+fn mdrun_args_do_not_force_unsupported_gpu_tasks_for_minimization() {
+    let args = mdrun_args(
+        "em",
+        "em_out.gro",
+        ComputeResources { cores: 16, gpu: 1 },
+        input::Integrator::SteepestDescent,
+    );
+    let has = |flag: &str, val: &str| args.windows(2).any(|w| w[0] == flag && w[1] == val);
+
+    assert!(has("-ntmpi", "1"));
+    assert!(has("-nb", "gpu"));
+    assert!(has("-ntomp", "16"));
+    assert!(!args.iter().any(|arg| arg == "-pme"));
+    assert!(!args.iter().any(|arg| arg == "-bonded"));
+    assert!(!args.iter().any(|arg| arg == "-update"));
+    assert!(!args.iter().any(|arg| arg == "-npme"));
 }
 
 #[test]

--- a/compute-core/src/md/run/preset.rs
+++ b/compute-core/src/md/run/preset.rs
@@ -363,7 +363,7 @@ impl PresetId {
 /// Coupling groups appropriate to the system's composition. Group by physical
 /// phase; don't over-split.
 fn coupling_groups_for(ctx: &EffectiveContext) -> CouplingGroups {
-    if ctx.is_framework() {
+    if ctx.is_framework() || ctx.water_token().is_none() {
         CouplingGroups::WholeSystem
     } else if ctx.has_membrane() {
         CouplingGroups::SoluteLipidSolvent
@@ -472,6 +472,27 @@ mod tests {
         assert!(stages[1].restraint.is_restrained());
         assert!(stages[2].restraint.is_restrained());
         assert!(!stages[3].restraint.is_restrained());
+        assert!(
+            stages
+                .iter()
+                .filter(|stage| stage.kind.is_dynamics())
+                .all(|stage| stage.coupling_groups == CouplingGroups::SoluteSolvent)
+        );
+    }
+
+    #[test]
+    fn dry_protein_preset_couples_the_whole_system() {
+        let mut ctx = context(true, false, false, false);
+        ctx.water_token = None;
+        let eff = ctx.with_overrides(SystemTypeOverrides::default());
+        let stages = PresetId::StandardBiomolecule.build(&eff, &PresetParams::default());
+
+        assert!(
+            stages
+                .iter()
+                .filter(|stage| stage.kind.is_dynamics())
+                .all(|stage| stage.coupling_groups == CouplingGroups::WholeSystem)
+        );
     }
 
     #[test]

--- a/compute-core/src/md/run/recommend.rs
+++ b/compute-core/src/md/run/recommend.rs
@@ -55,16 +55,26 @@ pub fn recommend(eff: &EffectiveContext) -> Recommendation {
     let mut notes = Vec::new();
     let mut warnings = Vec::new();
 
-    // Force-field family → nonbonded treatment + conventional water + Standard.
+    // Force-field family -> nonbonded treatment and the recorded solvent state.
     let family = eff.force_field_family();
     if family.is_biomolecular() {
-        let water = eff.water_token().unwrap_or("the family's conventional");
+        let intent = eff.water_token().map_or_else(
+            || {
+                format!(
+                    "apply the {} nonbonded treatment; no water model is recorded",
+                    family.label()
+                )
+            },
+            |water| {
+                format!(
+                    "apply the {} nonbonded treatment with {water} water",
+                    family.label()
+                )
+            },
+        );
         notes.push(RecNote::new(
             format!("Force field is {}", family.label()),
-            format!(
-                "apply the {} nonbonded treatment with {water} water",
-                family.label()
-            ),
+            intent,
         ));
     }
 
@@ -206,6 +216,24 @@ mod tests {
         assert!(rec.warnings.is_empty());
         // The ff-family note is present.
         assert!(rec.notes.iter().any(|n| n.reason.contains("AMBER")));
+    }
+
+    #[test]
+    fn dry_protein_note_does_not_claim_a_water_model() {
+        let mut c = ctx();
+        c.water_token = None;
+        let rec = recommend(&c.with_overrides(SystemTypeOverrides::default()));
+
+        assert!(
+            rec.notes
+                .iter()
+                .any(|note| note.intent.contains("no water model is recorded"))
+        );
+        assert!(
+            rec.notes
+                .iter()
+                .all(|note| !note.intent.contains("conventional water"))
+        );
     }
 
     #[test]

--- a/compute-core/src/md/run/validate.rs
+++ b/compute-core/src/md/run/validate.rs
@@ -54,6 +54,21 @@ pub fn validate(stages: &[MdStage], eff: &EffectiveContext) -> Vec<ValidationIss
         return issues;
     }
 
+    let dry_biomolecule = eff.water_token().is_none()
+        && !eff.is_framework()
+        && (eff.has_protein() || eff.has_nucleic() || eff.has_ligand() || eff.has_membrane());
+    let dry_pressure_or_production = stages.iter().any(|stage| {
+        stage.pressure.is_some() || matches!(stage.kind, StageKind::Produce | StageKind::Extend)
+    });
+    if dry_biomolecule && dry_pressure_or_production {
+        issues.push(ValidationIssue::warning(
+            None,
+            "No solvent was recorded for this biomolecular system. NPT or production MD is \
+             usually inappropriate without water and ions; rebuild a solvated system unless \
+             this dry simulation is intentional.",
+        ));
+    }
+
     let mut npt_equilibrated = false;
 
     for stage in stages {
@@ -179,6 +194,37 @@ mod tests {
         let stages = PresetId::StandardBiomolecule.build(&eff, &PresetParams::default());
         let issues = validate(&stages, &eff);
         assert!(!has_errors(&issues), "unexpected errors: {issues:?}");
+    }
+
+    #[test]
+    fn dry_biomolecule_warns_for_npt_or_production() {
+        let mut c = ctx(false, true);
+        c.water_token = None;
+        let eff = c.with_overrides(SystemTypeOverrides::default());
+        let stages = PresetId::StandardBiomolecule.build(&eff, &PresetParams::default());
+        let issues = validate(&stages, &eff);
+
+        assert!(!has_errors(&issues));
+        assert!(
+            issues
+                .iter()
+                .any(|issue| issue.message.contains("No solvent was recorded"))
+        );
+    }
+
+    #[test]
+    fn dry_biomolecule_minimization_only_has_no_solvent_warning() {
+        let mut c = ctx(false, true);
+        c.water_token = None;
+        let eff = c.with_overrides(SystemTypeOverrides::default());
+        let stages = PresetId::EnergyMinimization.build(&eff, &PresetParams::default());
+        let issues = validate(&stages, &eff);
+
+        assert!(
+            issues
+                .iter()
+                .all(|issue| !issue.message.contains("No solvent was recorded"))
+        );
     }
 
     #[test]

--- a/src/frontend/ui/secondary_sidebar/md_run.rs
+++ b/src/frontend/ui/secondary_sidebar/md_run.rs
@@ -9,6 +9,7 @@ pub(crate) fn render_md_run_task_panel(
 ) {
     // Computed before the prompt borrow so the picker can list configured hosts.
     let hosts = remote_host_options(state);
+    let pal = crate::frontend::theme::palette(ui);
     if let Some(prompt) = &mut state.ui.pending_md_run {
         use crate::frontend::state::MdEngineChoice;
 
@@ -46,7 +47,7 @@ pub(crate) fn render_md_run_task_panel(
                         .water_token
                         .as_deref()
                         .map(|water| format!(" · water {water}"))
-                        .unwrap_or_default(),
+                        .unwrap_or_else(|| " · dry (no solvent recorded)".to_string()),
                 ))
                 .small()
                 .color(egui::Color32::GRAY),
@@ -104,7 +105,7 @@ pub(crate) fn render_md_run_task_panel(
                     ui.label(
                         RichText::new(format!("⚠ {warning}"))
                             .small()
-                            .color(egui::Color32::YELLOW),
+                            .color(pal.status_amber),
                     );
                 }
             }
@@ -281,8 +282,8 @@ pub(crate) fn render_md_run_task_panel(
                 ui.separator();
                 for issue in &issues {
                     let (color, prefix) = match issue.severity {
-                        IssueSeverity::Error => (egui::Color32::LIGHT_RED, "error"),
-                        IssueSeverity::Warning => (egui::Color32::YELLOW, "warning"),
+                        IssueSeverity::Error => (pal.status_red, "error"),
+                        IssueSeverity::Warning => (pal.status_amber, "warning"),
                     };
                     let stage = issue
                         .stage


### PR DESCRIPTION
## Summary

- make GROMACS GPU offload stage-aware so energy minimization does not force unsupported GPU PME/update tasks
- couple dry biomolecular systems as a whole system instead of referencing a missing Non-Protein group
- surface dry-system guidance for NPT and production MD
- use the theme semantic status colors for MD warnings and errors

## Validation

- cargo pr-check
- remote GROMACS 2026.2 GPU energy-minimization verification
- remote 50,000-step GPU NVT verification with PP, PME, bonded, update, and constraints offloaded
- application E2E verification