### PR TITLE
feat(qm): add optional ORCA engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ manual in English and Chinese lives at <https://silicolab.github.io/silicolab/>.
 ## External tools
 
 SilicoLab can run without optional external tools until you use features that
-need them. Molecular dynamics requires GROMACS. Quantum chemistry is available
-through the built-in Hartree engine. See the manual for setup details:
+need them. Molecular dynamics requires GROMACS. Quantum chemistry uses the
+built-in Hartree engine by default, with ORCA available as an optional external
+engine when the user configures its executable path. See the manual for setup details:
 
 - [External tools](https://silicolab.github.io/silicolab/getting-started/external-tools/)
 - [Remote execution over SSH](https://silicolab.github.io/silicolab/getting-started/remote-execution/)

--- a/compute-core/src/engines/mod.rs
+++ b/compute-core/src/engines/mod.rs
@@ -2,6 +2,7 @@ pub mod docking;
 pub mod forcefield;
 pub mod gromacs;
 pub mod methods;
+pub mod orca;
 pub mod process;
 pub mod qm;
 pub mod registry;

--- a/compute-core/src/engines/orca.rs
+++ b/compute-core/src/engines/orca.rs
@@ -1,0 +1,427 @@
+//! ORCA molecular quantum-chemistry subprocess adapter.
+
+use std::{
+    fs,
+    path::Path,
+    sync::{Arc, atomic::AtomicBool},
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+
+use crate::{
+    domain::{Atom, Structure},
+    engines::{
+        process,
+        qm::{CpcmDielectric, QmDispersion, QmKind, QmMethod, QmOutcome, QmRequest, QmSolvation},
+        registry::EngineLaunch,
+    },
+};
+
+const INPUT_FILE: &str = "silicolab_orca.inp";
+const XYZ_FILE: &str = "silicolab_orca.xyz";
+
+pub fn run_orca(
+    request: QmRequest,
+    launch: EngineLaunch,
+    cores: Option<usize>,
+    cancel: Arc<AtomicBool>,
+    mut report: impl FnMut(&str),
+) -> Result<QmOutcome> {
+    validate_request(&request)?;
+    let run_dir = std::env::temp_dir().join(format!("silicolab-orca-{}", uuid::Uuid::new_v4()));
+    fs::create_dir_all(&run_dir)
+        .with_context(|| format!("create ORCA working directory {}", run_dir.display()))?;
+    let result = (|| {
+        let input = render_input(&request, cores)?;
+        fs::write(run_dir.join(INPUT_FILE), input).context("write ORCA input")?;
+        report("running ORCA");
+        let config = launch.to_process_config(&run_dir, [INPUT_FILE.to_string()], None);
+        let output = process::spawn_with_cancel(config, cancel)?.join()?;
+        if output.cancelled {
+            bail!("ORCA calculation cancelled");
+        }
+        if !output.success() {
+            let combined = format!("{}\n{}", output.stdout, output.stderr);
+            if let Some(reason) = parallel_startup_failure(cores, &combined) {
+                bail!("{reason}");
+            }
+            bail!(
+                "ORCA failed with exit code {}: {}",
+                output.exit_code,
+                output_tail(&combined, 20)
+            );
+        }
+        if !output.stdout.contains("ORCA TERMINATED NORMALLY") {
+            bail!(
+                "ORCA did not terminate normally: {}",
+                output_tail(&format!("{}\n{}", output.stdout, output.stderr), 20)
+            );
+        }
+        report("collecting ORCA results");
+        parse_outcome(&request, &run_dir, &output.stdout)
+    })();
+    let _ = fs::remove_dir_all(&run_dir);
+    result
+}
+
+pub fn render_input(request: &QmRequest, cores: Option<usize>) -> Result<String> {
+    validate_request(request)?;
+    let method = method_keyword(&request.method)?;
+    let basis = (!matches!(request.method, QmMethod::Composite(_)))
+        .then(|| safe_keyword(&request.basis, "basis set"))
+        .transpose()?;
+    let mut keywords = vec![method];
+    if let Some(basis) = basis {
+        keywords.push(basis);
+    }
+    keywords.push("TightSCF".to_string());
+    match request.kind {
+        QmKind::SinglePoint => {}
+        QmKind::Optimize => keywords.push("Opt".to_string()),
+        QmKind::Frequencies => keywords.push("Freq".to_string()),
+        QmKind::TransitionState => unreachable!("validated above"),
+    }
+    if let Some(dispersion) = request.options.dispersion {
+        keywords.push(
+            match dispersion {
+                QmDispersion::D3Bj => "D3BJ",
+                QmDispersion::D4 => "D4",
+            }
+            .to_string(),
+        );
+    }
+    let mut blocks = Vec::new();
+    if let Some(solvation) = &request.options.solvation {
+        match solvation {
+            QmSolvation::Cpcm(CpcmDielectric::Named(name)) => {
+                keywords.push(format!("CPCM({})", safe_keyword(name, "solvent")?));
+            }
+            QmSolvation::Cpcm(CpcmDielectric::Epsilon(epsilon)) => {
+                if !epsilon.is_finite() || *epsilon <= 1.0 {
+                    bail!("ORCA C-PCM dielectric must be finite and greater than 1");
+                }
+                blocks.push(format!("%cpcm\n  epsilon {epsilon}\nend"));
+            }
+            QmSolvation::Smd(name) => {
+                let name = safe_keyword(name, "SMD solvent")?;
+                blocks.push(format!("%cpcm\n  smd true\n  SMDsolvent \"{name}\"\nend"));
+            }
+            QmSolvation::Alpb(_) | QmSolvation::Gbsa(_) => {
+                bail!("ORCA support does not include ALPB or GBSA solvation")
+            }
+        }
+    }
+    if request.options.compute_properties {
+        keywords.push("Mayer".to_string());
+    }
+    if let Some(cores) = cores.filter(|cores| *cores > 1) {
+        blocks.push(format!("%pal\n  nprocs {cores}\nend"));
+    }
+
+    let mut input = format!("! {}\n", keywords.join(" "));
+    for block in blocks {
+        input.push_str(&block);
+        input.push('\n');
+    }
+    input.push_str(&format!(
+        "* xyz {} {}\n",
+        request.charge, request.multiplicity
+    ));
+    for atom in &request.structure.atoms {
+        input.push_str(&format!(
+            "{} {:.12} {:.12} {:.12}\n",
+            atom.element, atom.position.x, atom.position.y, atom.position.z
+        ));
+    }
+    input.push_str("*\n");
+    Ok(input)
+}
+
+fn validate_request(request: &QmRequest) -> Result<()> {
+    if request.structure.atoms.is_empty() {
+        bail!("ORCA request has no atoms");
+    }
+    if request.kind == QmKind::TransitionState {
+        bail!("ORCA support currently covers single-point, optimization, and frequencies only");
+    }
+    if request.multiplicity == 0 {
+        bail!("spin multiplicity must be at least 1");
+    }
+    Ok(())
+}
+
+fn method_keyword(method: &QmMethod) -> Result<String> {
+    match method {
+        QmMethod::Hf => Ok("HF".to_string()),
+        QmMethod::Rhf => Ok("RHF".to_string()),
+        QmMethod::Uhf => Ok("UHF".to_string()),
+        QmMethod::Rohf => Ok("ROHF".to_string()),
+        QmMethod::Mp2 => Ok("MP2".to_string()),
+        QmMethod::Ccsd => Ok("CCSD".to_string()),
+        QmMethod::CcsdT => Ok("CCSD(T)".to_string()),
+        QmMethod::Dft(name) | QmMethod::Composite(name) => safe_keyword(name, "method"),
+    }
+}
+
+fn safe_keyword(value: &str, field: &str) -> Result<String> {
+    let value = value.trim();
+    if value.is_empty()
+        || !value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '+' | '(' | ')' | ',' | '.'))
+    {
+        bail!("invalid ORCA {field} `{value}`");
+    }
+    Ok(value.to_string())
+}
+
+fn parse_outcome(request: &QmRequest, run_dir: &Path, output: &str) -> Result<QmOutcome> {
+    let energy_hartree = output
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("FINAL SINGLE POINT ENERGY"))
+        .filter_map(|value| value.trim().parse::<f64>().ok())
+        .next_back()
+        .ok_or_else(|| anyhow!("ORCA output contains no final single-point energy"))?;
+    let optimized_structure = if request.kind == QmKind::Optimize {
+        let path = run_dir.join(XYZ_FILE);
+        Some(
+            parse_xyz(&path, &request.structure.title)
+                .with_context(|| format!("read ORCA optimized geometry from {}", path.display()))?,
+        )
+    } else {
+        None
+    };
+    let frequencies = if request.kind == QmKind::Frequencies {
+        parse_frequencies(output)
+    } else {
+        Vec::new()
+    };
+    let converged = match request.kind {
+        QmKind::Optimize => output.contains("THE OPTIMIZATION HAS CONVERGED"),
+        _ => true,
+    };
+    let mut summary = format!(
+        "ORCA {} {} / {}\n  final energy: {:.12} Eh\n  converged: {}",
+        request.kind.label(),
+        request.method.label(),
+        request.basis,
+        energy_hartree,
+        if converged { "yes" } else { "no" }
+    );
+    if !frequencies.is_empty() {
+        summary.push_str("\n  frequencies (cm^-1):");
+        for chunk in frequencies.chunks(6) {
+            summary.push_str("\n   ");
+            for frequency in chunk {
+                summary.push_str(&format!(" {frequency:.2}"));
+            }
+        }
+    }
+    Ok(QmOutcome {
+        energy_hartree,
+        converged,
+        optimized_structure,
+        summary,
+        scf_trace: Vec::new(),
+        opt_trace: Vec::new(),
+        frequencies,
+    })
+}
+
+fn parse_xyz(path: &Path, name: &str) -> Result<Structure> {
+    let text = fs::read_to_string(path)?;
+    let mut lines = text.lines();
+    let count = lines
+        .next()
+        .ok_or_else(|| anyhow!("empty XYZ file"))?
+        .trim()
+        .parse::<usize>()
+        .context("parse XYZ atom count")?;
+    let _ = lines.next();
+    let mut atoms = Vec::with_capacity(count);
+    for (index, line) in lines.take(count).enumerate() {
+        let fields: Vec<_> = line.split_whitespace().collect();
+        if fields.len() < 4 {
+            bail!("invalid XYZ atom line {}", index + 3);
+        }
+        atoms.push(Atom {
+            element: fields[0].to_string(),
+            position: nalgebra::Point3::new(
+                fields[1].parse().context("parse XYZ x coordinate")?,
+                fields[2].parse().context("parse XYZ y coordinate")?,
+                fields[3].parse().context("parse XYZ z coordinate")?,
+            ),
+            charge: 0.0,
+        });
+    }
+    if atoms.len() != count {
+        bail!("XYZ declared {count} atoms but contained {}", atoms.len());
+    }
+    Ok(Structure::new(format!("{name} (ORCA optimized)"), atoms))
+}
+
+fn parse_frequencies(output: &str) -> Vec<f64> {
+    let mut in_section = false;
+    let mut frequencies = Vec::new();
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed == "VIBRATIONAL FREQUENCIES" {
+            in_section = true;
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        if trimmed.starts_with("NORMAL MODES") || trimmed.starts_with("IR SPECTRUM") {
+            break;
+        }
+        let Some((_, rest)) = trimmed.split_once(':') else {
+            continue;
+        };
+        let Some(value) = rest.split_whitespace().next() else {
+            continue;
+        };
+        if rest.contains("cm**-1")
+            && let Ok(value) = value.parse::<f64>()
+        {
+            frequencies.push(value);
+        }
+    }
+    frequencies
+}
+
+fn output_tail(output: &str, lines: usize) -> String {
+    let mut tail: Vec<_> = output.lines().rev().take(lines).collect();
+    tail.reverse();
+    tail.join("\n")
+}
+
+fn parallel_startup_failure(cores: Option<usize>, output: &str) -> Option<String> {
+    let cores = cores.filter(|cores| *cores > 1)?;
+    let lower = output.to_ascii_lowercase();
+    let missing_mpirun = lower.contains("mpirun: not found")
+        || lower.contains("mpirun: command not found")
+        || lower.contains("no such file or directory") && lower.contains("mpirun");
+    missing_mpirun.then(|| {
+        format!(
+            "ORCA parallel execution requested {cores} CPU cores, but `mpirun` is not available \
+             in the target environment. Install a compatible MPI runtime there, or set CPU cores \
+             to 1 to run ORCA serially."
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engines::qm::QmOptions;
+    use nalgebra::Point3;
+
+    fn request(kind: QmKind) -> QmRequest {
+        QmRequest {
+            structure: Structure::new(
+                "water",
+                vec![Atom {
+                    element: "O".into(),
+                    position: Point3::new(0.0, 0.0, 0.0),
+                    charge: 0.0,
+                }],
+            ),
+            method: QmMethod::Dft("b3lyp".into()),
+            basis: "def2-svp".into(),
+            charge: 0,
+            multiplicity: 1,
+            kind,
+            options: QmOptions {
+                dispersion: Some(QmDispersion::D3Bj),
+                ..Default::default()
+            },
+            ts: None,
+        }
+    }
+
+    #[test]
+    fn renders_single_point_input() {
+        let input = render_input(&request(QmKind::SinglePoint), Some(4)).unwrap();
+        assert!(input.contains("! b3lyp def2-svp TightSCF D3BJ"));
+        assert!(input.contains("nprocs 4"));
+        assert!(input.contains("* xyz 0 1"));
+    }
+
+    #[test]
+    fn parses_final_energy_and_frequencies() {
+        let output = "\nFINAL SINGLE POINT ENERGY     -76.123456789\n\nVIBRATIONAL FREQUENCIES\n-----------------------\n  0:       0.00 cm**-1\n  6:    1595.12 cm**-1\n  7:    3657.05 cm**-1\nNORMAL MODES\nORCA TERMINATED NORMALLY\n";
+        let parsed = parse_outcome(&request(QmKind::Frequencies), Path::new("."), output).unwrap();
+        assert_eq!(parsed.energy_hartree, -76.123456789);
+        assert_eq!(parsed.frequencies, vec![0.0, 1595.12, 3657.05]);
+    }
+
+    #[test]
+    fn rejects_transition_state() {
+        let error = render_input(&request(QmKind::TransitionState), None).unwrap_err();
+        assert!(error.to_string().contains("currently covers"));
+    }
+
+    #[test]
+    fn missing_mpirun_has_an_actionable_parallel_error() {
+        let output = "Calling Command: mpirun -np 8 orca_startup_mpi\nsh: 1: mpirun: not found";
+        let error = parallel_startup_failure(Some(8), output).expect("recognized MPI failure");
+        assert!(error.contains("requested 8 CPU cores"));
+        assert!(error.contains("Install a compatible MPI runtime"));
+        assert!(error.contains("set CPU cores to 1"));
+        assert!(parallel_startup_failure(Some(1), output).is_none());
+    }
+
+    #[test]
+    #[ignore = "requires SILICOLAB_TEST_ORCA_PROGRAM to name an ORCA executable"]
+    fn configured_orca_runs_supported_calculations() {
+        let program =
+            std::env::var("SILICOLAB_TEST_ORCA_PROGRAM").expect("set SILICOLAB_TEST_ORCA_PROGRAM");
+        let command_prefix: Vec<String> = std::env::var("SILICOLAB_TEST_ORCA_PREFIX")
+            .ok()
+            .map(|prefix| prefix.split_whitespace().map(str::to_string).collect())
+            .unwrap_or_default();
+        let launch = EngineLaunch {
+            command_prefix,
+            program,
+        };
+        let spec = crate::engines::registry::engine_spec(crate::launch::EngineId::ORCA)
+            .expect("ORCA engine spec");
+        let version = crate::engines::registry::verify_launch(&launch, spec)
+            .expect("configured ORCA should verify");
+        assert!(!version.is_empty());
+        for kind in [QmKind::SinglePoint, QmKind::Optimize, QmKind::Frequencies] {
+            let mut request = request(kind);
+            request.structure = Structure::new(
+                "h2",
+                vec![
+                    Atom {
+                        element: "H".into(),
+                        position: Point3::new(0.0, 0.0, 0.0),
+                        charge: 0.0,
+                    },
+                    Atom {
+                        element: "H".into(),
+                        position: Point3::new(0.0, 0.0, 0.9),
+                        charge: 0.0,
+                    },
+                ],
+            );
+            request.method = QmMethod::Rhf;
+            request.basis = "sto-3g".to_string();
+            request.options.dispersion = None;
+            let outcome = run_orca(request, launch.clone(), Some(1), Default::default(), |_| {})
+                .unwrap_or_else(|error| {
+                    panic!("configured ORCA should complete {kind:?}: {error}")
+                });
+            assert!(outcome.converged);
+            assert!(outcome.energy_hartree.is_finite());
+            if kind == QmKind::Optimize {
+                assert!(outcome.optimized_structure.is_some());
+            }
+            if kind == QmKind::Frequencies {
+                assert!(!outcome.frequencies.is_empty());
+            }
+        }
+    }
+}

--- a/compute-core/src/engines/qm/types.rs
+++ b/compute-core/src/engines/qm/types.rs
@@ -512,16 +512,59 @@ pub struct QmRequest {
     pub ts: Option<QmTsConfig>,
 }
 
+/// Quantum-chemistry backend selected for a job. Hartree is the built-in
+/// default; ORCA is an optional external executable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum QmEngine {
+    #[default]
+    Hartree,
+    Orca,
+}
+
+impl QmEngine {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Hartree => "Hartree (built-in)",
+            Self::Orca => "ORCA",
+        }
+    }
+}
+
 /// A quantum-chemistry job: a molecular calculation or a periodic (crystalline)
 /// one. Both produce a [`QmOutcome`], so the worker thread, the workflow entry
 /// point, and the result-polling UI handle the two uniformly — only the input
 /// form differs. Built by the panel/console; run by [`crate::workflows::qm`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum QmJob {
+pub enum QmCalculation {
     /// A molecular (non-periodic) HF/DFT/post-HF calculation.
     Molecular(QmRequest),
+    /// A molecular calculation executed by the user-configured ORCA binary.
     /// A periodic (PBC) Kohn–Sham calculation over a unit cell.
     Periodic(PeriodicQmRequest),
+}
+
+/// A quantum-chemistry job with backend selection kept orthogonal to the
+/// molecular/periodic calculation model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QmJob {
+    pub engine: QmEngine,
+    pub calculation: QmCalculation,
+}
+
+impl QmJob {
+    pub fn molecular(engine: QmEngine, request: QmRequest) -> Self {
+        Self {
+            engine,
+            calculation: QmCalculation::Molecular(request),
+        }
+    }
+
+    pub fn periodic(request: PeriodicQmRequest) -> Self {
+        Self {
+            engine: QmEngine::Hartree,
+            calculation: QmCalculation::Periodic(request),
+        }
+    }
 }
 
 /// The result of a quantum-chemistry calculation.

--- a/compute-core/src/engines/registry.rs
+++ b/compute-core/src/engines/registry.rs
@@ -124,21 +124,40 @@ pub struct EngineSpec {
     /// An absolute POSIX path is inert on a native Windows probe — it simply is
     /// not a file — so one list serves every platform.
     pub candidate_executables: &'static [&'static str],
-    pub version_arg: Option<&'static str>,
-    /// A substring the engine's own `version_arg` output always contains. Guards
+    pub version_args: &'static [&'static str],
+    /// Some engines print their identity before returning a non-zero usage status
+    /// when started without an input file.
+    pub identity_allows_nonzero_exit: bool,
+    /// A substring the engine's version-probe output always contains. Guards
     /// against a same-named binary that is not this engine, and against a missing
     /// binary whose error text would otherwise look like output.
     pub identity_marker: &'static str,
+    /// If true, discovery is disabled and the user must supply a program path.
+    pub requires_configured_path: bool,
 }
 
-const ENGINE_SPECS: &[EngineSpec] = &[EngineSpec {
-    id: EngineId::GROMACS,
-    name: "GROMACS",
-    description: "Molecular dynamics and minimization (gmx).",
-    candidate_executables: &["gmx", "/usr/local/gromacs/bin/gmx", "gmx_mpi", "gmx_d"],
-    version_arg: Some("--version"),
-    identity_marker: "GROMACS",
-}];
+const ENGINE_SPECS: &[EngineSpec] = &[
+    EngineSpec {
+        id: EngineId::GROMACS,
+        name: "GROMACS",
+        description: "Molecular dynamics and minimization (gmx).",
+        candidate_executables: &["gmx", "/usr/local/gromacs/bin/gmx", "gmx_mpi", "gmx_d"],
+        version_args: &["--version"],
+        identity_allows_nonzero_exit: false,
+        identity_marker: "GROMACS",
+        requires_configured_path: false,
+    },
+    EngineSpec {
+        id: EngineId::ORCA,
+        name: "ORCA",
+        description: "Optional molecular quantum chemistry for energies, optimizations, and frequencies.",
+        candidate_executables: &["orca"],
+        version_args: &[],
+        identity_allows_nonzero_exit: true,
+        identity_marker: "ORCA",
+        requires_configured_path: true,
+    },
+];
 
 /// The detection spec for `id`, or `None` for a built-in engine (no executable).
 pub fn engine_spec(id: EngineId) -> Option<&'static EngineSpec> {
@@ -243,6 +262,9 @@ fn local_status(overrides: &EngineLaunches, spec: &EngineSpec) -> EngineStatus {
             },
         };
     }
+    if spec.requires_configured_path {
+        return EngineStatus::NotConfigured;
+    }
     // A binary sitting on PATH is a launch, not a proof: it has not been run.
     match probe_native(spec) {
         Some(program) => EngineStatus::Unverified {
@@ -264,6 +286,9 @@ pub fn probe_native(spec: &EngineSpec) -> Option<String> {
 /// preferred; on Windows, an available WSL launcher falls back to the first
 /// conventional engine command inside the distribution.
 pub fn local_launch_candidate(spec: &EngineSpec) -> Option<EngineLaunch> {
+    if spec.requires_configured_path {
+        return None;
+    }
     if let Some(program) = probe_native(spec) {
         return Some(EngineLaunch::native(program));
     }
@@ -276,7 +301,7 @@ pub fn local_launch_candidate(spec: &EngineSpec) -> Option<EngineLaunch> {
         })
 }
 
-/// Run `<launch> <version_arg>` on this machine and decide whether it *is* this
+/// Run an engine's version probe on this machine and decide whether it *is* this
 /// engine: it must exit cleanly and print the spec's identity marker. On success
 /// returns the version it reported; on failure, a reason phrased for the settings
 /// panel, distinguishing "would not start" from "started, but is not this engine".
@@ -284,24 +309,23 @@ pub fn local_launch_candidate(spec: &EngineSpec) -> Option<EngineLaunch> {
 /// Slow — a WSL-prefixed launch cold-starts the VM. Never call from the UI thread.
 /// The remote twin of this is `engines::remote::verify_remote_launch`.
 pub fn verify_launch(launch: &EngineLaunch, spec: &EngineSpec) -> Result<String, String> {
-    let Some(version_arg) = spec.version_arg else {
-        return Err(format!("{} has no version check", spec.name));
-    };
     let config = launch.to_process_config(
         std::env::temp_dir(),
-        [version_arg.to_string()],
+        spec.version_args.iter().map(|arg| (*arg).to_string()),
         Some(Duration::from_secs(20)),
     );
     let result = process::run(config).map_err(|error| format!("could not run it: {error}"))?;
     let blob = format!("{}{}", result.stdout, result.stderr);
-    if !result.success() {
+    let identifies = blob.contains(spec.identity_marker);
+    if !result.success() && !(spec.identity_allows_nonzero_exit && identifies) {
+        let args = spec.version_args.join(" ");
         return Err(format!(
-            "`{} {version_arg}` failed: {}",
+            "`{} {args}` failed: {}",
             launch.display_command(),
             first_line(&blob).unwrap_or("no output")
         ));
     }
-    if !blob.contains(spec.identity_marker) {
+    if !identifies {
         return Err(format!(
             "it runs, but does not identify itself as {}",
             spec.name
@@ -317,6 +341,9 @@ pub fn verify_launch(launch: &EngineLaunch, spec: &EngineSpec) -> Result<String,
 ///
 /// Slow, for the same reason [`verify_launch`] is. Never call from the UI thread.
 pub fn probe_local(spec: &EngineSpec) -> Option<(EngineLaunch, String)> {
+    if spec.requires_configured_path {
+        return None;
+    }
     let native = probe_native(spec)
         .map(EngineLaunch::native)
         .and_then(|launch| verify_launch(&launch, spec).ok().map(|v| (launch, v)));
@@ -340,10 +367,15 @@ fn first_line(blob: &str) -> Option<&str> {
 /// Pull a version string out of a `--version` blob. Prefers a `Label: value`
 /// line whose label contains "version" (GROMACS prints
 /// `GROMACS version:    2026.2`), which avoids false positives like the
-/// echoed `gmx --version` command line. Falls back to the first non-empty
-/// line. Also used by `engines::remote` to parse a remote `--version` blob.
+/// echoed `gmx --version` command line. Also recognizes ORCA's `Program
+/// Version` banner. Used by `engines::remote` for the same probe output.
 pub(crate) fn extract_version(blob: &str) -> Option<String> {
     for line in blob.lines().map(str::trim) {
+        if let Some(rest) = line.strip_prefix("Program Version")
+            && let Some(version) = rest.split_whitespace().next()
+        {
+            return Some(version.to_string());
+        }
         if let Some((label, value)) = line.split_once(':')
             && label.to_ascii_lowercase().contains("version")
         {
@@ -353,10 +385,7 @@ pub(crate) fn extract_version(blob: &str) -> Option<String> {
             }
         }
     }
-    blob.lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .map(str::to_string)
+    None
 }
 
 #[cfg(test)]
@@ -494,6 +523,12 @@ mod tests {
             GROMACS version:    2026.2\n\
             Precision:          mixed\n";
         assert_eq!(extract_version(blob).as_deref(), Some("2026.2"));
+    }
+
+    #[test]
+    fn extract_version_reads_orca_banner() {
+        let blob = "Program Version 6.0.0  -  RELEASE";
+        assert_eq!(extract_version(blob).as_deref(), Some("6.0.0"));
     }
 
     /// Acceptance check for the Windows + GROMACS-in-WSL environment. Ignored

--- a/compute-core/src/engines/remote/mod.rs
+++ b/compute-core/src/engines/remote/mod.rs
@@ -274,7 +274,7 @@ pub fn check_passwordless(target: &RemoteTarget) -> bool {
     matches!(process::run(config), Ok(result) if result.success())
 }
 
-/// SSH-run `<prelude && launch> <version_arg>` and decide whether it *is* this
+/// SSH-run an engine's version probe and decide whether it *is* this
 /// engine. The remote twin of [`crate::engines::registry::verify_launch`]: same
 /// question, same two failure modes told apart ("would not start" vs "started, but
 /// is not this engine"), only the transport differs. Always off the UI thread.
@@ -283,9 +283,6 @@ pub fn verify_remote_launch(
     launch: &EngineLaunch,
     spec: &crate::engines::registry::EngineSpec,
 ) -> Result<String, String> {
-    let Some(version_arg) = spec.version_arg else {
-        return Err(format!("{} has no version check", spec.name));
-    };
     let command = launch
         .command_prefix
         .iter()
@@ -294,23 +291,26 @@ pub fn verify_remote_launch(
         .map(sh_quote)
         .collect::<Vec<_>>()
         .join(" ");
-    let script = format!(
-        "{}{command} {}",
-        target.prelude_prefix(),
-        sh_quote(version_arg)
-    );
+    let args = spec
+        .version_args
+        .iter()
+        .map(|arg| sh_quote(arg))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let script = format!("{}{command} {args}", target.prelude_prefix());
     let config = ssh_config(target, &script, Some(Duration::from_secs(30)));
     let result = process::run(config).map_err(|error| format!("ssh failed: {error}"))?;
     let blob = format!("{}{}", result.stdout, result.stderr);
-    if !result.success() {
+    let identifies = blob.contains(spec.identity_marker);
+    if !result.success() && !(spec.identity_allows_nonzero_exit && identifies) {
         let detail = blob
             .lines()
             .map(str::trim)
             .find(|line| !line.is_empty())
             .unwrap_or("no output");
-        return Err(format!("`{command} {version_arg}` failed: {detail}"));
+        return Err(format!("`{command} {args}` failed: {detail}"));
     }
-    if !blob.contains(spec.identity_marker) {
+    if !identifies {
         return Err(format!(
             "it runs, but does not identify itself as {}",
             spec.name

--- a/compute-core/src/launch.rs
+++ b/compute-core/src/launch.rs
@@ -21,6 +21,7 @@ pub struct EngineId(pub &'static str);
 impl EngineId {
     pub const UFF: Self = Self("uff");
     pub const HARTREE: Self = Self("hartree");
+    pub const ORCA: Self = Self("orca");
     pub const GROMACS: Self = Self("gromacs");
     pub const DOCKING: Self = Self("docking");
 

--- a/compute-core/src/wire.rs
+++ b/compute-core/src/wire.rs
@@ -9,7 +9,7 @@
 //! every out-of-process path shares.
 
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command};
+use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver};
 use std::sync::{Arc, Mutex};
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::engines::docking::{DockingInput, DockingOutcome, DockingRequest};
 use crate::engines::gromacs::GromacsProgress;
-use crate::engines::qm::{QmJob, QmOutcome};
+use crate::engines::qm::{QmCalculation, QmEngine, QmJob, QmOutcome};
 use crate::engines::remote::launcher::{self, RemoteExecution, RemoteJobPhase};
 use crate::launch::{EngineId, EngineLaunches};
 use crate::workflows::docking::{DockingProgress, run_docking_calculation};
@@ -98,6 +98,10 @@ impl EngineRequest {
 impl Engine {
     pub fn required_engines(&self) -> &'static [EngineId] {
         match self {
+            Engine::Qm(QmJob {
+                engine: QmEngine::Orca,
+                ..
+            }) => &[EngineId::ORCA],
             Engine::Qm(_) | Engine::Docking(_) => &[],
             Engine::Gromacs(_) => &[EngineId::GROMACS],
         }
@@ -117,7 +121,7 @@ fn engine_label(engine: &Engine) -> &'static str {
 // The QM variant embeds a full inline `Structure`, so it dwarfs the others; this
 // envelope is built once per job and immediately serialized or moved, never held
 // in bulk, so boxing every variant would only add indirection to a cold path (and
-// break the nested `Engine::Qm(QmJob::Molecular(..))` matching the call sites use).
+// make every engine payload pay for heap indirection on a cold path).
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Engine {
@@ -278,7 +282,8 @@ fn run_subprocess(request: EngineRequest) -> Running {
             let monitor = Arc::clone(&child);
             std::thread::spawn(move || {
                 let outcome_path = run_dir.join("outcome.json");
-                let result = wait_for_subprocess(&monitor, &outcome_path);
+                let result =
+                    wait_for_subprocess(&monitor, &outcome_path, &run_dir.join("engine.log"));
                 let _ = std::fs::remove_dir_all(&run_dir);
                 let _ = sender.send(match result {
                     Ok(outcome) => JobUpdate::Finished(Box::new(outcome)),
@@ -325,15 +330,23 @@ fn spawn_subprocess(request: &EngineRequest, run_dir: &Path) -> Result<Child> {
     std::fs::write(&request_path, json)
         .with_context(|| format!("write {}", request_path.display()))?;
     let exe = std::env::current_exe().context("resolve current executable")?;
+    let log = std::fs::File::create(run_dir.join("engine.log")).context("create engine log")?;
+    let stderr = log.try_clone().context("clone engine log")?;
     Command::new(exe)
         .arg("exec")
         .arg(&request_path)
         .arg(&outcome_path)
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(stderr))
         .spawn()
         .context("spawn engine subprocess")
 }
 
-fn wait_for_subprocess(child: &Arc<Mutex<Child>>, outcome_path: &Path) -> Result<EngineOutcome> {
+fn wait_for_subprocess(
+    child: &Arc<Mutex<Child>>,
+    outcome_path: &Path,
+    log_path: &Path,
+) -> Result<EngineOutcome> {
     let status = loop {
         {
             let mut guard = child
@@ -346,7 +359,14 @@ fn wait_for_subprocess(child: &Arc<Mutex<Child>>, outcome_path: &Path) -> Result
         std::thread::sleep(Duration::from_millis(50));
     };
     if !status.success() {
-        bail!("engine subprocess exited without success ({status})");
+        let log = std::fs::read_to_string(log_path).unwrap_or_default();
+        let mut tail = log.lines().rev().take(20).collect::<Vec<_>>();
+        tail.reverse();
+        let detail = tail.join("\n");
+        if detail.is_empty() {
+            bail!("engine subprocess exited without success ({status})");
+        }
+        bail!("engine subprocess exited without success ({status}):\n{detail}");
     }
     let bytes =
         std::fs::read(outcome_path).with_context(|| format!("read {}", outcome_path.display()))?;
@@ -521,14 +541,17 @@ fn validate_structure_atoms(structure: &crate::domain::Structure, role: &str) ->
 }
 
 fn validate_qm_job(job: &QmJob) -> Result<()> {
-    let structure = match job {
-        QmJob::Molecular(req) => &req.structure,
-        QmJob::Periodic(req) => &req.structure,
+    if job.engine == QmEngine::Orca && matches!(job.calculation, QmCalculation::Periodic(_)) {
+        bail!("ORCA does not support periodic QM jobs");
+    }
+    let structure = match &job.calculation {
+        QmCalculation::Molecular(req) => &req.structure,
+        QmCalculation::Periodic(req) => &req.structure,
     };
     validate_structure_atoms(structure, "engine request")?;
     // A two-endpoint transition-state search carries a second (product) structure
     // over the same untrusted boundary; validate it the way the reactant is.
-    if let QmJob::Molecular(req) = job
+    if let QmCalculation::Molecular(req) = &job.calculation
         && let Some(ts) = &req.ts
         && let crate::engines::qm::QmTsGuess::TwoEndpoint(endpoints) = &ts.guess
     {
@@ -536,7 +559,7 @@ fn validate_qm_job(job: &QmJob) -> Result<()> {
     }
     // A periodic job carries a lattice; a non-finite component would corrupt the
     // reciprocal-space setup, so reject it up front the way atom coordinates are.
-    if let QmJob::Periodic(_) = job
+    if let QmCalculation::Periodic(_) = &job.calculation
         && let Some(cell) = &structure.cell
     {
         let lattice_finite = [cell.a, cell.b, cell.c, cell.alpha, cell.beta, cell.gamma]
@@ -608,6 +631,20 @@ fn run_request(
     } = request;
     match engine {
         Engine::Qm(job) => {
+            if job.engine == QmEngine::Orca {
+                let QmCalculation::Molecular(request) = job.calculation else {
+                    bail!("ORCA does not support periodic QM jobs");
+                };
+                let launch = launches
+                    .get(EngineId::ORCA)
+                    .ok_or_else(|| anyhow::anyhow!("the ORCA job carries no launch for `orca`"))?
+                    .clone();
+                let outcome =
+                    crate::engines::orca::run_orca(request, launch, cores, cancel, |stage| {
+                        progress(stage.to_string())
+                    })?;
+                return Ok(EngineOutcome::Qm(outcome));
+            }
             let result =
                 run_qm_calculation(job, cores, cancel, |QmCalculationProgress { stage }| {
                     progress(stage)

--- a/compute-core/src/wire/tests.rs
+++ b/compute-core/src/wire/tests.rs
@@ -2,7 +2,9 @@ use nalgebra::Point3;
 
 use super::*;
 use crate::domain::{Atom, Structure};
-use crate::engines::qm::{QmKind, QmMethod, QmOptions, QmOutcome, QmRequest};
+use crate::engines::qm::{
+    QmCalculation, QmEngine, QmKind, QmMethod, QmOptions, QmOutcome, QmRequest,
+};
 use crate::launch::EngineLaunch;
 
 fn builtin_request(engine: Engine) -> EngineRequest {
@@ -40,31 +42,37 @@ fn h2_single_point() -> EngineRequest {
             },
         ],
     );
-    builtin_request(Engine::Qm(QmJob::Molecular(QmRequest {
-        structure,
-        method: QmMethod::Rhf,
-        basis: "sto-3g".to_string(),
-        charge: 0,
-        multiplicity: 1,
-        kind: QmKind::SinglePoint,
-        options: QmOptions::default(),
-        ts: None,
-    })))
+    builtin_request(Engine::Qm(QmJob::molecular(
+        QmEngine::Hartree,
+        QmRequest {
+            structure,
+            method: QmMethod::Rhf,
+            basis: "sto-3g".to_string(),
+            charge: 0,
+            multiplicity: 1,
+            kind: QmKind::SinglePoint,
+            options: QmOptions::default(),
+            ts: None,
+        },
+    )))
 }
 
 #[test]
 fn validate_request_rejects_empty_nan_and_accepts_h2() {
     // Empty atoms → rejected.
-    let empty = builtin_request(Engine::Qm(QmJob::Molecular(QmRequest {
-        structure: Structure::new("empty", Vec::new()),
-        method: QmMethod::Rhf,
-        basis: "sto-3g".to_string(),
-        charge: 0,
-        multiplicity: 1,
-        kind: QmKind::SinglePoint,
-        options: QmOptions::default(),
-        ts: None,
-    })));
+    let empty = builtin_request(Engine::Qm(QmJob::molecular(
+        QmEngine::Hartree,
+        QmRequest {
+            structure: Structure::new("empty", Vec::new()),
+            method: QmMethod::Rhf,
+            basis: "sto-3g".to_string(),
+            charge: 0,
+            multiplicity: 1,
+            kind: QmKind::SinglePoint,
+            options: QmOptions::default(),
+            ts: None,
+        },
+    )));
     assert!(validate_request(&empty).is_err());
 
     // A non-finite coordinate → rejected, message names the atom index. The
@@ -86,16 +94,19 @@ fn validate_request_rejects_empty_nan_and_accepts_h2() {
         ],
     );
     nan_structure.atoms[1].position.y = f32::INFINITY;
-    let nan = builtin_request(Engine::Qm(QmJob::Molecular(QmRequest {
-        structure: nan_structure,
-        method: QmMethod::Rhf,
-        basis: "sto-3g".to_string(),
-        charge: 0,
-        multiplicity: 1,
-        kind: QmKind::SinglePoint,
-        options: QmOptions::default(),
-        ts: None,
-    })));
+    let nan = builtin_request(Engine::Qm(QmJob::molecular(
+        QmEngine::Hartree,
+        QmRequest {
+            structure: nan_structure,
+            method: QmMethod::Rhf,
+            basis: "sto-3g".to_string(),
+            charge: 0,
+            multiplicity: 1,
+            kind: QmKind::SinglePoint,
+            options: QmOptions::default(),
+            ts: None,
+        },
+    )));
     let error = validate_request(&nan).unwrap_err().to_string();
     assert!(
         error.contains("atom 1"),
@@ -133,6 +144,30 @@ fn a_gromacs_job_without_a_launch_is_rejected_at_both_ends() {
     let mut blank = EngineLaunches::new();
     blank.insert(EngineId::GROMACS, EngineLaunch::native(""));
     assert!(!blank.contains(EngineId::GROMACS));
+}
+
+#[test]
+fn an_orca_job_requires_its_configured_launch() {
+    let mut request = h2_single_point();
+    let Engine::Qm(job) = &mut request.engine else {
+        unreachable!();
+    };
+    job.engine = QmEngine::Orca;
+    let error = EngineRequest::new(request.engine.clone(), None, EngineLaunches::new())
+        .expect_err("an ORCA job needs an explicit launch")
+        .to_string();
+    assert!(error.contains("orca"));
+
+    let mut launches = EngineLaunches::new();
+    launches.insert(EngineId::ORCA, EngineLaunch::native("/opt/orca/orca"));
+    let bound = EngineRequest::new(request.engine, None, launches).expect("ORCA launch supplied");
+    let json = serde_json::to_vec(&bound).unwrap();
+    let back: EngineRequest = serde_json::from_slice(&json).unwrap();
+    assert!(back.launches.contains(EngineId::ORCA));
+    let Engine::Qm(job) = back.engine else {
+        panic!("expected QM job");
+    };
+    assert_eq!(job.engine, QmEngine::Orca);
 }
 
 /// The smallest build request that satisfies the structure validator.
@@ -173,7 +208,7 @@ fn validate_request_rejects_a_non_finite_lattice() {
         }],
         cell,
     );
-    let request = builtin_request(Engine::Qm(QmJob::Periodic(PeriodicQmRequest::new(
+    let request = builtin_request(Engine::Qm(QmJob::periodic(PeriodicQmRequest::new(
         structure,
     ))));
     let error = validate_request(&request).unwrap_err().to_string();
@@ -189,7 +224,10 @@ fn engine_request_round_trips() {
     let json = serde_json::to_vec(&request).unwrap();
     let back: EngineRequest = serde_json::from_slice(&json).unwrap();
     match back.engine {
-        Engine::Qm(QmJob::Molecular(req)) => {
+        Engine::Qm(QmJob {
+            calculation: QmCalculation::Molecular(req),
+            ..
+        }) => {
             assert_eq!(req.basis, "sto-3g");
             assert_eq!(req.structure.atoms.len(), 2);
         }
@@ -218,7 +256,10 @@ fn ts_request_round_trips_with_two_endpoint_product() {
         ],
     );
     let mut request = match h2_single_point().engine {
-        Engine::Qm(QmJob::Molecular(req)) => req,
+        Engine::Qm(QmJob {
+            calculation: QmCalculation::Molecular(req),
+            ..
+        }) => req,
         _ => unreachable!(),
     };
     request.kind = QmKind::TransitionState;
@@ -226,10 +267,14 @@ fn ts_request_round_trips_with_two_endpoint_product() {
         guess: QmTsGuess::TwoEndpoint(Box::new(QmTsEndpoints::new(product))),
         ..QmTsConfig::default()
     });
-    let wrapped = builtin_request(Engine::Qm(QmJob::Molecular(request)));
+    let wrapped = builtin_request(Engine::Qm(QmJob::molecular(QmEngine::Hartree, request)));
     let json = serde_json::to_vec(&wrapped).unwrap();
     let back: EngineRequest = serde_json::from_slice(&json).unwrap();
-    let Engine::Qm(QmJob::Molecular(req)) = back.engine else {
+    let Engine::Qm(QmJob {
+        calculation: QmCalculation::Molecular(req),
+        ..
+    }) = back.engine
+    else {
         panic!("expected a molecular QM request");
     };
     assert!(matches!(req.kind, QmKind::TransitionState));
@@ -297,13 +342,16 @@ fn periodic_request_round_trips_with_cell() {
         }],
         UnitCell::from_parameters(5.43, 5.43, 5.43, 90.0, 90.0, 90.0),
     );
-    let request = builtin_request(Engine::Qm(QmJob::Periodic(PeriodicQmRequest::new(
+    let request = builtin_request(Engine::Qm(QmJob::periodic(PeriodicQmRequest::new(
         structure,
     ))));
     let json = serde_json::to_vec(&request).unwrap();
     let back: EngineRequest = serde_json::from_slice(&json).unwrap();
     match back.engine {
-        Engine::Qm(QmJob::Periodic(req)) => {
+        Engine::Qm(QmJob {
+            calculation: QmCalculation::Periodic(req),
+            ..
+        }) => {
             assert!(req.structure.cell.is_some());
         }
         _ => panic!("expected a periodic QM request"),

--- a/compute-core/src/workflows/qm.rs
+++ b/compute-core/src/workflows/qm.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, atomic::AtomicBool};
 
 use anyhow::Result;
 
-use crate::engines::qm::{QmJob, QmOutcome, run_periodic_qm, run_qm};
+use crate::engines::qm::{QmCalculation, QmEngine, QmJob, QmOutcome, run_periodic_qm, run_qm};
 
 /// A coarse progress update (`"running scf"`, `"collecting results"`, …).
 pub struct QmCalculationProgress {
@@ -43,9 +43,12 @@ pub fn run_qm_calculation(
                 stage: stage.to_string(),
             });
         };
-        let outcome = match job {
-            QmJob::Molecular(request) => run_qm(request, cancel, &mut report)?,
-            QmJob::Periodic(request) => run_periodic_qm(request, cancel, &mut report)?,
+        if job.engine != QmEngine::Hartree {
+            anyhow::bail!("external QM jobs require an engine launch");
+        }
+        let outcome = match job.calculation {
+            QmCalculation::Molecular(request) => run_qm(request, cancel, &mut report)?,
+            QmCalculation::Periodic(request) => run_periodic_qm(request, cancel, &mut report)?,
         };
         Ok(QmCalculationResult { outcome })
     };
@@ -68,7 +71,7 @@ mod tests {
     use super::run_qm_calculation;
     use crate::{
         domain::{Atom, Structure},
-        engines::qm::{QmJob, QmKind, QmMethod, QmRequest},
+        engines::qm::{QmEngine, QmJob, QmKind, QmMethod, QmRequest},
     };
 
     #[test]
@@ -89,16 +92,19 @@ mod tests {
             ],
         );
         let result = run_qm_calculation(
-            QmJob::Molecular(QmRequest {
-                structure,
-                method: QmMethod::Rhf,
-                basis: "sto-3g".into(),
-                charge: 0,
-                multiplicity: 1,
-                kind: QmKind::SinglePoint,
-                options: Default::default(),
-                ts: None,
-            }),
+            QmJob::molecular(
+                QmEngine::Hartree,
+                QmRequest {
+                    structure,
+                    method: QmMethod::Rhf,
+                    basis: "sto-3g".into(),
+                    charge: 0,
+                    multiplicity: 1,
+                    kind: QmKind::SinglePoint,
+                    options: Default::default(),
+                    ts: None,
+                },
+            ),
             Some(2),
             Default::default(),
             |_progress| {},
@@ -127,19 +133,22 @@ mod tests {
 
         let mut stages = Vec::new();
         let result = run_qm_calculation(
-            QmJob::Molecular(QmRequest {
-                structure,
-                method: QmMethod::Rhf,
-                basis: "sto-3g".to_string(),
-                charge: 0,
-                multiplicity: 1,
-                kind: QmKind::SinglePoint,
-                options: crate::engines::qm::QmOptions {
-                    compute_properties: true,
-                    ..Default::default()
+            QmJob::molecular(
+                QmEngine::Hartree,
+                QmRequest {
+                    structure,
+                    method: QmMethod::Rhf,
+                    basis: "sto-3g".to_string(),
+                    charge: 0,
+                    multiplicity: 1,
+                    kind: QmKind::SinglePoint,
+                    options: crate::engines::qm::QmOptions {
+                        compute_properties: true,
+                        ..Default::default()
+                    },
+                    ts: None,
                 },
-                ts: None,
-            }),
+            ),
             None,
             Default::default(),
             |progress| stages.push(progress.stage),

--- a/compute-core/tests/remote_direct.rs
+++ b/compute-core/tests/remote_direct.rs
@@ -17,7 +17,7 @@
 //! (parity is bounded, never bit-for-bit).
 
 use compute_core::domain::{Atom, Structure};
-use compute_core::engines::qm::{QmJob, QmKind, QmMethod, QmOptions, QmRequest};
+use compute_core::engines::qm::{QmEngine, QmJob, QmKind, QmMethod, QmOptions, QmRequest};
 use compute_core::engines::remote::launcher::{Launcher, RemoteExecution};
 use compute_core::engines::remote::{RemoteTarget, deploy};
 use compute_core::hosts::RemoteHost;
@@ -43,16 +43,19 @@ fn h2_single_point() -> EngineRequest {
         ],
     );
     EngineRequest::builtin(
-        Engine::Qm(QmJob::Molecular(QmRequest {
-            structure,
-            method: QmMethod::Rhf,
-            basis: "sto-3g".to_string(),
-            charge: 0,
-            multiplicity: 1,
-            kind: QmKind::SinglePoint,
-            options: QmOptions::default(),
-            ts: None,
-        })),
+        Engine::Qm(QmJob::molecular(
+            QmEngine::Hartree,
+            QmRequest {
+                structure,
+                method: QmMethod::Rhf,
+                basis: "sto-3g".to_string(),
+                charge: 0,
+                multiplicity: 1,
+                kind: QmKind::SinglePoint,
+                options: QmOptions::default(),
+                ts: None,
+            },
+        )),
         None,
     )
 }

--- a/compute-core/tests/remote_slurm.rs
+++ b/compute-core/tests/remote_slurm.rs
@@ -5,7 +5,7 @@
 use std::time::{Duration, Instant};
 
 use compute_core::domain::{Atom, Structure};
-use compute_core::engines::qm::{QmJob, QmKind, QmMethod, QmOptions, QmRequest};
+use compute_core::engines::qm::{QmEngine, QmJob, QmKind, QmMethod, QmOptions, QmRequest};
 use compute_core::engines::remote::launcher::{
     Launcher, RemoteJobPhase, detect_slurm, retrieve_outcome,
 };
@@ -31,16 +31,19 @@ fn request() -> EngineRequest {
         ],
     );
     EngineRequest::builtin(
-        Engine::Qm(QmJob::Molecular(QmRequest {
-            structure,
-            method: QmMethod::Rhf,
-            basis: "sto-3g".to_string(),
-            charge: 0,
-            multiplicity: 1,
-            kind: QmKind::SinglePoint,
-            options: QmOptions::default(),
-            ts: None,
-        })),
+        Engine::Qm(QmJob::molecular(
+            QmEngine::Hartree,
+            QmRequest {
+                structure,
+                method: QmMethod::Rhf,
+                basis: "sto-3g".to_string(),
+                charge: 0,
+                multiplicity: 1,
+                kind: QmKind::SinglePoint,
+                options: QmOptions::default(),
+                ts: None,
+            },
+        )),
         None,
     )
 }

--- a/docs-site/src/content/docs/getting-started/external-tools.md
+++ b/docs-site/src/content/docs/getting-started/external-tools.md
@@ -8,6 +8,28 @@ sidebar:
 SilicoLab can launch without optional external tools. Install these programs
 only when you need the features that call them.
 
+## ORCA
+
+The built-in Hartree engine is the default for quantum chemistry. ORCA is
+an optional alternative for molecular single-point energies, geometry
+optimizations, and vibrational frequencies. Transition-state and periodic QM
+calculations currently use Hartree.
+
+Install ORCA separately, then open **Settings > Compute targets**. In the ORCA
+row for **This machine**, enter the executable path and select **Verify**.
+SilicoLab deliberately does not search for ORCA or choose it automatically.
+
+For ORCA inside WSL on Windows, set **Command prefix** to `wsl.exe -e` and set
+**Program** to the executable's Linux path, such as `/opt/orca/orca`. For a
+native installation, leave the command prefix empty. Select ORCA explicitly in
+the QM task panel or use `qm energy --engine orca` in a script.
+
+ORCA starts with one CPU core. Requesting more cores enables ORCA's `%pal`
+parallel mode and requires `mpirun` to be available in the target environment.
+
+Remote hosts have their own ORCA program setting. Enter a path valid on that
+host; a local path is never copied to a remote target.
+
 ## GROMACS
 
 Molecular dynamics simulations require

--- a/docs-site/src/content/docs/getting-started/installation.md
+++ b/docs-site/src/content/docs/getting-started/installation.md
@@ -30,7 +30,10 @@ SilicoLab works without them until you use the corresponding feature.
 
 - **GROMACS** — required for molecular dynamics simulations.
 
-Quantum chemistry is available through the built-in Hartree engine.
+ORCA is an optional external engine for molecular single-point energies,
+geometry optimizations, and vibrational frequencies. Quantum chemistry uses
+the built-in Hartree engine by default; ORCA is never required or selected
+automatically.
 
 See [External tools](./external-tools/) for setup notes, including GPU
 acceleration. See [Remote execution](./remote-execution/) to run heavy jobs on

--- a/docs-site/src/content/docs/getting-started/remote-execution.md
+++ b/docs-site/src/content/docs/getting-started/remote-execution.md
@@ -98,3 +98,5 @@ Slurm target. Allocation state and pending reason belong in the task monitor.
   cluster** and check that the selected partition contains that GRES type.
 - **GROMACS is missing:** add the appropriate module or environment command to
   **Job environment commands**, then use **Detect GROMACS**.
+- **ORCA is not configured:** enter the ORCA executable path for that remote
+  host under **Compute targets**. ORCA is not auto-detected.

--- a/docs-site/src/content/docs/zh/getting-started/external-tools.md
+++ b/docs-site/src/content/docs/zh/getting-started/external-tools.md
@@ -8,6 +8,20 @@ sidebar:
 SilicoLab 在没有可选外部工具时也可以启动。只有在使用对应功能时，才需要安装
 这些程序。
 
+## ORCA
+
+量子化学计算默认使用内置 Hartree 引擎。ORCA 是可选引擎，首版支持分子体系的
+单点能、几何优化和振动频率计算；过渡态与周期 QM 计算仅支持 Hartree。
+
+请单独安装 ORCA，然后打开 **设置 > 计算目标**，在本机或远程主机的 ORCA 行中
+填写该目标可用的可执行文件路径，再点击 **验证**。SilicoLab 不会自动搜索或选择
+ORCA。在 Windows 中使用 WSL 版 ORCA 时，将命令前缀设为 `wsl.exe -e`，程序填写
+WSL 内的通用 Linux 路径，例如 `/opt/orca/orca`；原生安装则将命令前缀留空。
+
+在 QM 任务面板中显式选择 ORCA，或在脚本中使用 `qm energy --engine orca`。
+ORCA 默认使用一个 CPU 核心；请求更多核心会启用 `%pal` 并行模式，并要求目标
+环境中能够调用 `mpirun`。
+
 ## GROMACS
 
 分子动力学模拟需要单独安装 [GROMACS](https://www.gromacs.org/)。

--- a/docs-site/src/content/docs/zh/getting-started/installation.md
+++ b/docs-site/src/content/docs/zh/getting-started/installation.md
@@ -28,7 +28,8 @@ Windows 下为 `silicolab.exe`）。
 
 - **GROMACS** —— 运行分子动力学模拟时必需。
 
-SilicoLab 已内置 Hartree 引擎，可用于量子化学计算。
+量子化学计算默认使用内置 Hartree 引擎。ORCA 可作为分子单点能、几何优化和
+振动频率计算的可选外部引擎，必须由用户指定可执行文件路径。
 
 请阅读[外部工具](./external-tools/)了解配置说明，包括 GPU 加速。
 如需通过 SSH 在远程 Linux 主机上运行大型任务，请阅读[远程执行](./remote-execution/)。

--- a/docs/developing-remote-execution.md
+++ b/docs/developing-remote-execution.md
@@ -80,7 +80,8 @@ The remote machine must run **x86_64 Linux** and accept passwordless login
 through SilicoLab's host-key-verified SSH configuration. ARM64/aarch64 hosts are
 not supported by this worker. The remote machine needs no Rust toolchain,
 container runtime, source checkout, compiler, or operating-system changes.
-GROMACS jobs still require a working `gmx` on the remote host; QM and docking do
+GROMACS jobs require a working `gmx` on the remote host, while ORCA-backed QM
+jobs require the configured ORCA executable; built-in QM and docking do
 not.
 
 ## Standard workflows

--- a/src/backend/engine_launch.rs
+++ b/src/backend/engine_launch.rs
@@ -48,6 +48,9 @@ impl LaunchTarget<'_> {
     /// Resolve an unconfigured launch. Local discovery never starts the engine;
     /// remote discovery runs in the remote submission worker and verifies it.
     fn resolve_unconfigured(&self, spec: &EngineSpec) -> Option<(EngineLaunch, Option<String>)> {
+        if spec.requires_configured_path {
+            return None;
+        }
         match self {
             Self::Local(_) => {
                 crate::engines::registry::local_launch_candidate(spec).map(|launch| (launch, None))
@@ -62,6 +65,9 @@ impl LaunchTarget<'_> {
 
     /// Find a verified launch for an explicit Verify action.
     fn probe_verified(&self, spec: &EngineSpec) -> Option<(EngineLaunch, String)> {
+        if spec.requires_configured_path {
+            return None;
+        }
         match self {
             Self::Local(_) => crate::engines::registry::probe_local(spec),
             Self::Remote(host) => {
@@ -161,6 +167,13 @@ fn launch_spec(id: EngineId) -> Result<&'static EngineSpec> {
 }
 
 fn not_found_message(target: &LaunchTarget<'_>, spec: &EngineSpec) -> String {
+    if spec.requires_configured_path {
+        return format!(
+            "{} requires a user-specified program path in Settings -> Compute targets for {}.",
+            spec.name,
+            target.describe()
+        );
+    }
     let first = spec.candidate_executables.first().copied().unwrap_or("it");
     match target {
         LaunchTarget::Local(_) => format!(

--- a/src/frontend/agent/loop_driver/heavy.rs
+++ b/src/frontend/agent/loop_driver/heavy.rs
@@ -8,7 +8,6 @@ use crate::frontend::agent::session::{AssistantConversationId, PendingTurn, Tran
 use crate::frontend::jobs::{
     AgentHeavyJob, DockingWorkerMessage, EngineWorkerMessage, QmWorkerMessage, RunningDockingJob,
     RunningEngineJob, RunningQmJob, TrackedAgentJob, spawn_docking_job, spawn_gromacs_pipeline_job,
-    spawn_qm_job,
 };
 use crate::frontend::state::AppState;
 use crate::io::llm::types::ToolCall;
@@ -154,10 +153,20 @@ pub fn spawn_heavy(state: &mut AppState, call: &ToolCall, kind: HeavyKind, ctx: 
 
     let spawned: Result<AgentHeavyJob, String> = match kind {
         HeavyKind::Qm => crate::frontend::qm_commands::build_agent_qm_request(state, args)
-            .map(|request| {
-                AgentHeavyJob::Qm(spawn_qm_job(
-                    crate::engines::qm::QmJob::Molecular(request),
-                    None,
+            .and_then(|job| {
+                let mut launches = crate::engines::registry::EngineLaunches::new();
+                if job.engine == crate::engines::qm::QmEngine::Orca {
+                    let launch = crate::backend::engine_launch::resolve_engine_launch(
+                        crate::backend::engine_launch::LaunchTarget::Local(
+                            &state.config.engine_overrides,
+                        ),
+                        crate::engines::registry::EngineId::ORCA,
+                    )?
+                    .launch;
+                    launches.insert(crate::engines::registry::EngineId::ORCA, launch);
+                }
+                Ok(AgentHeavyJob::Qm(
+                    crate::frontend::jobs::spawn_qm_job_with_launches(job, None, launches)?,
                 ))
             })
             .map_err(|error| error.to_string()),

--- a/src/frontend/agent/tools.rs
+++ b/src/frontend/agent/tools.rs
@@ -13,7 +13,7 @@ use std::fmt::Write;
 use serde_json::{Value, json};
 
 use crate::backend::config::ApprovalMode;
-use crate::engines::registry::{EngineId, EngineRegistry, EngineStatus};
+use crate::engines::registry::{EngineRegistry, EngineStatus, external_engine_specs};
 use crate::frontend::console::{RiskLevel, command_risk};
 use crate::frontend::state::AppState;
 use crate::io::llm::types::{ToolCall, ToolDef};
@@ -657,16 +657,23 @@ pub fn inspect(state: &AppState, _query: Option<&str>) -> String {
     }
 
     let registry = EngineRegistry::probe(&state.config.engine_overrides);
-    let _ = writeln!(
-        out,
-        "engines: GROMACS {}",
-        match registry.status(EngineId::GROMACS) {
-            Some(EngineStatus::Verified { version, .. }) => format!("{version} (verified)"),
-            Some(EngineStatus::Unverified { launch }) =>
-                format!("configured at {}, not verified", launch.display_command()),
-            _ => "not configured".to_string(),
-        }
-    );
+    let engines = external_engine_specs()
+        .iter()
+        .map(|spec| {
+            let status = match registry.status(spec.id) {
+                Some(EngineStatus::Verified { version, .. }) => {
+                    format!("{version} (verified)")
+                }
+                Some(EngineStatus::Unverified { launch }) => {
+                    format!("configured at {}, not verified", launch.display_command())
+                }
+                _ => "not configured".to_string(),
+            };
+            format!("{} {status}", spec.name)
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    let _ = writeln!(out, "engines: {engines}");
 
     let running_jobs = crate::frontend::jobs::list_controlled_jobs(state)
         .into_iter()

--- a/src/frontend/dispatcher/builders/qm.rs
+++ b/src/frontend/dispatcher/builders/qm.rs
@@ -81,7 +81,10 @@ pub(crate) fn start_pending_qm(state: &mut AppState) {
             return;
         }
     }
-    if !prompt.periodic && resolve_remote_host(state, &prompt.prefs.target).is_none() {
+    if prompt.engine == crate::engines::qm::QmEngine::Hartree
+        && !prompt.periodic
+        && resolve_remote_host(state, &prompt.prefs.target).is_none()
+    {
         let request = prompt.to_request(state.structure().clone(), ts_product.clone());
         let verdict = memory_verdict(&request, crate::backend::hardware::qm_incore_budget_bytes());
         if let Some(notification) = qm_memory_notification(&verdict, "this machine") {
@@ -91,6 +94,21 @@ pub(crate) fn start_pending_qm(state: &mut AppState) {
     }
     let job = prompt.to_job(state.structure().clone(), ts_product);
     let remote_host = resolve_remote_host(state, &prompt.prefs.target);
+    let mut local_launches = crate::engines::registry::EngineLaunches::new();
+    if remote_host.is_none() && prompt.engine == crate::engines::qm::QmEngine::Orca {
+        let resolved = crate::backend::engine_launch::resolve_engine_launch(
+            crate::backend::engine_launch::LaunchTarget::Local(&state.config.engine_overrides),
+            crate::engines::registry::EngineId::ORCA,
+        );
+        let Ok(resolved) = resolved else {
+            state.set_message(
+                "set the ORCA program path in Settings -> Compute targets before running"
+                    .to_string(),
+            );
+            return;
+        };
+        local_launches.insert(crate::engines::registry::EngineId::ORCA, resolved.launch);
+    }
     state.set_source_path(None);
     state.ui.editor = None;
     state.ui.pending_qm = None;
@@ -100,7 +118,18 @@ pub(crate) fn start_pending_qm(state: &mut AppState) {
         Some(host) => start_remote_qm(state, job, host, prompt.prefs.job_resources()),
         None => {
             reserve_qm_run_dir(state);
-            let running = spawn_qm_job(job, Some(qm_thread_count(state, &prompt.prefs)));
+            let running = crate::frontend::jobs::spawn_qm_job_with_launches(
+                job,
+                Some(qm_thread_count(state, &prompt.prefs)),
+                local_launches,
+            );
+            let running = match running {
+                Ok(running) => running,
+                Err(error) => {
+                    state.set_message(format!("could not bind the QM engine launch: {error}"));
+                    return;
+                }
+            };
             state.jobs.set_qm(running);
             if let Some(task_run_id) = state.active_task_run {
                 state.tasks.mark_status(task_run_id, TaskStatus::Running);

--- a/src/frontend/dispatcher/mod.rs
+++ b/src/frontend/dispatcher/mod.rs
@@ -30,7 +30,7 @@ use crate::{
             EngineWorkerMessage, GromacsPipelineRequest, OptimizationWorkerMessage,
             QmWorkerMessage, engine_poll_frame, optimization_finished_message,
             request_next_optimization_poll, spawn_gromacs_build_job, spawn_gromacs_pipeline_job,
-            spawn_optimization_job, spawn_qm_job, spawn_self_update, spawn_update_check,
+            spawn_optimization_job, spawn_self_update, spawn_update_check,
         },
         md_support::{
             gromacs_topology_path_for_entry, load_md_topology_for_entry, write_md_system_context,

--- a/src/frontend/jobs/qm.rs
+++ b/src/frontend/jobs/qm.rs
@@ -23,14 +23,28 @@ pub enum QmWorkerMessage {
 /// thread and return the live handle. The worker streams coarse stage updates,
 /// then a `Finished` outcome or `Failed` error. Caller stores the handle in
 /// [`JobManager`].
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn spawn_qm_job(job: QmJob, threads: Option<usize>) -> RunningQmJob {
+    spawn_qm_job_with_launches(
+        job,
+        threads,
+        crate::engines::registry::EngineLaunches::new(),
+    )
+    .expect("built-in QM job does not require an external launch")
+}
+
+pub fn spawn_qm_job_with_launches(
+    job: QmJob,
+    threads: Option<usize>,
+    launches: crate::engines::registry::EngineLaunches,
+) -> anyhow::Result<RunningQmJob> {
     let executor = if cfg!(test) {
         Executor::InProcess
     } else {
         Executor::LocalSubprocess
     };
-    // hartree is built in: a QM job needs no external launch.
-    let running = run_job(EngineRequest::builtin(Engine::Qm(job), threads), executor);
+    let request = EngineRequest::new(Engine::Qm(job), threads, launches)?;
+    let running = run_job(request, executor);
     // Production runs QM in a subprocess so Cancel can kill an opaque hartree
     // calculation without requiring in-process preemption hooks. Tests keep the
     // in-process path because Rust's test harness is not the self-exec worker.
@@ -54,10 +68,10 @@ pub fn spawn_qm_job(job: QmJob, threads: Option<usize>) -> RunningQmJob {
         }
     });
 
-    RunningQmJob {
+    Ok(RunningQmJob {
         cancel,
         receiver,
         latest_stage: None,
         cancel_requested: false,
-    }
+    })
 }

--- a/src/frontend/qm_commands.rs
+++ b/src/frontend/qm_commands.rs
@@ -9,9 +9,9 @@
 //!   geometry, a reactant→product pair (`--product`), or a driven coordinate
 //!   (`--scan-bond`/`--scan-angle`/`--scan-dihedral`).
 //!
-//! All run synchronously via [`crate::engines::qm`] (pure-Rust hartree), which
-//! suits headless `.sls`/CLI use and small molecules; the GUI drives the same
-//! engine on a worker thread so long calculations don't block rendering.
+//! Commands run synchronously for headless `.sls`/CLI use; the GUI drives the
+//! same selected backend on a worker thread so long calculations do not block
+//! rendering.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, atomic::AtomicBool};
@@ -20,10 +20,10 @@ use anyhow::{Result, anyhow, bail};
 
 use crate::{
     engines::qm::{
-        CpcmDielectric, KMesh, PeriodicFunctional, PeriodicQmRequest, QmDispersion,
-        QmInternalCoordinate, QmJob, QmKind, QmMethod, QmOptions, QmRequest, QmScfBackend,
-        QmSolvation, QmTsAlgorithm, QmTsConfig, QmTsCoordinateScan, QmTsCoordinates, QmTsEndpoints,
-        QmTsGuess, periodic,
+        CpcmDielectric, KMesh, PeriodicFunctional, PeriodicQmRequest, QmCalculation, QmDispersion,
+        QmEngine, QmInternalCoordinate, QmJob, QmKind, QmMethod, QmOptions, QmRequest,
+        QmScfBackend, QmSolvation, QmTsAlgorithm, QmTsConfig, QmTsCoordinateScan, QmTsCoordinates,
+        QmTsEndpoints, QmTsGuess, periodic,
     },
     frontend::state::AppState,
     io::structure_paths::default_structure_save_path,
@@ -36,6 +36,7 @@ pub fn qm_command(state: &mut AppState, args: &[String]) -> Result<String> {
         bail!(
             "usage: qm <energy|optimize|freq|ts|periodic> [options]\n\
              \n\
+             engine:   --engine hartree|orca   (default: hartree; ORCA path must be configured)\n\
              core:     --method <m>   hf|rhf|uhf|rohf|mp2|ccsd|ccsd(t), a functional \
              (pbe, b3lyp, r2scan, wb97m-v, b2plyp, …) with an optional -d3/-d4 suffix, \
              or a composite (r2scan-3c, b97-3c, pbeh-3c, b3lyp-3c)\n\
@@ -110,11 +111,42 @@ fn qm_recommend(args: &[String]) -> Result<String> {
 /// Assemble a [`QmRequest`] from the active structure and parsed `--flags`.
 /// Shared by the synchronous `run` and the agent's async `run_qm` tool so the two
 /// build the exact same request.
-fn assemble_qm_request(state: &AppState, kind: QmKind, args: &[String]) -> Result<QmRequest> {
+fn assemble_qm_job(state: &AppState, kind: QmKind, args: &[String]) -> Result<QmJob> {
     if state.structure().atoms.is_empty() {
         bail!("no active structure; open one before `qm`");
     }
     let flags = QmFlags::parse(args)?;
+    let engine = match flags.str("engine") {
+        None | Some("hartree") => QmEngine::Hartree,
+        Some("orca") => QmEngine::Orca,
+        Some(other) => bail!("--engine must be hartree or orca, got `{other}`"),
+    };
+    if engine == QmEngine::Orca && kind == QmKind::TransitionState {
+        bail!("ORCA support currently covers energy, optimize, and freq only");
+    }
+    if engine == QmEngine::Orca {
+        for option in [
+            "direct",
+            "ri",
+            "cosx",
+            "ri-mp2",
+            "x2c",
+            "all-electron",
+            "grid",
+            "smear",
+            "fod",
+            "sph",
+            "symmetry-number",
+            "qrrho-w0",
+            "alpb",
+            "gbsa",
+            "properties",
+        ] {
+            if flags.flag(option) || flags.str(option).is_some() {
+                bail!("--{option} is available only with the Hartree engine");
+            }
+        }
+    }
     let (method, suffix_dispersion) = flags
         .str("method")
         .map(QmMethod::parse)
@@ -128,16 +160,19 @@ fn assemble_qm_request(state: &AppState, kind: QmKind, args: &[String]) -> Resul
     } else {
         None
     };
-    Ok(QmRequest {
-        structure: state.structure().clone(),
-        method,
-        basis,
-        charge,
-        multiplicity,
-        kind,
-        options,
-        ts,
-    })
+    Ok(QmJob::molecular(
+        engine,
+        QmRequest {
+            structure: state.structure().clone(),
+            method,
+            basis,
+            charge,
+            multiplicity,
+            kind,
+            options,
+            ts,
+        },
+    ))
 }
 
 /// Assemble the [`QmTsConfig`] for a `qm ts` run from parsed flags. The guess
@@ -257,7 +292,7 @@ fn parse_scan_coordinate(flags: &QmFlags) -> Result<Option<QmInternalCoordinate>
 
 /// Map a `qm <subcommand>` line (subcommand + flags) to a [`QmRequest`] for the
 /// agent's async tool. Mirrors [`qm_command`]'s subcommand dispatch.
-pub fn build_agent_qm_request(state: &AppState, args: &[String]) -> Result<QmRequest> {
+pub fn build_agent_qm_request(state: &AppState, args: &[String]) -> Result<QmJob> {
     let Some(sub) = args.first().map(String::as_str) else {
         bail!("usage: qm <energy|optimize|freq> [options]");
     };
@@ -270,7 +305,7 @@ pub fn build_agent_qm_request(state: &AppState, args: &[String]) -> Result<QmReq
             bail!("unknown qm subcommand `{other}` (expected energy, optimize, freq, or ts)")
         }
     };
-    assemble_qm_request(state, kind, &args[1..])
+    assemble_qm_job(state, kind, &args[1..])
 }
 
 fn kind_keyword(kind: QmKind) -> &'static str {
@@ -283,16 +318,19 @@ fn kind_keyword(kind: QmKind) -> &'static str {
 }
 
 fn run(state: &mut AppState, kind: QmKind, args: &[String]) -> Result<String> {
-    let request = assemble_qm_request(state, kind, args)?;
+    let job = assemble_qm_job(state, kind, args)?;
+    let QmCalculation::Molecular(request) = &job.calculation else {
+        unreachable!("molecular command built a periodic job");
+    };
 
     // Reject in-core jobs whose ERI tensor would blow the RAM budget before we
     // start allocating. Periodic runs go through run_periodic_command and are
     // exempt (no nao⁴ in-core tensor).
     let budget = crate::backend::hardware::qm_incore_budget_bytes();
-    let verdict = crate::engines::qm::memory_verdict(&request, budget);
-    match &verdict {
-        crate::engines::qm::MemoryVerdict::Ok => {}
-        crate::engines::qm::MemoryVerdict::ExceedsCanDirect { .. } => {
+    let verdict = crate::engines::qm::memory_verdict(request, budget);
+    match (&job.engine, &verdict) {
+        (QmEngine::Orca, _) | (_, crate::engines::qm::MemoryVerdict::Ok) => {}
+        (_, crate::engines::qm::MemoryVerdict::ExceedsCanDirect { .. }) => {
             bail!(
                 "{} Re-run `qm {}` with --direct (integral-direct SCF) or --ri, \
                  or choose a smaller basis.",
@@ -300,7 +338,7 @@ fn run(state: &mut AppState, kind: QmKind, args: &[String]) -> Result<String> {
                 kind_keyword(kind),
             );
         }
-        crate::engines::qm::MemoryVerdict::ExceedsMustReduce { .. } => {
+        (_, crate::engines::qm::MemoryVerdict::ExceedsMustReduce { .. }) => {
             bail!(
                 "{} This calculation type needs in-core integrals; choose a smaller \
                  basis set or a smaller system.",
@@ -311,13 +349,24 @@ fn run(state: &mut AppState, kind: QmKind, args: &[String]) -> Result<String> {
 
     // Synchronous: a throwaway cancel flag and a no-op progress sink.
     let cancel = Arc::new(AtomicBool::new(false));
-    let result = run_qm_calculation(
-        QmJob::Molecular(request),
-        Some(state.config.compute_core_count.max(1)),
-        cancel,
-        |_| {},
-    )?;
-    let outcome = result.outcome;
+    let cores = Some(match job.engine {
+        QmEngine::Hartree => state.config.compute_core_count.max(1),
+        QmEngine::Orca => 1,
+    });
+    let outcome = match job.engine {
+        QmEngine::Hartree => run_qm_calculation(job, cores, cancel, |_| {})?.outcome,
+        QmEngine::Orca => {
+            let launch = crate::backend::engine_launch::resolve_engine_launch(
+                crate::backend::engine_launch::LaunchTarget::Local(&state.config.engine_overrides),
+                crate::engines::registry::EngineId::ORCA,
+            )?
+            .launch;
+            let QmCalculation::Molecular(request) = job.calculation else {
+                unreachable!("ORCA command built a periodic job");
+            };
+            crate::engines::orca::run_orca(request, launch, cores, cancel, |_| {})?
+        }
+    };
 
     // A QM run is a heavy calculation; surface its optimized geometry as a new
     // entry (the original is preserved), matching the GUI task and MD commands.
@@ -337,7 +386,7 @@ fn run_periodic_command(state: &mut AppState, args: &[String]) -> Result<String>
     let request = assemble_periodic_request(state, args)?;
     let cancel = Arc::new(AtomicBool::new(false));
     let result = run_qm_calculation(
-        QmJob::Periodic(request),
+        QmJob::periodic(request),
         Some(state.config.compute_core_count.max(1)),
         cancel,
         |_| {},

--- a/src/frontend/qm_commands/tests.rs
+++ b/src/frontend/qm_commands/tests.rs
@@ -30,6 +30,13 @@ fn water() -> Structure {
     )
 }
 
+fn molecular(job: crate::engines::qm::QmJob) -> crate::engines::qm::QmRequest {
+    match job.calculation {
+        crate::engines::qm::QmCalculation::Molecular(request) => request,
+        crate::engines::qm::QmCalculation::Periodic(_) => panic!("expected molecular QM job"),
+    }
+}
+
 #[test]
 fn qm_recommend_reports_a_level_of_theory() {
     let mut state = AppState::scratch(Default::default(), Vec::new());
@@ -92,7 +99,7 @@ fn build_agent_qm_request_maps_subcommands() {
     let save_path = default_structure_save_path(&water(), None);
     state.entries.add_entry(water(), None, save_path);
 
-    let request = super::build_agent_qm_request(
+    let job = super::build_agent_qm_request(
         &state,
         &[
             "optimize".to_string(),
@@ -101,6 +108,7 @@ fn build_agent_qm_request_maps_subcommands() {
         ],
     )
     .expect("agent qm request should build");
+    let request = molecular(job);
     assert!(matches!(request.kind, super::QmKind::Optimize));
     assert_eq!(request.basis, "sto-3g");
     // Unknown subcommand is rejected.
@@ -114,21 +122,23 @@ fn qm_ts_subcommand_builds_a_coordinate_scan() {
     let save_path = default_structure_save_path(&water(), None);
     state.entries.add_entry(water(), None, save_path);
 
-    let request = super::build_agent_qm_request(
-        &state,
-        &[
-            "ts".to_string(),
-            "--scan-bond".to_string(),
-            "1,3".to_string(),
-            "--scan-from".to_string(),
-            "0.9".to_string(),
-            "--scan-to".to_string(),
-            "1.6".to_string(),
-            "--basis".to_string(),
-            "sto-3g".to_string(),
-        ],
-    )
-    .expect("qm ts coordinate scan should build");
+    let request = molecular(
+        super::build_agent_qm_request(
+            &state,
+            &[
+                "ts".to_string(),
+                "--scan-bond".to_string(),
+                "1,3".to_string(),
+                "--scan-from".to_string(),
+                "0.9".to_string(),
+                "--scan-to".to_string(),
+                "1.6".to_string(),
+                "--basis".to_string(),
+                "sto-3g".to_string(),
+            ],
+        )
+        .expect("qm ts coordinate scan should build"),
+    );
     assert!(matches!(request.kind, super::QmKind::TransitionState));
     match request.ts.expect("ts config").guess {
         QmTsGuess::CoordinateScan(scan) => {
@@ -139,15 +149,17 @@ fn qm_ts_subcommand_builds_a_coordinate_scan() {
     }
 
     // A bare `qm ts` is a single-guess search from the current geometry.
-    let single = super::build_agent_qm_request(
-        &state,
-        &[
-            "ts".to_string(),
-            "--basis".to_string(),
-            "sto-3g".to_string(),
-        ],
-    )
-    .expect("bare qm ts should build");
+    let single = molecular(
+        super::build_agent_qm_request(
+            &state,
+            &[
+                "ts".to_string(),
+                "--basis".to_string(),
+                "sto-3g".to_string(),
+            ],
+        )
+        .expect("bare qm ts should build"),
+    );
     assert!(matches!(
         single.ts.expect("ts config").guess,
         QmTsGuess::Single
@@ -163,7 +175,7 @@ fn agent_qm_request_runs_off_thread() {
     let save_path = default_structure_save_path(&water(), None);
     state.entries.add_entry(water(), None, save_path);
 
-    let request = super::build_agent_qm_request(
+    let job = super::build_agent_qm_request(
         &state,
         &[
             "energy".to_string(),
@@ -177,7 +189,7 @@ fn agent_qm_request_runs_off_thread() {
 
     // Spawn the same job the agent's heavy path uses and poll it to
     // completion, exactly as `poll_heavy_qm` does (minus the agent loop).
-    let job = spawn_qm_job(crate::engines::qm::QmJob::Molecular(request), None);
+    let job = spawn_qm_job(job, None);
     let deadline = Instant::now() + Duration::from_secs(120);
     let mut summary = None;
     while Instant::now() < deadline {

--- a/src/frontend/remote_jobs.rs
+++ b/src/frontend/remote_jobs.rs
@@ -144,7 +144,10 @@ fn remote_qm_memory_rejection(verdict: &MemoryVerdict, host_label: &str) -> Opti
 fn engine_id_token(engine: &crate::wire::Engine) -> &'static str {
     use crate::engines::registry::EngineId;
     match engine {
-        crate::wire::Engine::Qm(_) => EngineId::HARTREE.as_str(),
+        crate::wire::Engine::Qm(job) => match job.engine {
+            crate::engines::qm::QmEngine::Hartree => EngineId::HARTREE.as_str(),
+            crate::engines::qm::QmEngine::Orca => EngineId::ORCA.as_str(),
+        },
         crate::wire::Engine::Docking(_) => EngineId::DOCKING.as_str(),
         crate::wire::Engine::Gromacs(_) => EngineId::GROMACS.as_str(),
     }
@@ -191,7 +194,10 @@ pub fn spawn_remote_submit(
             // than left to OOM mid-SCF on the node. Only in-core molecular QM has
             // this tensor; every other engine (and periodic QM) skips the guard,
             // as does a host whose RAM we could not probe (falling open).
-            if let Engine::Qm(QmJob::Molecular(request)) = &engine
+            if let Engine::Qm(QmJob {
+                engine: crate::engines::qm::QmEngine::Hartree,
+                calculation: crate::engines::qm::QmCalculation::Molecular(request),
+            }) = &engine
                 && let Some(ram) = resources
                     .memory_mib
                     .map(|mib| mib.saturating_mul(1024 * 1024))

--- a/src/frontend/remote_jobs/tests/e2e.rs
+++ b/src/frontend/remote_jobs/tests/e2e.rs
@@ -202,7 +202,7 @@ fn argon_em_job() -> Engine {
 #[ignore = "requires an SSH host (set SILICOLAB_TEST_SSH_HOST)"]
 fn remote_qm_submit_then_refresh_against_ssh_host() {
     use crate::domain::{Atom, Structure};
-    use crate::engines::qm::{QmJob, QmKind, QmMethod, QmOptions, QmRequest};
+    use crate::engines::qm::{QmEngine, QmJob, QmKind, QmMethod, QmOptions, QmRequest};
     use nalgebra::Point3;
 
     let Some(host) = test_host(EngineLaunches::new()) else {
@@ -224,16 +224,19 @@ fn remote_qm_submit_then_refresh_against_ssh_host() {
             },
         ],
     );
-    let job = Engine::Qm(QmJob::Molecular(QmRequest {
-        structure,
-        method: QmMethod::Rhf,
-        basis: "sto-3g".to_string(),
-        charge: 0,
-        multiplicity: 1,
-        kind: QmKind::SinglePoint,
-        options: QmOptions::default(),
-        ts: None,
-    }));
+    let job = Engine::Qm(QmJob::molecular(
+        QmEngine::Hartree,
+        QmRequest {
+            structure,
+            method: QmMethod::Rhf,
+            basis: "sto-3g".to_string(),
+            charge: 0,
+            multiplicity: 1,
+            kind: QmKind::SinglePoint,
+            options: QmOptions::default(),
+            ts: None,
+        },
+    ));
     let resources = JobResources {
         cpus_per_task: Some(1),
         ..Default::default()

--- a/src/frontend/state/qm_prompts.rs
+++ b/src/frontend/state/qm_prompts.rs
@@ -192,6 +192,7 @@ impl TsPromptForm {
 /// User-editable configuration for a quantum-chemistry (hartree) calculation.
 #[derive(Debug, Clone)]
 pub struct QmPrompt {
+    pub engine: crate::engines::qm::QmEngine,
     pub method: crate::engines::qm::QmMethod,
     /// Free-text functional name backing the "custom functional" field. When the
     /// method dropdown selects "Custom functional…", the panel reads this into
@@ -278,6 +279,7 @@ impl QmPrompt {
             QmKind::Optimize | QmKind::Frequencies | QmKind::TransitionState => "def2-svp",
         };
         Self {
+            engine: crate::engines::qm::QmEngine::Hartree,
             method: QmMethod::Dft("b3lyp".to_string()),
             custom_functional: String::new(),
             basis: basis.to_string(),
@@ -331,7 +333,7 @@ impl QmPrompt {
         use crate::engines::qm::{KMesh, PeriodicQmRequest, QmJob};
         if self.periodic {
             let form = &self.periodic_form;
-            QmJob::Periodic(PeriodicQmRequest {
+            QmJob::periodic(PeriodicQmRequest {
                 structure,
                 functional: form.functional,
                 basis: form.basis.clone(),
@@ -344,7 +346,7 @@ impl QmPrompt {
                 stress: form.stress,
             })
         } else {
-            QmJob::Molecular(self.to_request(structure, product))
+            QmJob::molecular(self.engine, self.to_request(structure, product))
         }
     }
 

--- a/src/frontend/ui/secondary_sidebar/qm_form.rs
+++ b/src/frontend/ui/secondary_sidebar/qm_form.rs
@@ -148,11 +148,13 @@ pub(crate) fn render_molecular_qm_form(
         QmKind::Frequencies,
         "Vibrational frequencies",
     );
-    ui.radio_value(
-        &mut prompt.kind,
-        QmKind::TransitionState,
-        "Transition-state search",
-    );
+    if prompt.engine == crate::engines::qm::QmEngine::Hartree {
+        ui.radio_value(
+            &mut prompt.kind,
+            QmKind::TransitionState,
+            "Transition-state search",
+        );
+    }
 
     if prompt.kind == QmKind::TransitionState {
         render_qm_transition_state_form(ui, prompt, entry_options);
@@ -165,16 +167,18 @@ pub(crate) fn render_molecular_qm_form(
     // the shared dot style is not misread as "mutually exclusive with the
     // calculation above". `ui.radio` is purely visual here — the click
     // handler flips the bool; it does not join the calculation-kind group.
-    ui.separator();
-    ui.label("Options:");
-    if ui
-        .radio(
-            prompt.options.compute_properties,
-            "Compute dipole, charges & bond orders",
-        )
-        .clicked()
-    {
-        prompt.options.compute_properties = !prompt.options.compute_properties;
+    if prompt.engine == crate::engines::qm::QmEngine::Hartree {
+        ui.separator();
+        ui.label("Options:");
+        if ui
+            .radio(
+                prompt.options.compute_properties,
+                "Compute dipole, charges & bond orders",
+            )
+            .clicked()
+        {
+            prompt.options.compute_properties = !prompt.options.compute_properties;
+        }
     }
 
     render_qm_advanced(ui, prompt);
@@ -536,6 +540,9 @@ fn render_qm_advanced(ui: &mut egui::Ui, prompt: &mut crate::frontend::state::Qm
                 Some(QmSolvation::Alpb(n)) => (3, n.clone()),
                 Some(QmSolvation::Gbsa(n)) => (4, n.clone()),
             };
+            if prompt.engine == crate::engines::qm::QmEngine::Orca && model > 2 {
+                model = 0;
+            }
             ui.horizontal(|ui| {
                 ui.label("Solvation:");
                 egui::ComboBox::from_id_salt("qm_solv_model")
@@ -548,14 +555,13 @@ fn render_qm_advanced(ui: &mut egui::Ui, prompt: &mut crate::frontend::state::Qm
                     })
                     .show_ui(ui, |ui| {
                         crate::frontend::theme::stabilize_selectable_rows(ui);
-                        for (value, label) in [
-                            (0, "none"),
-                            (1, "C-PCM"),
-                            (2, "SMD"),
-                            (3, "ALPB"),
-                            (4, "GBSA"),
-                        ] {
+                        for (value, label) in [(0, "none"), (1, "C-PCM"), (2, "SMD")] {
                             ui.selectable_value(&mut model, value as u8, label);
+                        }
+                        if prompt.engine == crate::engines::qm::QmEngine::Hartree {
+                            for (value, label) in [(3, "ALPB"), (4, "GBSA")] {
+                                ui.selectable_value(&mut model, value as u8, label);
+                            }
                         }
                     });
                 if model != 0 {
@@ -576,6 +582,10 @@ fn render_qm_advanced(ui: &mut egui::Ui, prompt: &mut crate::frontend::state::Qm
                 4 => Some(QmSolvation::Gbsa(name)),
                 _ => None,
             };
+
+            if prompt.engine == crate::engines::qm::QmEngine::Orca {
+                return;
+            }
 
             // SCF backend.
             ui.horizontal(|ui| {

--- a/src/frontend/ui/secondary_sidebar/task_panels.rs
+++ b/src/frontend/ui/secondary_sidebar/task_panels.rs
@@ -247,10 +247,41 @@ pub(crate) fn render_qm_task_panel(
         .map(|prompt| prompt.memory_signature(state.structure()));
 
     if let Some(prompt) = &mut state.ui.pending_qm {
+        let previous_engine = prompt.engine;
+        ui.horizontal(|ui| {
+            ui.label("Engine:");
+            egui::ComboBox::from_id_salt("qm_engine")
+                .selected_text(prompt.engine.label())
+                .show_ui(ui, |ui| {
+                    crate::frontend::theme::stabilize_selectable_rows(ui);
+                    ui.selectable_value(
+                        &mut prompt.engine,
+                        crate::engines::qm::QmEngine::Hartree,
+                        crate::engines::qm::QmEngine::Hartree.label(),
+                    );
+                    ui.selectable_value(
+                        &mut prompt.engine,
+                        crate::engines::qm::QmEngine::Orca,
+                        crate::engines::qm::QmEngine::Orca.label(),
+                    );
+                });
+        });
+        if prompt.engine != previous_engine && prompt.engine == crate::engines::qm::QmEngine::Orca {
+            prompt.prefs.cores_per_subtask = 1;
+        }
+        if prompt.engine == crate::engines::qm::QmEngine::Orca {
+            prompt.periodic = false;
+            prompt.options.compute_properties = false;
+            if prompt.kind == crate::engines::qm::QmKind::TransitionState {
+                prompt.kind = crate::engines::qm::QmKind::SinglePoint;
+            }
+            ui.small("ORCA requires a program path configured for the selected compute target.");
+            ui.separator();
+        }
         // Offer molecular vs. periodic only when a cell is present; without one,
         // force the form back to molecular so a stale periodic selection (left
         // over from a previous entry) can't run against a non-periodic system.
-        if has_real_cell {
+        if has_real_cell && prompt.engine == crate::engines::qm::QmEngine::Hartree {
             ui.label("Calculation target:");
             ui.horizontal(|ui| {
                 crate::frontend::theme::stabilize_selectable_rows(ui);
@@ -287,6 +318,7 @@ pub(crate) fn render_qm_task_panel(
         // The memory estimate models the molecular in-core ERI tensor; a periodic
         // GPW run has none, so the button is molecular-only.
         if !prompt.periodic
+            && prompt.engine == crate::engines::qm::QmEngine::Hartree
             && ui
                 .add_enabled(
                     !structure_is_empty,

--- a/src/frontend/ui/views/engine_row.rs
+++ b/src/frontend/ui/views/engine_row.rs
@@ -28,6 +28,7 @@ pub(crate) struct EngineRow<'a> {
     pub probe: Option<EngineProbeState>,
     /// A local program can be picked from a file dialog; a remote path cannot.
     pub browsable: bool,
+    pub auto_discovery: bool,
 }
 
 /// Render `row`'s status line, launch fields, and actions, editing `draft` in place.
@@ -67,7 +68,11 @@ pub(crate) fn engine_row(
         });
     });
     ui.label(caption_text(
-        "Leave empty to look for it on this target automatically.",
+        if row.auto_discovery {
+            "Leave empty to look for it on this target automatically."
+        } else {
+            "Required: specify the engine executable path."
+        },
         pal.text_tertiary,
     ));
 

--- a/src/frontend/ui/views/engines.rs
+++ b/src/frontend/ui/views/engines.rs
@@ -87,6 +87,7 @@ pub(crate) fn render_engine_settings(
                 status,
                 probe,
                 browsable: true,
+                auto_discovery: !spec.requires_configured_path,
             },
             draft,
             actions,

--- a/src/frontend/ui/views/remote.rs
+++ b/src/frontend/ui/views/remote.rs
@@ -109,6 +109,7 @@ fn render_host_engines(
                 probe,
                 // A remote path is not on this filesystem; there is nothing to browse.
                 browsable: false,
+                auto_discovery: !spec.requires_configured_path,
             },
             draft,
             actions,

--- a/tests/engine_exec.rs
+++ b/tests/engine_exec.rs
@@ -8,23 +8,27 @@
 
 use std::process::Command;
 
-use silicolab::engines::qm::{QmJob, QmKind, QmMethod, QmOptions, QmRequest};
+use silicolab::engines::qm::{QmEngine, QmJob, QmKind, QmMethod, QmOptions, QmRequest};
 use silicolab::io::formats::xyz::parse_xyz;
+use silicolab::launch::{EngineId, EngineLaunch, EngineLaunches};
 use silicolab::wire::{Engine, EngineOutcome, EngineRequest, Executor, JobUpdate, run_job};
 
 fn h2_request() -> EngineRequest {
     let structure = parse_xyz("2\nh2\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74\n").expect("parse h2");
     EngineRequest::builtin(
-        Engine::Qm(QmJob::Molecular(QmRequest {
-            structure,
-            method: QmMethod::Rhf,
-            basis: "sto-3g".to_string(),
-            charge: 0,
-            multiplicity: 1,
-            kind: QmKind::SinglePoint,
-            options: QmOptions::default(),
-            ts: None,
-        })),
+        Engine::Qm(QmJob::molecular(
+            QmEngine::Hartree,
+            QmRequest {
+                structure,
+                method: QmMethod::Rhf,
+                basis: "sto-3g".to_string(),
+                charge: 0,
+                multiplicity: 1,
+                kind: QmKind::SinglePoint,
+                options: QmOptions::default(),
+                ts: None,
+            },
+        )),
         None,
     )
 }
@@ -76,5 +80,68 @@ fn exec_subcommand_matches_in_process_within_tolerance() {
         outcome.energy_hartree
     );
 
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+#[ignore = "requires SILICOLAB_TEST_ORCA_PROGRAM to name an ORCA executable"]
+fn exec_subcommand_runs_configured_orca() {
+    let program =
+        std::env::var("SILICOLAB_TEST_ORCA_PROGRAM").expect("set SILICOLAB_TEST_ORCA_PROGRAM");
+    let command_prefix = std::env::var("SILICOLAB_TEST_ORCA_PREFIX")
+        .ok()
+        .map(|prefix| prefix.split_whitespace().map(str::to_string).collect())
+        .unwrap_or_default();
+    let structure = parse_xyz("5\nmethane\nC 0 0 0\nH 0.63 0.63 0.63\nH -0.63 -0.63 0.63\nH -0.63 0.63 -0.63\nH 0.63 -0.63 -0.63\n")
+        .expect("parse methane");
+    let job = Engine::Qm(QmJob::molecular(
+        QmEngine::Orca,
+        QmRequest {
+            structure,
+            method: QmMethod::Dft("b3lyp".to_string()),
+            basis: "def2-tzvp".to_string(),
+            charge: 0,
+            multiplicity: 1,
+            kind: QmKind::SinglePoint,
+            options: QmOptions {
+                dispersion: Some(silicolab::engines::qm::QmDispersion::D3Bj),
+                ..Default::default()
+            },
+            ts: None,
+        },
+    ));
+    let mut launches = EngineLaunches::new();
+    launches.insert(
+        EngineId::ORCA,
+        EngineLaunch {
+            command_prefix,
+            program,
+        },
+    );
+    let request = EngineRequest::new(job, Some(1), launches).expect("bind ORCA launch");
+
+    let dir = std::env::temp_dir().join("silicolab-it-orca-exec");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    let request_path = dir.join("request.json");
+    let outcome_path = dir.join("outcome.json");
+    std::fs::write(&request_path, serde_json::to_vec(&request).unwrap()).expect("write request");
+    let output = Command::new(env!("CARGO_BIN_EXE_silicolab"))
+        .arg("exec")
+        .arg(&request_path)
+        .arg(&outcome_path)
+        .output()
+        .expect("run ORCA through the exec subcommand");
+    assert!(
+        output.status.success(),
+        "exec failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let bytes = std::fs::read(&outcome_path).expect("read outcome");
+    let EngineOutcome::Qm(outcome) = serde_json::from_slice(&bytes).expect("parse outcome") else {
+        panic!("expected a QM outcome");
+    };
+    assert!(outcome.converged);
+    assert!(outcome.energy_hartree.is_finite());
     let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary

- add ORCA as an optional external QM engine while keeping built-in Hartree as the default
- support molecular single-point energies, geometry optimizations, and vibrational frequencies
- support native, WSL-prefixed, and remote ORCA launches using user-configured executable paths
- expose engine selection in the QM panel and through `qm ... --engine orca`
- document ORCA setup in English and Chinese

## Implementation

- model QM jobs as an engine selection plus an engine-neutral calculation
- generate ORCA inputs for common methods, basis sets, charge, multiplicity, dispersion, C-PCM, and SMD
- parse final energies, optimized XYZ geometries, and vibrational frequencies
- require users to configure the ORCA executable separately for each compute target
- keep transition-state and periodic QM calculations on Hartree
- default ORCA to one CPU core; multi-core `%pal` execution requires `mpirun`
- report actionable errors when ORCA parallel execution cannot find `mpirun`
- preserve the engine subprocess log tail in user-facing failures

## Validation

- `cargo pr-check`
- real WSL ORCA verification
- real ORCA single-point, geometry optimization, and frequency calculations
- real `silicolab exec` subprocess path with a molecular B3LYP-D3BJ/def2-TZVP calculation

## Notes

- ORCA is not auto-detected or selected automatically
- real remote SSH/Slurm execution was not exercised, but remote launch binding, worker builds, wire serialization, and deployment tests are covered