### PR TITLE
refactor(feedback): typed session-bounded feedback architecture

### DIFF
--- a/src/frontend/actions.rs
+++ b/src/frontend/actions.rs
@@ -495,6 +495,21 @@ pub enum AppAction {
     ResetWorkbenchLayout,
     /// Dismiss the active [`Notification`] without taking any of its actions.
     DismissNotification,
+    /// Reveal the Output tab and apply a source/exact-job filter in one step —
+    /// the single owner of dock reveal + filter selection for a job-detail or
+    /// "show Output" navigation. Renderers never touch the dock model and the
+    /// Output filter independently.
+    RevealOutput(crate::frontend::state::OutputTarget),
+    /// Follow a status-notice link to its typed detail target (Output, an
+    /// Activity job, or Settings).
+    OpenDetailTarget(crate::frontend::state::DetailTarget),
+    /// Dismiss the current status notice (its canonical log/job record persists).
+    AcknowledgeStatus,
+    PostStatusNeutral(String),
+    ReportSystemError {
+        subsystem: crate::frontend::state::SystemSubsystem,
+        text: String,
+    },
     /// Accept the heavy-structure suggestion for an entry: switch all of its
     /// atoms to wireframe, then render it.
     UseWireframeForHeavyEntry(u64),
@@ -562,11 +577,10 @@ impl LeaveConfirmation {
 }
 
 /// A non-modal notification surfaced over the workspace: a short message that,
-/// unlike [`crate::frontend::state::AppState::set_message`]'s plain status-bar
-/// text, can offer the user a choice through action buttons. One notification is
-/// shown at a time; posting a new one replaces any current one. Clicking a button
-/// dismisses the notification and then dispatches the button's action, so a
-/// button may itself post a follow-up notification.
+/// unlike a plain status notice, can offer the user a choice through action
+/// buttons. One notification is shown at a time; posting a new one replaces any
+/// current one. Clicking a button dismisses the notification and then dispatches
+/// the button's action, so a button may itself post a follow-up notification.
 #[derive(Debug, Clone)]
 pub struct Notification {
     pub severity: NotificationSeverity,

--- a/src/frontend/agent/loop_driver.rs
+++ b/src/frontend/agent/loop_driver.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use crate::backend::config::save_config;
 use crate::frontend::agent::session::TranscriptEntry;
-use crate::frontend::state::AppState;
+use crate::frontend::state::{AppState, SystemSubsystem};
 use crate::io::llm::types::{AssistantTurn, ChatMessage, ContentBlock, ReasoningBlob, Role};
 
 mod heavy;
@@ -116,7 +116,10 @@ fn notice(state: &mut AppState, message: &str) {
 
 fn persist(state: &mut AppState) {
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save assistant settings: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save assistant settings: {error}"),
+        );
     }
 }
 

--- a/src/frontend/agent/loop_driver/heavy.rs
+++ b/src/frontend/agent/loop_driver/heavy.rs
@@ -9,9 +9,10 @@ use crate::frontend::jobs::{
     AgentHeavyJob, DockingWorkerMessage, EngineWorkerMessage, QmWorkerMessage, RunningDockingJob,
     RunningEngineJob, RunningQmJob, TrackedAgentJob, spawn_docking_job, spawn_gromacs_pipeline_job,
 };
-use crate::frontend::state::AppState;
+use crate::frontend::state::{AppState, LogLevel, SystemSubsystem};
 use crate::io::llm::types::ToolCall;
 use crate::io::structure_io::default_structure_save_path;
+use crate::job::JobId;
 
 /// Most heavy jobs the agent may have running at once. Serialized to one by
 /// default to bound memory — a ~21-atom QM run can already cost ~19 GB — so a
@@ -110,15 +111,6 @@ fn register_agent_task_run(state: &mut AppState, kind: HeavyKind, command: &str)
     task_run_id
 }
 
-fn complete_agent_task_run(state: &mut AppState, task_run_id: u64, is_error: bool) {
-    let status = if is_error {
-        TaskStatus::Failed
-    } else {
-        TaskStatus::Completed
-    };
-    crate::frontend::dispatcher::mark_task_status(state, task_run_id, status);
-}
-
 /// Launch a heavy command as a detached background job and record an immediate
 /// "started" tool result, so the model hands control back at once instead of
 /// blocking. Heavy jobs are serialized ([`MAX_AGENT_HEAVY`]): while one runs, a
@@ -184,11 +176,22 @@ pub fn spawn_heavy(state: &mut AppState, call: &ToolCall, kind: HeavyKind, ctx: 
             state.jobs.next_agent_job_id += 1;
             let conversation = state.ui.agent.active_conversation;
             let task_run_id = register_agent_task_run(state, kind, &command);
+            let job_kind = state
+                .tasks
+                .task_run(task_run_id)
+                .map(|task| task.controller_id.to_string());
+            let job_id = crate::frontend::dispatcher::begin_job_execution(
+                state,
+                task_run_id,
+                crate::backend::run_attempt::Placement::Local,
+                job_kind,
+            );
             state.jobs.agent_jobs.push(TrackedAgentJob {
                 id,
                 conversation,
                 label: label.clone(),
                 task_run_id,
+                job_id,
                 job,
             });
             record_result(
@@ -230,10 +233,13 @@ pub fn poll_agent_jobs(state: &mut AppState, ctx: &egui::Context) {
     let mut survivors = Vec::with_capacity(jobs.len());
     let mut any_completed = false;
     for mut tracked in jobs {
+        let job_id = tracked.job_id;
         let completion = match &mut tracked.job {
-            AgentHeavyJob::Qm(running) => drain_qm(state, running, tracked.task_run_id),
-            AgentHeavyJob::Engine(running) => drain_engine(state, running, tracked.task_run_id),
-            AgentHeavyJob::Docking(running) => drain_docking(state, running),
+            AgentHeavyJob::Qm(running) => drain_qm(state, running, tracked.task_run_id, job_id),
+            AgentHeavyJob::Engine(running) => {
+                drain_engine(state, running, tracked.task_run_id, job_id)
+            }
+            AgentHeavyJob::Docking(running) => drain_docking(state, running, job_id),
         };
         match completion {
             Some((summary, is_error)) => {
@@ -260,20 +266,24 @@ pub fn cancel_conversation_jobs(
     state: &mut AppState,
     conversation: AssistantConversationId,
 ) -> usize {
-    let mut cancelled_runs = Vec::new();
+    let mut cancelled_jobs = Vec::new();
     state.jobs.agent_jobs.retain(|job| {
         if job.conversation == conversation {
             job.job.cancel();
-            cancelled_runs.push(job.task_run_id);
+            cancelled_jobs.push(job.job_id);
             false
         } else {
             true
         }
     });
-    for task_run_id in &cancelled_runs {
-        crate::frontend::dispatcher::mark_task_status(state, *task_run_id, TaskStatus::Cancelled);
+    for job_id in &cancelled_jobs {
+        crate::frontend::dispatcher::complete_local_job(
+            state,
+            Some(*job_id),
+            TaskStatus::Cancelled,
+        );
     }
-    cancelled_runs.len()
+    cancelled_jobs.len()
 }
 
 /// Route a finished job to the conversation that launched it: a transcript
@@ -286,14 +296,20 @@ fn finish_agent_job(
     is_error: bool,
 ) {
     let cancelled = matches!(&tracked.job, AgentHeavyJob::Qm(job) if job.cancel_requested);
-    if cancelled {
-        crate::frontend::dispatcher::mark_task_status(
-            state,
-            tracked.task_run_id,
-            TaskStatus::Cancelled,
-        );
+    let status = if cancelled {
+        TaskStatus::Cancelled
+    } else if is_error {
+        TaskStatus::Failed
     } else {
-        complete_agent_task_run(state, tracked.task_run_id, is_error);
+        TaskStatus::Completed
+    };
+    // Finalize execution and task through the run graph exactly as a manual job
+    // does, then surface the same job-scoped feedback.
+    crate::frontend::dispatcher::complete_local_job(state, Some(tracked.job_id), status);
+    match status {
+        TaskStatus::Completed => state.job_succeeded(tracked.job_id, summary.clone()),
+        TaskStatus::Failed => state.job_failed(tracked.job_id, summary.clone()),
+        _ => state.job_notice(tracked.job_id, summary.clone()),
     }
     let verb = if cancelled {
         "cancelled"
@@ -313,17 +329,18 @@ fn finish_agent_job(
     }
 }
 
-fn drain_docking(state: &mut AppState, running: &RunningDockingJob) -> Option<(String, bool)> {
+fn drain_docking(
+    state: &mut AppState,
+    running: &mut RunningDockingJob,
+    _job_id: JobId,
+) -> Option<(String, bool)> {
     let mut completion = None;
     while let Ok(message) = running.receiver.try_recv() {
         match message {
-            DockingWorkerMessage::Progress { stage } => {
-                state.set_message(format!("Docking: {stage}; running in background"));
-            }
+            DockingWorkerMessage::Progress { stage } => running.latest_stage = Some(stage),
             DockingWorkerMessage::Finished(outcome) => {
                 let outcome = *outcome;
                 crate::frontend::docking_commands::add_pose_entries(state, &outcome);
-                state.set_message(outcome.summary.clone());
                 completion = Some((outcome.summary, false));
             }
             DockingWorkerMessage::Failed(error) => {
@@ -351,9 +368,10 @@ fn save_agent_qm_artifacts(
     }
     match crate::frontend::dispatcher::ensure_task_run_dir(state, task_run_id, kind, None) {
         Ok(run_dir) => crate::frontend::dispatcher::save_qm_artifacts(state, &run_dir, outcome),
-        Err(error) => state
-            .output_log
-            .push(format!("failed to create QM run directory: {error}")),
+        Err(error) => state.report_system_error(
+            SystemSubsystem::Storage,
+            format!("failed to create QM run directory: {error}"),
+        ),
     }
 }
 
@@ -361,12 +379,12 @@ fn drain_qm(
     state: &mut AppState,
     running: &mut RunningQmJob,
     task_run_id: u64,
+    _job_id: JobId,
 ) -> Option<(String, bool)> {
     let mut completion = None;
     while let Ok(message) = running.receiver.try_recv() {
         match message {
             QmWorkerMessage::Progress { stage } => {
-                state.set_message(format!("QM: {stage}; running in background"));
                 running.latest_stage = Some(stage);
             }
             QmWorkerMessage::Finished(outcome) => {
@@ -394,7 +412,6 @@ fn drain_qm(
                 }
                 state.ui.chart_availability.clear();
                 state.ui.task_chart_thumbnails.remove(&task_run_id);
-                state.set_message(outcome.summary.clone());
                 completion = Some((outcome.summary, false));
             }
             QmWorkerMessage::Failed(error) => {
@@ -413,15 +430,15 @@ fn drain_engine(
     state: &mut AppState,
     running: &mut RunningEngineJob,
     task_run_id: u64,
+    job_id: JobId,
 ) -> Option<(String, bool)> {
     let mut completion = None;
     while let Ok(message) = running.receiver.try_recv() {
         match message {
             EngineWorkerMessage::Stage(stage) => {
-                state.set_message(format!("{}: {stage}", running.engine));
                 running.latest_stage = Some(stage);
             }
-            EngineWorkerMessage::Log(line) => running.append_log(line),
+            EngineWorkerMessage::Log(line) => state.append_job_log(job_id, LogLevel::Info, line),
             EngineWorkerMessage::Finished(success) => {
                 let success = *success;
                 let summary = success.summary.clone();
@@ -437,7 +454,6 @@ fn drain_engine(
                     crate::frontend::dispatcher::md_run_origin(trajectory, project_root.as_deref());
                 state.entries.set_entry_origin(entry_id, origin);
                 crate::frontend::dispatcher::record_task_result_entry(state, task_run_id, entry_id);
-                state.set_message(summary.clone());
                 completion = Some((summary, false));
             }
             EngineWorkerMessage::Failed(error) => {
@@ -495,6 +511,12 @@ mod tests {
         // task's result — attributed by the TrackedAgentJob's task_run_id.
         let mut state = AppState::scratch(Default::default(), Vec::new());
         let task = register_agent_task_run(&mut state, HeavyKind::Qm, "qm optimize");
+        let job_id = crate::frontend::dispatcher::begin_job_execution(
+            &mut state,
+            task,
+            crate::backend::run_attempt::Placement::Local,
+            Some("qm-optimize".to_string()),
+        );
 
         let (tx, rx) = std::sync::mpsc::channel();
         tx.send(QmWorkerMessage::Finished(Box::new(
@@ -518,7 +540,7 @@ mod tests {
             cancel_requested: false,
         };
 
-        let completion = drain_qm(&mut state, &mut running, task);
+        let completion = drain_qm(&mut state, &mut running, task, job_id);
         let (_summary, is_error) = completion.expect("the job completes");
         assert!(!is_error, "a converged run is not an error");
         assert!(
@@ -534,16 +556,38 @@ mod tests {
 
     #[test]
     fn complete_marks_terminal_status() {
+        // An agent-launched job finalizes through the same run graph a manual job
+        // does: completing its bound execution marks the task terminal.
         let mut state = AppState::scratch(Default::default(), Vec::new());
         let ok = register_agent_task_run(&mut state, HeavyKind::Qm, "qm energy");
-        complete_agent_task_run(&mut state, ok, false);
+        let ok_job = crate::frontend::dispatcher::begin_job_execution(
+            &mut state,
+            ok,
+            crate::backend::run_attempt::Placement::Local,
+            Some("qm-energy".to_string()),
+        );
+        crate::frontend::dispatcher::complete_local_job(
+            &mut state,
+            Some(ok_job),
+            TaskStatus::Completed,
+        );
         assert_eq!(
             state.tasks.task_run(ok).unwrap().status,
             TaskStatus::Completed
         );
 
         let bad = register_agent_task_run(&mut state, HeavyKind::Md, "md run");
-        complete_agent_task_run(&mut state, bad, true);
+        let bad_job = crate::frontend::dispatcher::begin_job_execution(
+            &mut state,
+            bad,
+            crate::backend::run_attempt::Placement::Local,
+            Some("md-run".to_string()),
+        );
+        crate::frontend::dispatcher::complete_local_job(
+            &mut state,
+            Some(bad_job),
+            TaskStatus::Failed,
+        );
         assert_eq!(
             state.tasks.task_run(bad).unwrap().status,
             TaskStatus::Failed

--- a/src/frontend/agent/loop_driver/settings.rs
+++ b/src/frontend/agent/loop_driver/settings.rs
@@ -6,7 +6,7 @@ use crate::backend::config::ApprovalMode;
 use crate::frontend::agent::registry;
 use crate::frontend::agent::session::{AssistantConversationId, ModelFetchStatus};
 use crate::frontend::jobs::spawn_model_fetch;
-use crate::frontend::state::AppState;
+use crate::frontend::state::{AppState, SystemSubsystem};
 use crate::io::llm::types::Effort;
 
 pub fn new_assistant_conversation(state: &mut AppState) {
@@ -110,8 +110,11 @@ pub fn set_assistant_base_url(state: &mut AppState, base_url: &str) {
 pub fn set_assistant_api_key(state: &mut AppState, key: &str) {
     let provider = registry::active_provider(&state.config.assistant);
     match crate::backend::secrets::set_stored_key(provider.id, key.trim()) {
-        Ok(()) => state.set_message(format!("Saved the API key for {}.", provider.label)),
-        Err(error) => state.set_message(format!("Could not save the API key: {error}")),
+        Ok(()) => state.status_success(format!("Saved the API key for {}.", provider.label)),
+        Err(error) => state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save the API key: {error}"),
+        ),
     }
     refresh_key_status(state);
 }
@@ -124,8 +127,11 @@ pub fn clear_stored_key(state: &mut AppState, provider_id: &str) {
         .map(|spec| spec.label)
         .unwrap_or(provider_id);
     match crate::backend::secrets::clear_stored_key(provider_id) {
-        Ok(()) => state.set_message(format!("Removed the stored API key for {label}.")),
-        Err(error) => state.set_message(format!("Could not remove the API key: {error}")),
+        Ok(()) => state.status_success(format!("Removed the stored API key for {label}.")),
+        Err(error) => state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not remove the API key: {error}"),
+        ),
     }
     refresh_key_status(state);
 }
@@ -180,7 +186,7 @@ pub fn poll_model_fetch(state: &mut AppState, ctx: &egui::Context) {
             let count = ids.len();
             state.ui.agent.fetched_models.insert(job.provider_id, ids);
             state.ui.agent.model_fetch = ModelFetchStatus::Idle;
-            state.set_message(format!("Listed {count} models from the provider."));
+            state.status_success(format!("Listed {count} models from the provider."));
             ctx.request_repaint();
         }
         Ok(Err(error)) => {

--- a/src/frontend/agent/loop_driver/tests/mod.rs
+++ b/src/frontend/agent/loop_driver/tests/mod.rs
@@ -26,6 +26,7 @@ fn fake_qm_job(
         conversation,
         label: "qm optimize".to_string(),
         task_run_id: 0,
+        job_id: crate::job::JobId::new(),
         job: AgentHeavyJob::Qm(RunningQmJob {
             cancel: crate::wire::JobCancelHandle::from_flag(Arc::new(AtomicBool::new(false))),
             receiver: sender,
@@ -95,12 +96,19 @@ fn read_only_tool_runs_inline_and_records_result() {
     // (the model asked for run_command "inspect" â€” a console command â€” which
     // is unknown to the console and returns an error result; the point is the
     // tool dispatched and produced a tool_result.)
+    use crate::frontend::state::{CommandActor, LogFilter, LogQuery, LogScope};
+    let query = LogQuery::new(LogFilter::Command);
     assert!(
-        state
-            .output_log
-            .iter()
-            .any(|line| line.starts_with("agent>")),
-        "tool command should echo into the shared output log"
+        state.session_log().query(&query).any(|entry| {
+            matches!(
+                entry.scope,
+                LogScope::Command {
+                    actor: CommandActor::Agent,
+                    ..
+                }
+            ) && entry.text == "inspect"
+        }),
+        "the assistant-issued command is recorded in the Console transcript"
     );
     // Usage accumulated.
     assert_eq!(state.ui.agent.session_usage.input, 10);
@@ -169,11 +177,15 @@ fn plan_mode_proposes_without_executing() {
     // Nothing waits and nothing destructive ran; the call became a proposal.
     assert!(state.ui.agent.pending_approval().is_none());
     assert!(state.ui.agent.pending_calls.is_empty());
+    let query = crate::frontend::state::LogQuery::new(crate::frontend::state::LogFilter::Command);
     assert!(
-        !state
-            .output_log
-            .iter()
-            .any(|line| line.starts_with("agent>")),
+        !state.session_log().query(&query).any(|entry| matches!(
+            entry.scope,
+            crate::frontend::state::LogScope::Command {
+                actor: crate::frontend::state::CommandActor::Agent,
+                ..
+            }
+        )),
         "plan mode must not execute the command"
     );
 }
@@ -366,11 +378,15 @@ fn error_result_is_surfaced() {
         Err(LlmError::BadRequest("bad shape".to_string())),
         &ctx,
     );
+    let query = crate::frontend::state::LogQuery::new(crate::frontend::state::LogFilter::Source(
+        crate::frontend::state::OutputSource::Agent,
+    ));
     assert!(
         state
-            .output_log
-            .iter()
-            .any(|line| line.contains("bad shape"))
+            .session_log()
+            .query(&query)
+            .any(|entry| entry.text.contains("bad shape")),
+        "the turn error is surfaced as Agent-scoped detail"
     );
 }
 

--- a/src/frontend/agent/loop_driver/turn.rs
+++ b/src/frontend/agent/loop_driver/turn.rs
@@ -8,7 +8,7 @@ use crate::frontend::agent::registry;
 use crate::frontend::agent::session::{AgentPhase, PendingTurn, TranscriptEntry};
 use crate::frontend::agent::tools;
 use crate::frontend::jobs::{AgentTurnEvent, spawn_agent_turn};
-use crate::frontend::state::AppState;
+use crate::frontend::state::{AppState, LogLevel};
 use crate::io::llm::types::{AssistantTurn, ChatMessage, LlmConfig, LlmError, StopReason};
 
 /// Handle a user message. Idle → start a turn immediately; busy or paused on
@@ -176,7 +176,7 @@ pub fn handle_turn_result(
         Err(error) => {
             let message = error.user_message();
             notice(state, &format!("Assistant error: {message}"));
-            state.output_log.push(format!("assistant error: {message}"));
+            state.log_agent(None, LogLevel::Error, format!("assistant error: {message}"));
             let cancelled = matches!(error, LlmError::Cancelled);
             state.ui.agent.phase = if cancelled {
                 AgentPhase::Idle
@@ -206,9 +206,11 @@ pub fn handle_turn_result(
             .agent
             .transcript
             .push(TranscriptEntry::Assistant(turn.text.clone()));
-        state
-            .output_log
-            .push(format!("assistant> {}", turn.text.trim()));
+        state.log_agent(
+            None,
+            LogLevel::Info,
+            format!("assistant> {}", turn.text.trim()),
+        );
     }
 
     // Record the assistant turn for replay via the provider's encoder (with a

--- a/src/frontend/agent/tools.rs
+++ b/src/frontend/agent/tools.rs
@@ -15,7 +15,7 @@ use serde_json::{Value, json};
 use crate::backend::config::ApprovalMode;
 use crate::engines::registry::{EngineRegistry, EngineStatus, external_engine_specs};
 use crate::frontend::console::{RiskLevel, command_risk};
-use crate::frontend::state::AppState;
+use crate::frontend::state::{AppState, LogLevel};
 use crate::io::llm::types::{ToolCall, ToolDef};
 
 /// How much of a tool result is replayed into history. Large md/qm/inspect
@@ -326,8 +326,8 @@ fn list_jobs_tool(state: &AppState) -> String {
 fn cancel_job_tool(state: &mut AppState, id: &str) -> ToolOutcome {
     match crate::frontend::jobs::cancel_job_by_token(state, id) {
         Ok(message) => {
-            state.output_log.push(format!("agent cancel_job> {id}"));
-            state.output_log.push(message.clone());
+            state.log_agent(None, LogLevel::Info, format!("agent cancel_job> {id}"));
+            state.log_agent(None, LogLevel::Info, message.clone());
             ToolOutcome {
                 content: message,
                 is_error: false,
@@ -335,7 +335,7 @@ fn cancel_job_tool(state: &mut AppState, id: &str) -> ToolOutcome {
         }
         Err(error) => {
             let message = format!("cancel_job failed: {error}");
-            state.output_log.push(message.clone());
+            state.log_agent(None, LogLevel::Error, message.clone());
             ToolOutcome {
                 content: message,
                 is_error: true,
@@ -421,7 +421,7 @@ fn save_skill_tool(state: &mut AppState, input: &Value) -> ToolOutcome {
                 skill.name,
                 path.display()
             );
-            state.output_log.push(summary.clone());
+            state.log_agent(None, LogLevel::Info, summary.clone());
             ToolOutcome {
                 content: summary,
                 is_error: false,
@@ -542,31 +542,30 @@ fn yaml_scalar(value: &str) -> String {
     format!("\"{escaped}\"")
 }
 
-/// Run one `.sls` command, echoing it and its result into the shared
-/// `output_log` so agent-executed commands share the console's audit trail.
+/// Run one `.sls` command, recording it and its result into the Console
+/// transcript under the Agent actor so assistant-executed commands share the
+/// command audit trail without being confused for user input.
 fn run_command_tool(state: &mut AppState, command: &str) -> ToolOutcome {
-    state.output_log.push(format!("agent> {command}"));
-    match crate::frontend::console::execute_console_line(state, command) {
+    match crate::frontend::console::record_console_command(
+        state,
+        command,
+        crate::frontend::state::CommandActor::Agent,
+    ) {
         Ok(message) => {
             let summary = if message.trim().is_empty() {
                 format!("ok: {command}")
             } else {
                 message
             };
-            state.output_log.push(summary.clone());
             ToolOutcome {
                 content: clamp_result(&summary),
                 is_error: false,
             }
         }
-        Err(error) => {
-            let message = format!("command failed: {error}");
-            state.output_log.push(message.clone());
-            ToolOutcome {
-                content: clamp_result(&message),
-                is_error: true,
-            }
-        }
+        Err(error) => ToolOutcome {
+            content: clamp_result(&format!("command failed: {error}")),
+            is_error: true,
+        },
     }
 }
 
@@ -703,7 +702,11 @@ pub fn inspect(state: &AppState, _query: Option<&str>) -> String {
         let _ = writeln!(out, "running jobs: {summary}{suffix}");
     }
 
-    let _ = writeln!(out, "status: {}", state.message);
+    let status = state
+        .status_notice()
+        .map(|notice| notice.text.as_str())
+        .unwrap_or("(no active status)");
+    let _ = writeln!(out, "status: {status}");
     out
 }
 

--- a/src/frontend/agent/tools/tests.rs
+++ b/src/frontend/agent/tools/tests.rs
@@ -477,6 +477,7 @@ fn list_jobs_and_cancel_job_control_assistant_qm_job() {
             conversation: state.ui.agent.active_conversation,
             label: "qm optimize".to_string(),
             task_run_id,
+            job_id: crate::job::JobId::new(),
             job: crate::frontend::jobs::AgentHeavyJob::Qm(crate::frontend::jobs::RunningQmJob {
                 cancel: crate::wire::JobCancelHandle::from_flag(std::sync::Arc::clone(&cancel)),
                 receiver: rx,

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -66,7 +66,7 @@ pub fn run(structure: Structure, source_path: Option<PathBuf>) -> Result<()> {
                 } else {
                     fake
                 };
-                app.state.set_message(format!(
+                app.state.status_neutral(format!(
                     "SilicoLab {version} is available (you have {})",
                     env!("CARGO_PKG_VERSION")
                 ));
@@ -483,7 +483,7 @@ impl SilicoLabApp {
                             ));
                         }
                         if let Some(message) = startup_message.take() {
-                            state.set_message(message);
+                            state.status_neutral(message);
                         }
                         return Self {
                             state,
@@ -508,7 +508,7 @@ impl SilicoLabApp {
             AppState::scratch(config, recent_projects)
         };
         if let Some(message) = startup_message {
-            state.set_message(message);
+            state.status_neutral(message);
         }
         Self {
             state,
@@ -656,7 +656,7 @@ impl eframe::App for SilicoLabApp {
         dispatcher::flush_dirty_run_graph(&mut self.state);
         dispatcher::flush_pending_autosave(&mut self.state, &ctx);
         dispatcher::flush_pending_layout_save(&mut self.state, &ctx);
-        self.state.record_message_change();
+        self.state.tick_status(std::time::Instant::now());
     }
 
     /// Backing color behind the UI.

--- a/src/frontend/console.rs
+++ b/src/frontend/console.rs
@@ -5,7 +5,7 @@ use std::{
 
 use anyhow::{Result, bail};
 
-use crate::frontend::state::AppState;
+use crate::frontend::state::{AppState, CommandActor, LogLevel, LogScope, NewLogEntry};
 
 mod args;
 mod editing;
@@ -24,10 +24,37 @@ pub(crate) use render::*;
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug, Clone, Default)]
+/// The Console tab's full session state: the command input, the recall history,
+/// and the transient view state (wrap, auto-follow, and the clear-view / unread
+/// cursors over the command transcript). The transcript itself is owned by the
+/// [`SessionLogStore`](crate::frontend::state::SessionLogStore); this holds only
+/// what the view needs.
+#[derive(Debug, Clone)]
 pub struct CommandConsoleState {
     pub input: String,
     pub history: Vec<String>,
+    pub wrap_lines: bool,
+    /// Whether the transcript follows new output. Suspended when the user scrolls
+    /// up, resumed by the New output affordance.
+    pub auto_follow: bool,
+    /// Command entries whose latest occurrence is before this sequence are hidden
+    /// by the Console's clear-view cursor. It hides, never deletes.
+    pub cleared_before: crate::frontend::state::SessionSeq,
+    /// Highest command sequence the user has seen, for the New output affordance.
+    pub last_seen: crate::frontend::state::SessionSeq,
+}
+
+impl Default for CommandConsoleState {
+    fn default() -> Self {
+        Self {
+            input: String::new(),
+            history: Vec::new(),
+            wrap_lines: true,
+            auto_follow: true,
+            cleared_before: 0,
+            last_seen: 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -50,6 +77,33 @@ impl ScriptContext {
 pub fn execute_console_line(state: &mut AppState, line: &str) -> Result<String> {
     let mut context = ScriptContext::default();
     execute_console_line_with_context(state, line, &mut context)
+}
+
+/// Run one `.sls` command and record its prompt and result/error into the Console
+/// transcript under one [`CommandId`](crate::frontend::state::CommandId), so a
+/// user-issued and an assistant-issued command are grouped identically and never
+/// misassociated. Returns the raw command result for the caller to surface (a
+/// status line, or the assistant's tool result). Command history is the caller's
+/// concern — only user input is recalled.
+pub fn record_console_command(
+    state: &mut AppState,
+    command: &str,
+    actor: CommandActor,
+) -> Result<String> {
+    let command_id = state.allocate_command_id();
+    let scope = LogScope::Command { command_id, actor };
+    state.append_log(NewLogEntry::new(scope.clone(), LogLevel::Info, command));
+    let result = execute_console_line(state, command);
+    match &result {
+        Ok(message) if !message.trim().is_empty() => {
+            state.append_log(NewLogEntry::new(scope, LogLevel::Info, message.clone()));
+        }
+        Ok(_) => {}
+        Err(error) => {
+            state.append_log(NewLogEntry::new(scope, LogLevel::Error, format!("{error}")));
+        }
+    }
+    result
 }
 
 pub fn run_script_file_with_args(

--- a/src/frontend/dispatcher/builders.rs
+++ b/src/frontend/dispatcher/builders.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::frontend::state::SystemSubsystem;
 
 mod qm;
 
@@ -40,12 +41,12 @@ pub(crate) fn preview_framework_task(state: &mut AppState) {
             state.set_save_path(built.save_path);
             state.ui.camera = crate::frontend::ViewCamera::default();
             state.ui.selection.clear();
-            state.set_message(format!(
+            state.status_neutral(format!(
                 "Reticular structure preview generated; {}",
                 built.analysis
             ));
         }
-        Err(error) => state.set_message(format!("Reticular structure build failed: {error}")),
+        Err(error) => state.status_error(format!("Reticular structure build failed: {error}")),
     }
 }
 
@@ -59,7 +60,7 @@ pub(crate) fn accept_framework_task(state: &mut AppState) {
                 state.restore_edit_snapshot(before);
             }
             add_and_show_entry(state, built.structure, None, built.save_path);
-            state.set_message(format!("Reticular structure built; {}", built.analysis));
+            state.status_success(format!("Reticular structure built; {}", built.analysis));
             complete_active_task(
                 state,
                 TaskKind::BuildReticularStructure,
@@ -67,7 +68,7 @@ pub(crate) fn accept_framework_task(state: &mut AppState) {
             );
             close_active_task_panel(state);
         }
-        Err(error) => state.set_message(format!("Reticular structure build failed: {error}")),
+        Err(error) => state.status_error(format!("Reticular structure build failed: {error}")),
     }
 }
 
@@ -80,7 +81,7 @@ pub(crate) fn cancel_framework_task(state: &mut AppState) {
         state.ui.reticular_builder = None;
     }
     state.ui.reticular_builder = None;
-    state.set_message("Reticular structure build canceled".to_string());
+    state.status_neutral("Reticular structure build canceled".to_string());
     complete_active_task(state, TaskKind::BuildReticularStructure, TaskStatus::Failed);
     close_active_task_panel(state);
 }
@@ -112,9 +113,9 @@ pub(crate) fn preview_nanosheet_task(state: &mut AppState) {
             state.set_save_path(built.save_path);
             state.ui.camera = crate::frontend::ViewCamera::default();
             state.ui.selection.clear();
-            state.set_message(format!("Nanosheet preview generated; {}", built.analysis));
+            state.status_neutral(format!("Nanosheet preview generated; {}", built.analysis));
         }
-        Err(error) => state.set_message(format!("Nanosheet build failed: {error}")),
+        Err(error) => state.status_error(format!("Nanosheet build failed: {error}")),
     }
 }
 
@@ -128,11 +129,11 @@ pub(crate) fn accept_nanosheet_task(state: &mut AppState) {
                 state.restore_edit_snapshot(before);
             }
             add_and_show_entry(state, built.structure, None, built.save_path);
-            state.set_message(format!("Nanosheet built; {}", built.analysis));
+            state.status_success(format!("Nanosheet built; {}", built.analysis));
             complete_active_task(state, TaskKind::BuildNanosheet, TaskStatus::Completed);
             close_active_task_panel(state);
         }
-        Err(error) => state.set_message(format!("Nanosheet build failed: {error}")),
+        Err(error) => state.status_error(format!("Nanosheet build failed: {error}")),
     }
 }
 
@@ -145,7 +146,7 @@ pub(crate) fn cancel_nanosheet_task(state: &mut AppState) {
         state.ui.nanosheet_builder = None;
     }
     state.ui.nanosheet_builder = None;
-    state.set_message("Nanosheet build canceled".to_string());
+    state.status_neutral("Nanosheet build canceled".to_string());
     complete_active_task(state, TaskKind::BuildNanosheet, TaskStatus::Failed);
     close_active_task_panel(state);
 }
@@ -157,7 +158,7 @@ pub(crate) fn save_block_editor_task(state: &mut AppState) {
     match BuildingBlockService::save(editor, state.structure()) {
         Ok((path, source)) => {
             let current_structure = state.structure().clone();
-            state.set_message(format!("Building block saved {}", path.display()));
+            state.status_success(format!("Building block saved {}", path.display()));
             state
                 .ui
                 .reticular_builder
@@ -171,13 +172,16 @@ pub(crate) fn save_block_editor_task(state: &mut AppState) {
             complete_active_task(state, TaskKind::CreateBuildingBlock, TaskStatus::Completed);
             close_active_task_panel(state);
         }
-        Err(error) => state.set_message(format!("Building block save failed: {error}")),
+        Err(error) => state.report_system_error(
+            SystemSubsystem::Storage,
+            format!("Building block save failed: {error}"),
+        ),
     }
 }
 
 pub(crate) fn cancel_block_editor_task(state: &mut AppState) {
     state.ui.block_editor = None;
-    state.set_message("Building block creation canceled".to_string());
+    state.status_neutral("Building block creation canceled".to_string());
     complete_active_task(state, TaskKind::CreateBuildingBlock, TaskStatus::Failed);
     close_active_task_panel(state);
 }
@@ -188,14 +192,15 @@ pub(crate) fn start_pending_optimization(state: &mut AppState) {
         return;
     };
     if state.jobs.optimization_running() {
-        state.set_message(
+        state.status_neutral(
             "forcefield optimization is already running; press Esc to stop".to_string(),
         );
         return;
     }
     if prompt.allow_cell_optimization && state.structure().cell.is_none() {
-        state
-            .set_message("crystal geometry optimization requires a periodic structure".to_string());
+        state.status_neutral(
+            "crystal geometry optimization requires a periodic structure".to_string(),
+        );
         return;
     }
     let options = prompt.options(&state.ui.selection);
@@ -214,10 +219,10 @@ pub(crate) fn start_pending_optimization(state: &mut AppState) {
                 );
                 state.tasks.mark_status(task_run_id, TaskStatus::Running);
             }
-            state.set_message("forcefield optimization running; press Esc to stop".to_string());
+            state.status_neutral("forcefield optimization running; press Esc to stop".to_string());
         }
         Err(error) => {
-            state.set_message(format!("forcefield optimization failed to start: {error}"));
+            state.status_error(format!("forcefield optimization failed to start: {error}"));
             complete_active_task(state, TaskKind::OptimizeGeometry, TaskStatus::Failed);
             complete_active_task(state, TaskKind::OptimizeCrystalGeometry, TaskStatus::Failed);
         }
@@ -235,7 +240,7 @@ pub(crate) fn cancel_pending_optimization_request(state: &mut AppState) {
         );
     }
     state.ui.pending_optimization = None;
-    state.set_message("forcefield optimization canceled".to_string());
+    state.status_neutral("forcefield optimization canceled".to_string());
     complete_active_task(state, TaskKind::OptimizeGeometry, TaskStatus::Failed);
     complete_active_task(state, TaskKind::OptimizeCrystalGeometry, TaskStatus::Failed);
     close_active_task_panel(state);
@@ -250,7 +255,7 @@ pub(crate) fn confirm_pending_supercell(state: &mut AppState) {
         state.structure(),
         "supercell expansion requires a periodic structure",
     ) {
-        state.set_message(error.to_string());
+        state.status_neutral(error.to_string());
         return;
     }
     let prompt = state
@@ -265,7 +270,7 @@ pub(crate) fn confirm_pending_supercell(state: &mut AppState) {
 pub(crate) fn cancel_pending_supercell_request(state: &mut AppState) {
     bind_active_panel_task(state, TaskPanelKind::SupercellPrompt);
     state.ui.pending_supercell = None;
-    state.set_message("Supercell expansion canceled".to_string());
+    state.status_neutral("Supercell expansion canceled".to_string());
     complete_active_task(state, TaskKind::ExpandSupercell, TaskStatus::Failed);
     close_active_task_panel(state);
 }
@@ -284,7 +289,7 @@ pub(crate) fn confirm_pending_protein_prep(state: &mut AppState) {
 pub(crate) fn cancel_pending_protein_prep_request(state: &mut AppState) {
     bind_active_panel_task(state, TaskPanelKind::ProteinPrepPrompt);
     state.ui.pending_protein_prep = None;
-    state.set_message("Protein preparation canceled".to_string());
+    state.status_neutral("Protein preparation canceled".to_string());
     complete_active_task(state, TaskKind::PrepareProtein, TaskStatus::Failed);
     close_active_task_panel(state);
 }
@@ -298,7 +303,7 @@ pub(crate) fn prepare_protein(
     prompt: crate::frontend::state::ProteinPrepPrompt,
 ) -> bool {
     if state.structure().atoms.is_empty() {
-        state.set_message("no active structure to prepare".to_string());
+        state.status_neutral("no active structure to prepare".to_string());
         return false;
     }
     if let Some(task_run_id) = state.active_task_run {
@@ -320,7 +325,7 @@ pub(crate) fn prepare_protein(
     if let Some(task_run_id) = state.active_task_run {
         record_task_result_entry(state, task_run_id, entry_id);
     }
-    state.set_message(format!(
+    state.status_success(format!(
         "Protein prepared: added {added_hydrogens} hydrogen(s) (new entry)"
     ));
     complete_active_task(state, TaskKind::PrepareProtein, TaskStatus::Completed);
@@ -341,7 +346,7 @@ pub(crate) fn confirm_pending_md_system(state: &mut AppState) {
 pub(crate) fn cancel_pending_md_system_request(state: &mut AppState) {
     bind_active_panel_task(state, TaskPanelKind::MdSystemPrompt);
     state.ui.pending_md_system = None;
-    state.set_message("MD system build canceled".to_string());
+    state.status_neutral("MD system build canceled".to_string());
     complete_active_task(state, TaskKind::BuildMdSystem, TaskStatus::Failed);
     close_active_task_panel(state);
 }
@@ -380,7 +385,10 @@ pub(crate) fn select_custom_force_field(state: &mut AppState, name: Option<Strin
                 prompt.custom_force_field = Some(name);
                 prompt.custom_force_field_text = Some(text);
             }
-            Err(error) => state.set_message(format!("failed to load force field: {error}")),
+            Err(error) => state.report_system_error(
+                SystemSubsystem::Storage,
+                format!("failed to load force field: {error}"),
+            ),
         },
     }
 }
@@ -393,11 +401,11 @@ pub(crate) fn save_custom_force_field(state: &mut AppState) {
     let name = prompt.custom_ff_draft_name.trim().to_string();
     let text = prompt.custom_ff_draft.clone();
     if name.is_empty() {
-        state.set_message("enter a name for the force field before saving".to_string());
+        state.status_neutral("enter a name for the force field before saving".to_string());
         return;
     }
     if text.trim().is_empty() {
-        state.set_message("the force field is empty".to_string());
+        state.status_neutral("the force field is empty".to_string());
         return;
     }
     match crate::backend::force_fields::save_force_field(&name, &text) {
@@ -408,9 +416,12 @@ pub(crate) fn save_custom_force_field(state: &mut AppState) {
                 prompt.custom_ff_draft.clear();
                 prompt.custom_ff_draft_name.clear();
             }
-            state.set_message(format!("saved force field `{name}`"));
+            state.status_success(format!("saved force field `{name}`"));
         }
-        Err(error) => state.set_message(format!("failed to save force field: {error}")),
+        Err(error) => state.report_system_error(
+            SystemSubsystem::Storage,
+            format!("failed to save force field: {error}"),
+        ),
     }
 }
 
@@ -425,9 +436,12 @@ pub(crate) fn delete_custom_force_field(state: &mut AppState, name: &str) {
                 prompt.custom_force_field = None;
                 prompt.custom_force_field_text = None;
             }
-            state.set_message(format!("deleted force field `{name}`"));
+            state.status_success(format!("deleted force field `{name}`"));
         }
-        Err(error) => state.set_message(format!("failed to delete force field: {error}")),
+        Err(error) => state.report_system_error(
+            SystemSubsystem::Storage,
+            format!("failed to delete force field: {error}"),
+        ),
     }
 }
 
@@ -444,7 +458,10 @@ pub(crate) fn import_custom_force_field_file(state: &mut AppState) {
     let text = match std::fs::read_to_string(&path) {
         Ok(text) => text,
         Err(error) => {
-            state.set_message(format!("failed to read {}: {error}", path.display()));
+            state.report_system_error(
+                SystemSubsystem::File,
+                format!("failed to read {}: {error}", path.display()),
+            );
             return;
         }
     };

--- a/src/frontend/dispatcher/builders/qm.rs
+++ b/src/frontend/dispatcher/builders/qm.rs
@@ -1,6 +1,7 @@
 use super::super::*;
 use crate::engines::qm::{MemoryVerdict, QmScfBackend, memory_verdict};
 use crate::frontend::actions::{Notification, NotificationButton, NotificationSeverity};
+use crate::frontend::state::SystemSubsystem;
 
 /// Resolve the product structure for a two-endpoint transition-state search from
 /// the prompt's chosen entry, loading it on demand. `None` for any other route or
@@ -29,11 +30,11 @@ pub(crate) fn start_pending_qm(state: &mut AppState) {
         return;
     };
     if state.jobs.qm_running() {
-        state.set_message("a QM calculation is already running; press Esc to stop".to_string());
+        state.status_neutral("a QM calculation is already running; press Esc to stop".to_string());
         return;
     }
     if state.structure().atoms.is_empty() {
-        state.set_message("open a structure before running a QM calculation".to_string());
+        state.status_neutral("open a structure before running a QM calculation".to_string());
         return;
     }
     // A periodic run needs a real unit cell; reject early with a clear message
@@ -47,8 +48,9 @@ pub(crate) fn start_pending_qm(state: &mut AppState) {
             .filter(|cell| !cell.is_placeholder())
             .is_none()
     {
-        state
-            .set_message("periodic QM needs a real unit cell; this structure has none".to_string());
+        state.status_neutral(
+            "periodic QM needs a real unit cell; this structure has none".to_string(),
+        );
         return;
     }
     // Memory guard: estimate the in-core ERI allocation for a molecular job and
@@ -65,7 +67,7 @@ pub(crate) fn start_pending_qm(state: &mut AppState) {
         && prompt.ts.route == crate::frontend::state::TsRouteKind::TwoEndpoint
     {
         if ts_product.is_none() {
-            state.set_message(
+            state.status_neutral(
                 "choose a product structure for the two-endpoint transition-state search"
                     .to_string(),
             );
@@ -74,7 +76,7 @@ pub(crate) fn start_pending_qm(state: &mut AppState) {
         // The reactant is the active entry; identical endpoints give a degenerate
         // (zero-displacement) guess, so reject the active entry as its own product.
         if prompt.ts.product_entry == state.entries.active_entry_id() {
-            state.set_message(
+            state.status_neutral(
                 "the product must be a different structure than the reactant (the active entry)"
                     .to_string(),
             );
@@ -101,7 +103,7 @@ pub(crate) fn start_pending_qm(state: &mut AppState) {
             crate::engines::registry::EngineId::ORCA,
         );
         let Ok(resolved) = resolved else {
-            state.set_message(
+            state.status_neutral(
                 "set the ORCA program path in Settings -> Compute targets before running"
                     .to_string(),
             );
@@ -126,7 +128,7 @@ pub(crate) fn start_pending_qm(state: &mut AppState) {
             let running = match running {
                 Ok(running) => running,
                 Err(error) => {
-                    state.set_message(format!("could not bind the QM engine launch: {error}"));
+                    state.status_error(format!("could not bind the QM engine launch: {error}"));
                     return;
                 }
             };
@@ -135,7 +137,7 @@ pub(crate) fn start_pending_qm(state: &mut AppState) {
                 begin_local_job(state, crate::frontend::jobs::LocalJobSlot::Qm, task_run_id);
                 state.tasks.mark_status(task_run_id, TaskStatus::Running);
             }
-            state.set_message("QM calculation running; press Esc to stop".to_string());
+            state.status_neutral("QM calculation running; press Esc to stop".to_string());
         }
     }
 }
@@ -155,9 +157,10 @@ fn reserve_qm_run_dir(state: &mut AppState) {
         return;
     };
     if let Err(error) = ensure_active_task_run_dir(state, kind, None) {
-        state
-            .output_log
-            .push(format!("failed to create QM run directory: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Storage,
+            format!("failed to create QM run directory: {error}"),
+        );
     }
 }
 
@@ -230,17 +233,24 @@ fn start_remote_qm(
 pub(crate) fn cancel_pending_qm_request(state: &mut AppState) {
     bind_active_panel_task(state, TaskPanelKind::QmPrompt);
     if state.jobs.qm_running() {
+        // Read the Copy JobId before the cancel borrows `state` mutably, so the
+        // stop notice can be scoped to the exact job.
+        let job_id = state
+            .jobs
+            .local_execution(crate::frontend::jobs::LocalJobSlot::Qm);
         let _ = crate::frontend::jobs::cancel_controlled_job(
             state,
             &crate::frontend::jobs::JobControlId::Local(crate::frontend::jobs::LocalJobSlot::Qm),
         );
         state.ui.pending_qm = None;
-        state.set_message("QM calculation stopping".to_string());
+        if let Some(job_id) = job_id {
+            state.job_notice(job_id, "QM calculation stopping");
+        }
         close_active_task_panel(state);
         return;
     }
     state.ui.pending_qm = None;
-    state.set_message("QM calculation canceled".to_string());
+    state.status_neutral("QM calculation canceled".to_string());
     complete_active_qm_task(state, TaskStatus::Failed);
     close_active_task_panel(state);
 }
@@ -307,7 +317,7 @@ pub(crate) fn estimate_qm_memory(state: &mut AppState) {
         return;
     }
     if state.structure().atoms.is_empty() {
-        state.set_message("open a structure before estimating QM memory".to_string());
+        state.status_neutral("open a structure before estimating QM memory".to_string());
         return;
     }
     // The product does not change the in-core estimate (the guess shares the
@@ -330,7 +340,7 @@ pub(crate) fn estimate_qm_memory(state: &mut AppState) {
             if let Some(prompt) = state.ui.pending_qm.as_mut() {
                 prompt.memory_report = None;
             }
-            state.set_message(format!("could not estimate QM memory: {error}"));
+            state.status_error(format!("could not estimate QM memory: {error}"));
         }
     }
 }

--- a/src/frontend/dispatcher/chart.rs
+++ b/src/frontend/dispatcher/chart.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use super::*;
 use crate::backend::runs::{QmSeries, SERIES_FILE, load_qm_series_file};
 use crate::frontend::actions::{ChartAxis, ChartTarget};
-use crate::frontend::state::{ChartExportDraft, ChartState, StaticView};
+use crate::frontend::state::{ChartExportDraft, ChartState, LogLevel, StaticView, SystemSubsystem};
 use crate::plot::spec::{
     AxisSpec, ChartSpec, ExportFormat, ExportStyle, Mark, PresetChoice, Series,
 };
@@ -75,7 +75,7 @@ pub(crate) fn open_chart(state: &mut AppState, target: ChartTarget, ctx: &egui::
         ChartTarget::TaskRun(task_run_id) => task_series_path(state, task_run_id),
     };
     let Some((source_name, series_path)) = resolved else {
-        state.set_message("This item has no chart data".to_string());
+        state.status_neutral("This item has no chart data".to_string());
         return;
     };
     let mut chart = ChartState::new(source_name);
@@ -185,7 +185,7 @@ pub(crate) fn export_chart(state: &mut AppState) {
         return;
     };
     let Some(dataset) = chart.active_dataset() else {
-        state.set_message("No dataset to export".to_string());
+        state.status_neutral("No dataset to export".to_string());
         return;
     };
     let mut spec = dataset.clone();
@@ -219,22 +219,23 @@ pub(crate) fn export_chart(state: &mut AppState) {
                 preset: draft.preset,
                 dpi: draft.dpi,
             };
-            // The prefs save is a best-effort follow-up; fold any failure into
-            // the export confirmation so the "Chart exported" message isn't
-            // silently overwritten by the warning.
+            // The prefs save is a best-effort follow-up; a failure is logged to
+            // Output so the "Chart exported" success status isn't overwritten by
+            // a warning.
             let exported = format!("Chart exported to {}", path.display());
             if let Err(error) = save_config(&state.config) {
-                state.set_message(format!(
-                    "{exported}. Export preferences were not saved: {error}"
-                ));
-            } else {
-                state.set_message(exported);
+                state.log_system(
+                    SystemSubsystem::Settings,
+                    LogLevel::Warn,
+                    format!("Export preferences were not saved: {error}"),
+                );
             }
+            state.status_success(exported);
             if let Some(chart) = state.ui.chart.as_mut() {
                 chart.export_open = false;
             }
         }
-        Err(error) => state.set_message(format!("Chart export failed: {error}")),
+        Err(error) => state.status_error(format!("Chart export failed: {error}")),
     }
 }
 

--- a/src/frontend/dispatcher/disorder.rs
+++ b/src/frontend/dispatcher/disorder.rs
@@ -28,17 +28,17 @@ pub(crate) fn start_pending_disorder(state: &mut AppState) {
         return;
     };
     if state.jobs.disorder_running() {
-        state.set_message("a packing job is already running".to_string());
+        state.status_neutral("a packing job is already running");
         return;
     }
     if prompt.components.is_empty() {
-        state.set_message("Add at least one molecule to pack".to_string());
+        state.status_neutral("Add at least one molecule to pack");
         return;
     }
     let request = match build_pack_request(state, &prompt) {
         Ok(request) => request,
         Err(error) => {
-            state.set_message(error.to_string());
+            state.status_neutral(error.to_string());
             return;
         }
     };
@@ -74,7 +74,7 @@ pub(crate) fn start_pending_disorder(state: &mut AppState) {
         );
         mark_task_status(state, task_run_id, TaskStatus::Running);
     }
-    state.set_message("Packing disordered system; press Esc to stop".to_string());
+    state.status_neutral("Packing disordered system; press Esc to stop");
 }
 
 pub(crate) fn cancel_pending_disorder_request(state: &mut AppState) {
@@ -88,7 +88,7 @@ pub(crate) fn cancel_pending_disorder_request(state: &mut AppState) {
         );
     }
     state.ui.pending_disorder = None;
-    state.set_message("Packing canceled".to_string());
+    state.status_neutral("Packing canceled");
     complete_active_task(state, TaskKind::BuildDisorderedSystem, TaskStatus::Failed);
     close_active_task_panel(state);
 }
@@ -259,24 +259,27 @@ impl JobRuntime for RunningDisorderJob {
     fn request_cancel(&mut self, state: &mut AppState) -> CancelSignal {
         self.cancel
             .store(true, std::sync::atomic::Ordering::Relaxed);
-        state.set_message("Packing stopping; finishing the current pass".to_string());
+        if let Some(job_id) = state.jobs.local_execution(self.slot()) {
+            state.job_notice(job_id, "Packing stopping; finishing the current pass");
+        }
         CancelSignal::Accepted
     }
 
-    fn poll(&mut self, state: &mut AppState, _cx: &JobContext) -> JobPoll {
+    fn poll(&mut self, state: &mut AppState, cx: &JobContext) -> JobPoll {
         // Disorder streams into the entry created up front (`result_entry_id`),
         // overwriting it in place; it adds no new entry and records no ledger row.
         let entry_id = self.result_entry_id;
         loop {
             match self.receiver.try_recv() {
                 Ok(DisorderWorkerMessage::Progress { structure, report }) => {
+                    // Placement counts are structured progress Activity reads, not a
+                    // log firehose; the Esc hint is posted once, on the first update.
+                    let first = self.latest_report.is_none();
                     write_disorder_structure(state, entry_id, structure);
-                    state.set_message(format!(
-                        "Packing: {}/{} molecules placed; press Esc to stop",
-                        report.total_placed(),
-                        report.total_requested()
-                    ));
                     self.latest_report = Some(report);
+                    if first {
+                        state.status_neutral("Packing disordered system… press Esc to stop");
+                    }
                 }
                 Ok(DisorderWorkerMessage::Finished { structure, report }) => {
                     write_disorder_structure(state, entry_id, structure);
@@ -289,12 +292,20 @@ impl JobRuntime for RunningDisorderJob {
                             None,
                         );
                     }
-                    state.set_message(disorder_finished_message(&report));
+                    let message = disorder_finished_message(&report);
+                    match cx.job_id {
+                        Some(job_id) => state.job_succeeded(job_id, message),
+                        None => state.status_success(message),
+                    }
                     self.latest_report = Some(report);
                     return JobPoll::Terminal(TaskStatus::Completed);
                 }
                 Ok(DisorderWorkerMessage::Failed(error)) => {
-                    state.set_message(format!("Packing failed: {error}"));
+                    let message = format!("Packing failed: {error}");
+                    match cx.job_id {
+                        Some(job_id) => state.job_failed(job_id, message),
+                        None => state.status_error(message),
+                    }
                     return JobPoll::Terminal(TaskStatus::Failed);
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => return JobPoll::Running,

--- a/src/frontend/dispatcher/dock.rs
+++ b/src/frontend/dispatcher/dock.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::frontend::state::{DockArea, DockTab, StaticView};
+use crate::frontend::state::{
+    DetailTarget, DockArea, DockTab, LogFilter, LogQuery, OutputTarget, StaticView,
+};
 
 /// Mark the workbench layout dirty using the current egui clock; the debounced
 /// flush (see [`flush_pending_layout_save`]) coalesces a burst of changes into a
@@ -44,6 +46,36 @@ pub(crate) fn toggle_dock_area(state: &mut AppState, area: DockArea, ctx: &egui:
         }
     }
     mark_dirty(state, ctx);
+}
+
+/// Reveal the Output tab and apply `target`'s source/exact-job filter in one
+/// step: restore the tab if absent, activate its dock area, select the filter,
+/// and mark the target read. The dispatcher owns dock reveal *and* filter
+/// selection so a single user action never leaves them out of sync.
+pub(crate) fn reveal_output(state: &mut AppState, target: OutputTarget) {
+    state.ui.layout.dock.reveal_static(StaticView::Output);
+    let query = LogQuery::new(LogFilter::from_output_target(&target));
+    if let Some(latest) = state.session_log().latest_matching_seq(&query) {
+        state
+            .ui
+            .output
+            .last_seen_by_target
+            .insert(target.clone(), latest);
+    }
+    state.ui.output.auto_follow = true;
+    state.ui.output.target = target;
+}
+
+/// Follow a status-notice link to its typed detail target.
+pub(crate) fn open_detail_target(state: &mut AppState, target: DetailTarget) {
+    match target {
+        DetailTarget::Output(output_target) => reveal_output(state, output_target),
+        DetailTarget::ActivityJob(job_id) => {
+            state.ui.activity_job_target = Some(job_id);
+            state.ui.layout.dock.reveal_static(StaticView::TaskMonitor);
+        }
+        DetailTarget::Settings => state.ui.layout.settings_open = true,
+    }
 }
 
 /// Resize a dock area — the right sidebar's width or the bottom panel's height —
@@ -102,7 +134,10 @@ pub(crate) fn persist_layout(state: &mut AppState) {
     state.clear_layout_save_deadline();
     state.config.dock_layout = state.ui.layout.dock.to_config();
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save layout: {error}"));
+        state.report_system_error(
+            crate::frontend::state::SystemSubsystem::Settings,
+            format!("Could not save layout: {error}"),
+        );
     }
 }
 

--- a/src/frontend/dispatcher/docking.rs
+++ b/src/frontend/dispatcher/docking.rs
@@ -8,6 +8,7 @@ use crate::engines::docking::{
 use crate::frontend::jobs::{
     DockingWorkerMessage, LocalJobSlot, RunningDockingJob, spawn_docking_job,
 };
+use crate::frontend::state::{LogLevel, SystemSubsystem};
 use crate::job::CancelSignal;
 
 /// File name of the saved multi-pose PDBQT inside a docking task's run directory.
@@ -20,37 +21,40 @@ pub(crate) fn start_pending_docking(state: &mut AppState) {
         return;
     };
     if state.jobs.docking_running() {
-        state.set_message("a docking run is already in progress; press Esc to stop".to_string());
+        state.status_neutral("a docking run is already in progress; press Esc to stop");
         return;
     }
     let Some(receptor_id) = prompt.receptor_entry else {
-        state.set_message("choose a receptor entry before docking".to_string());
+        state.status_neutral("choose a receptor entry before docking");
         return;
     };
     let Some(ligand_id) = prompt.ligand_entry else {
-        state.set_message("choose a ligand entry before docking".to_string());
+        state.status_neutral("choose a ligand entry before docking");
         return;
     };
     if receptor_id == ligand_id {
-        state.set_message("the receptor and ligand must be different entries".to_string());
+        state.status_neutral("the receptor and ligand must be different entries");
         return;
     }
     if prompt.box_size.iter().any(|&size| size <= 0.0) {
-        state.set_message("the search box must have a positive size on every axis".to_string());
+        state.status_neutral("the search box must have a positive size on every axis");
         return;
     }
     let Some(receptor) = entry_structure(state, receptor_id) else {
-        state.set_message("the receptor entry has no structure".to_string());
+        state.status_neutral("the receptor entry has no structure");
         return;
     };
     let Some(ligand) = entry_structure(state, ligand_id) else {
-        state.set_message("the ligand entry has no structure".to_string());
+        state.status_neutral("the ligand entry has no structure");
         return;
     };
     // Create the run directory up front so the poses artifact has a home and the
     // run records its source entry.
     if let Err(error) = ensure_active_task_run_dir(state, TaskKind::RunDocking, None) {
-        state.set_message(format!("could not create docking run directory: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Storage,
+            format!("could not create docking run directory: {error}"),
+        );
         return;
     }
 
@@ -96,7 +100,7 @@ pub(crate) fn start_pending_docking(state: &mut AppState) {
                 );
                 state.tasks.mark_status(task_run_id, TaskStatus::Running);
             }
-            state.set_message("docking running; press Esc to stop".to_string());
+            state.status_neutral("docking running; press Esc to stop");
         }
     }
 }
@@ -121,7 +125,7 @@ pub(crate) fn cancel_pending_docking_request(state: &mut AppState) {
         );
     }
     state.ui.pending_docking = None;
-    state.set_message("docking canceled".to_string());
+    state.status_neutral("docking canceled");
     complete_active_task(state, TaskKind::RunDocking, TaskStatus::Failed);
     close_active_task_panel(state);
 }
@@ -146,22 +150,27 @@ impl JobRuntime for RunningDockingJob {
         // truthfully as `Unsupported` — the job is not moved to `Cancelling`.
         self.cancel
             .store(true, std::sync::atomic::Ordering::Relaxed);
-        state.set_message("docking stopping (the current search runs to completion)".to_string());
+        if let Some(job_id) = state.jobs.local_execution(self.slot()) {
+            state.job_notice(
+                job_id,
+                "docking stopping (the current search runs to completion)",
+            );
+        }
         CancelSignal::Unsupported
     }
 
     fn poll(&mut self, state: &mut AppState, cx: &JobContext) -> JobPoll {
         loop {
             match self.receiver.try_recv() {
-                Ok(DockingWorkerMessage::Progress { stage }) => {
-                    state.set_message(format!("Docking: {stage}; press Esc to stop"));
-                }
+                Ok(DockingWorkerMessage::Progress { stage }) => self.latest_stage = Some(stage),
                 Ok(DockingWorkerMessage::Finished(outcome)) => {
                     apply_docking_outcome(state, cx, *outcome);
                     return JobPoll::Terminal(TaskStatus::Completed);
                 }
                 Ok(DockingWorkerMessage::Failed(error)) => {
-                    state.set_message(format!("docking failed: {error}"));
+                    if let Some(job_id) = cx.job_id {
+                        state.job_failed(job_id, format!("docking failed: {error}"));
+                    }
                     return JobPoll::Terminal(TaskStatus::Failed);
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => return JobPoll::Running,
@@ -174,8 +183,10 @@ impl JobRuntime for RunningDockingJob {
 /// Apply a finished local docking search: save the poses, add one entry per pose,
 /// and record them in the ledger so a re-poll never re-creates them.
 fn apply_docking_outcome(state: &mut AppState, cx: &JobContext, outcome: DockingOutcome) {
-    for line in outcome.summary.lines() {
-        state.output_log.push(line.to_string());
+    if let Some(job_id) = cx.job_id {
+        for line in outcome.summary.lines() {
+            state.append_job_log(job_id, LogLevel::Info, line);
+        }
     }
     let poses_path = save_dock_poses(state, &outcome);
     let already = cx
@@ -192,11 +203,15 @@ fn apply_docking_outcome(state: &mut AppState, cx: &JobContext, outcome: Docking
         .first()
         .map(|pose| pose.affinity)
         .unwrap_or(0.0);
-    state.set_message(format!(
+    let summary = format!(
         "Docking complete: {} pose(s), best {:+.2} kcal/mol",
         outcome.poses.len(),
         best
-    ));
+    );
+    match cx.job_id {
+        Some(job_id) => state.job_succeeded(job_id, summary),
+        None => state.status_success(summary),
+    }
 }
 
 /// Apply a retrieved remote docking outcome: log the summary, save the poses
@@ -209,8 +224,17 @@ pub(crate) fn apply_remote_docking_outcome(
     row: &crate::backend::storage::jobs::RemoteJob,
     outcome: DockingOutcome,
 ) {
-    for line in outcome.summary.lines() {
-        state.output_log.push(line.to_string());
+    let job_id: Option<crate::job::JobId> = row.job_id.parse().ok();
+    if job_id.is_none() {
+        state.report_unscoped_remote_error(format!(
+            "Remote docking result has invalid job id `{}`",
+            row.job_id
+        ));
+    }
+    if let Some(job_id) = job_id {
+        for line in outcome.summary.lines() {
+            state.append_job_log(job_id, LogLevel::Info, line);
+        }
     }
     let run_dir = PathBuf::from(&row.local_run_dir);
     let _ = std::fs::create_dir_all(&run_dir);
@@ -239,11 +263,14 @@ pub(crate) fn apply_remote_docking_outcome(
         .first()
         .map(|pose| pose.affinity)
         .unwrap_or(0.0);
-    state.set_message(format!(
+    let summary = format!(
         "Remote docking complete: {} pose(s), best {:+.2} kcal/mol",
         outcome.poses.len(),
         best
-    ));
+    );
+    if let Some(job_id) = job_id {
+        state.job_succeeded(job_id, summary);
+    }
 }
 
 /// Format every pose as one multi-`MODEL` PDBQT document — the saved run artifact,
@@ -268,24 +295,30 @@ fn save_dock_poses(state: &mut AppState, outcome: &DockingOutcome) -> Option<Pat
     let run_dir = match ensure_active_task_run_dir(state, TaskKind::RunDocking, None) {
         Ok(run_dir) => run_dir,
         Err(error) => {
-            state
-                .output_log
-                .push(format!("failed to create docking run directory: {error}"));
+            state.log_system(
+                SystemSubsystem::Storage,
+                LogLevel::Warn,
+                format!("failed to create docking run directory: {error}"),
+            );
             return None;
         }
     };
     let path = run_dir.join(DOCK_POSES_FILE);
     match std::fs::write(&path, dock_poses_pdbqt(outcome)) {
         Ok(()) => {
-            state
-                .output_log
-                .push(format!("docking poses saved to {}", path.display()));
+            state.log_system(
+                SystemSubsystem::File,
+                LogLevel::Info,
+                format!("docking poses saved to {}", path.display()),
+            );
             Some(path)
         }
         Err(error) => {
-            state
-                .output_log
-                .push(format!("failed to save docking poses: {error}"));
+            state.log_system(
+                SystemSubsystem::Storage,
+                LogLevel::Warn,
+                format!("failed to save docking poses: {error}"),
+            );
             None
         }
     }

--- a/src/frontend/dispatcher/export.rs
+++ b/src/frontend/dispatcher/export.rs
@@ -7,7 +7,7 @@ use crate::{
 
 pub(crate) fn open_export_dialog(state: &mut AppState, entry_id: Option<u64>) {
     if state.entries.records.is_empty() {
-        state.set_message("Nothing to export".to_string());
+        state.status_neutral("Nothing to export".to_string());
         return;
     }
 
@@ -35,7 +35,7 @@ pub(crate) fn run_export(state: &mut AppState) {
         &entry_ids_for_scope(state, prompt.scope, &prompt.selected_entry_ids),
     );
     if ids.is_empty() {
-        state.set_message("Nothing to export".to_string());
+        state.status_neutral("Nothing to export".to_string());
         return;
     }
 
@@ -180,7 +180,7 @@ fn export_to_file(state: &mut AppState, ids: &[u64], format: StructureFormat) {
         .save_file()
         .map(|path| structure_io::path_with_format_extension(&path, format))
     else {
-        state.set_message("Export canceled".to_string());
+        state.status_neutral("Export canceled".to_string());
         return;
     };
 
@@ -191,19 +191,19 @@ fn export_to_file(state: &mut AppState, ids: &[u64], format: StructureFormat) {
             if let [entry_id] = ids {
                 remember_export_target(state, *entry_id, path.clone());
             }
-            state.set_message(format!(
+            state.status_success(format!(
                 "Exported {} to {}",
                 structure_count(ids.len()),
                 path.display()
             ));
         }
-        Err(error) => state.set_message(format!("Export failed: {error}")),
+        Err(error) => state.status_error(format!("Export failed: {error}")),
     }
 }
 
 fn export_to_directory(state: &mut AppState, ids: &[u64], format: StructureFormat) {
     let Some(directory) = rfd::FileDialog::new().pick_folder() else {
-        state.set_message("Export canceled".to_string());
+        state.status_neutral("Export canceled".to_string());
         return;
     };
 
@@ -212,12 +212,12 @@ fn export_to_directory(state: &mut AppState, ids: &[u64], format: StructureForma
         .filter(|path| path.exists())
         .count();
     if existing > 0 && !confirm_overwrite(existing) {
-        state.set_message("Export canceled".to_string());
+        state.status_neutral("Export canceled".to_string());
         return;
     }
 
     let (paths, results) = write_ids_to_directory(state, ids, &directory, format);
-    state.set_message(directory_export_summary(&directory, &paths, &results));
+    state.status_success(directory_export_summary(&directory, &paths, &results));
 }
 
 pub(crate) fn directory_export_summary(

--- a/src/frontend/dispatcher/feedback_tests.rs
+++ b/src/frontend/dispatcher/feedback_tests.rs
@@ -1,0 +1,202 @@
+//! Integration tests for the typed feedback architecture: command-transcript
+//! grouping, exact-`JobId` log isolation, typed Output reveal, and the composite
+//! persistence-failure route. Store-level folding/retention live with
+//! [`SessionLogStore`](crate::frontend::state::SessionLogStore); these exercise
+//! the dispatcher/state seams.
+
+use crate::frontend::console::record_console_command;
+use crate::frontend::state::{
+    AppState, CommandActor, DockTab, LogFilter, LogLevel, LogQuery, LogScope, OutputSource,
+    OutputTarget, StaticView, StatusSeverity, SystemSubsystem,
+};
+use crate::job::JobId;
+
+fn scratch() -> AppState {
+    AppState::scratch(Default::default(), Vec::new())
+}
+
+fn command_entries(state: &AppState) -> Vec<(u64, CommandActor, LogLevel, String)> {
+    let query = LogQuery::new(LogFilter::Command);
+    state
+        .session_log()
+        .query(&query)
+        .filter_map(|entry| match entry.scope {
+            LogScope::Command { command_id, actor } => {
+                Some((command_id, actor, entry.level, entry.text.clone()))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn console_command_groups_prompt_and_result_under_one_command_id() {
+    let mut state = scratch();
+    let _ = record_console_command(&mut state, "help", CommandActor::User);
+
+    let entries = command_entries(&state);
+    assert!(entries.len() >= 2, "prompt plus at least one result line");
+    let command_id = entries[0].0;
+    assert!(
+        entries.iter().all(|(id, ..)| *id == command_id),
+        "every entry of one invocation shares its CommandId"
+    );
+    assert_eq!(entries[0].1, CommandActor::User);
+    assert_eq!(entries[0].3, "help", "the prompt records the raw command");
+}
+
+#[test]
+fn concurrent_commands_do_not_cross_associate() {
+    let mut state = scratch();
+    let _ = record_console_command(&mut state, "help", CommandActor::User);
+    let _ = record_console_command(&mut state, "help", CommandActor::User);
+
+    let ids: std::collections::BTreeSet<u64> = command_entries(&state)
+        .into_iter()
+        .map(|(id, ..)| id)
+        .collect();
+    assert_eq!(ids.len(), 2, "each invocation gets a distinct CommandId");
+}
+
+#[test]
+fn assistant_issued_command_is_command_scoped_with_agent_actor() {
+    let mut state = scratch();
+    let _ = record_console_command(&mut state, "help", CommandActor::Agent);
+
+    let entries = command_entries(&state);
+    assert!(!entries.is_empty());
+    assert!(
+        entries
+            .iter()
+            .all(|(_, actor, ..)| *actor == CommandActor::Agent),
+        "an assistant command stays Command-scoped with the Agent actor"
+    );
+    // It never leaks into the Output (non-command) surface.
+    let output = LogQuery::new(LogFilter::OutputAll);
+    assert_eq!(state.session_log().query(&output).count(), 0);
+}
+
+#[test]
+fn console_error_is_recorded_as_a_command_error() {
+    let mut state = scratch();
+    let result = record_console_command(&mut state, "definitely-not-a-command", CommandActor::User);
+    assert!(result.is_err());
+    let entries = command_entries(&state);
+    assert!(
+        entries
+            .iter()
+            .any(|(_, _, level, _)| *level == LogLevel::Error),
+        "a failed command records an error line in the transcript"
+    );
+}
+
+#[test]
+fn two_concurrent_same_kind_jobs_never_share_log_scope() {
+    let mut state = scratch();
+    let a = JobId::new();
+    let b = JobId::new();
+    state.append_job_log(a, LogLevel::Info, "a: scf step 1");
+    state.append_job_log(b, LogLevel::Info, "b: scf step 1");
+    state.append_job_log(a, LogLevel::Info, "a: scf step 2");
+
+    let a_lines: Vec<_> = state
+        .session_log()
+        .tail_for_job(a, 10)
+        .map(|entry| entry.text.clone())
+        .collect();
+    let b_lines: Vec<_> = state
+        .session_log()
+        .tail_for_job(b, 10)
+        .map(|entry| entry.text.clone())
+        .collect();
+    assert_eq!(a_lines, vec!["a: scf step 1", "a: scf step 2"]);
+    assert_eq!(b_lines, vec!["b: scf step 1"]);
+}
+
+#[test]
+fn reveal_output_reveals_the_tab_and_applies_the_job_filter() {
+    let mut state = scratch();
+    let job_id = JobId::new();
+    // Collapse the bottom dock so reveal must restore/activate the tab.
+    state.ui.layout.dock.bottom.collapsed = true;
+    super::reveal_output(&mut state, OutputTarget::Job(job_id));
+
+    assert_eq!(state.ui.output.target, OutputTarget::Job(job_id));
+    assert!(
+        state
+            .ui
+            .layout
+            .dock
+            .is_visible(crate::frontend::state::DockArea::Bottom),
+        "revealing Output uncollapses its dock area"
+    );
+    assert_eq!(
+        state.ui.layout.dock.bottom.active,
+        Some(DockTab::Static(StaticView::Output)),
+    );
+}
+
+#[test]
+fn reveal_output_to_a_job_with_no_text_keeps_it_selected() {
+    let mut state = scratch();
+    let job_id = JobId::new();
+    super::reveal_output(&mut state, OutputTarget::Job(job_id));
+    // No captured text yet, but the exact job remains the active filter.
+    assert_eq!(state.ui.output.target, OutputTarget::Job(job_id));
+    let query = LogQuery::new(LogFilter::Job(job_id));
+    assert!(!state.session_log().any(&query));
+}
+
+#[test]
+fn persistence_failure_yields_one_system_log_and_one_linked_sticky_status() {
+    let mut state = scratch();
+    state.report_system_error(SystemSubsystem::Storage, "disk full");
+
+    // Exactly one canonical System entry (not two differently-worded rows).
+    let query = LogQuery::new(LogFilter::Source(OutputSource::System));
+    let system: Vec<_> = state
+        .session_log()
+        .query(&query)
+        .map(|entry| (entry.level, entry.text.clone()))
+        .collect();
+    assert_eq!(system, vec![(LogLevel::Error, "disk full".to_string())]);
+
+    // Plus one linked sticky error status carrying the same text.
+    let notice = state.status_notice().expect("a status is posted");
+    assert_eq!(notice.severity, StatusSeverity::Error);
+    assert_eq!(notice.text, "disk full");
+    assert!(notice.target.is_some(), "the status links to the detail");
+}
+
+#[test]
+fn status_link_navigates_and_acknowledge_clears() {
+    let mut state = scratch();
+    state.report_system_error(SystemSubsystem::Settings, "bad config");
+    assert!(state.status_notice().is_some());
+    state.acknowledge_status();
+    assert!(
+        state.status_notice().is_none(),
+        "acknowledging clears the slot; the System log record persists"
+    );
+    // The canonical log entry survives acknowledgement.
+    let query = LogQuery::new(LogFilter::OutputAll);
+    assert_eq!(state.session_log().query(&query).count(), 1);
+}
+
+#[test]
+fn dock_default_bottom_order_keeps_the_five_tokens() {
+    let dock = crate::frontend::state::DockModel::default();
+    let tokens: Vec<&str> = dock
+        .bottom
+        .tabs
+        .iter()
+        .filter_map(|tab| match tab {
+            DockTab::Static(view) => Some(view.token()),
+            DockTab::Task(_) => None,
+        })
+        .collect();
+    assert_eq!(
+        tokens,
+        vec!["console", "sequence", "task_monitor", "output", "plot"],
+    );
+}

--- a/src/frontend/dispatcher/files.rs
+++ b/src/frontend/dispatcher/files.rs
@@ -31,7 +31,7 @@ pub(crate) fn fetch_pdb(state: &mut AppState) {
             state.ui.pending_pdb_fetch = None;
             open_paths(state, [fetched.path]);
         }
-        Err(error) => state.set_message(format!("Fetch failed: {error}")),
+        Err(error) => state.status_error(format!("Fetch failed: {error}")),
     }
 }
 
@@ -54,7 +54,7 @@ pub fn open_paths(state: &mut AppState, paths: impl IntoIterator<Item = PathBuf>
 
     let Some((entry_id, last_path)) = opened.last() else {
         if let Some(error) = failed.first() {
-            state.set_message(format!("Failed to open {error}"));
+            state.status_error(format!("Failed to open {error}"));
         }
         return;
     };
@@ -63,7 +63,7 @@ pub fn open_paths(state: &mut AppState, paths: impl IntoIterator<Item = PathBuf>
     state.ui.entry_list.selected_entry_ids.insert(*entry_id);
     load_active_entry(state);
     state.ui.selection.clear();
-    state.set_message(format_open_results(opened.len(), failed.len(), last_path));
+    state.status_success(format_open_results(opened.len(), failed.len(), last_path));
 }
 
 pub(crate) fn format_open_results(
@@ -113,7 +113,7 @@ pub(crate) fn apply_structure_edits(state: &mut AppState) {
         state.history.push_undo(before);
         state.edit_origin = None;
         state.ui.editor = None;
-        state.set_message("Applied structure edits".to_string());
+        state.status_success("Applied structure edits".to_string());
     }
 }
 
@@ -127,5 +127,5 @@ pub(crate) fn cancel_structure_edits(state: &mut AppState) {
     } else {
         return;
     }
-    state.set_message("Edit canceled".to_string());
+    state.status_neutral("Edit canceled".to_string());
 }

--- a/src/frontend/dispatcher/gromacs.rs
+++ b/src/frontend/dispatcher/gromacs.rs
@@ -5,6 +5,7 @@
 
 use super::*;
 
+use crate::frontend::state::LogLevel;
 use crate::workflows::gromacs::{GromacsJob, GromacsOutcome, WireTopology};
 
 /// Submit a prepared GROMACS job to a remote host as a detached relay: tag the
@@ -46,8 +47,17 @@ pub(crate) fn apply_remote_gromacs_outcome(
     row: &crate::backend::storage::jobs::RemoteJob,
     outcome: GromacsOutcome,
 ) {
-    for line in outcome.summary.lines() {
-        state.output_log.push(line.to_string());
+    let job_id: Option<crate::job::JobId> = row.job_id.parse().ok();
+    if job_id.is_none() {
+        state.report_unscoped_remote_error(format!(
+            "Remote GROMACS result has invalid job id `{}`",
+            row.job_id
+        ));
+    }
+    if let Some(job_id) = job_id {
+        for line in outcome.summary.lines() {
+            state.append_job_log(job_id, LogLevel::Info, line);
+        }
     }
 
     let belongs_here = outcome_belongs_to_current_workspace(state, row);
@@ -101,7 +111,10 @@ pub(crate) fn apply_remote_gromacs_outcome(
         .lines()
         .next()
         .unwrap_or("GROMACS run complete");
-    state.set_message(format!("Remote {headline}"));
+    let summary = format!("Remote {headline}");
+    if let Some(job_id) = job_id {
+        state.job_succeeded(job_id, summary);
+    }
 }
 
 /// Write a relayed topology (`topol.top` plus its `.itp` includes) into the run

--- a/src/frontend/dispatcher/heavy_render.rs
+++ b/src/frontend/dispatcher/heavy_render.rs
@@ -70,7 +70,7 @@ pub(crate) fn use_wireframe_for_heavy_entry(state: &mut AppState, entry_id: u64)
             .ui
             .viewport
             .apply_atom_styles(items, AtomStyle::Wireframe);
-        state.set_message(format!("Showing {count} atom(s) as wireframe"));
+        state.status_neutral(format!("Showing {count} atom(s) as wireframe"));
     }
     state.ui.heavy_render_decided.insert(entry_id);
     state.ui.pending_heavy_gate = None;
@@ -82,6 +82,6 @@ pub(crate) fn render_heavy_entry_at_full(state: &mut AppState, entry_id: u64) {
     state.ui.heavy_render_decided.insert(entry_id);
     state.ui.pending_heavy_gate = None;
     if state.entries.active_entry_id() == Some(entry_id) {
-        state.set_message("Rendering at full detail".to_string());
+        state.status_neutral("Rendering at full detail".to_string());
     }
 }

--- a/src/frontend/dispatcher/jobs.rs
+++ b/src/frontend/dispatcher/jobs.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::frontend::state::{LogLevel, SystemSubsystem};
 
 mod compute;
 mod poll;
@@ -31,7 +32,7 @@ pub(crate) fn load_trajectory(
         match requested.or_else(|| entry.origin.trajectory().map(|path| path.to_path_buf())) {
             Some(relative) => relative,
             None => {
-                state.set_message("This entry has no trajectory to play");
+                state.status_neutral("This entry has no trajectory to play");
                 return;
             }
         };
@@ -62,12 +63,12 @@ pub(crate) fn load_trajectory(
     }
 
     let Some(project) = state.workspace.project() else {
-        state.set_message("Trajectory playback requires an open project");
+        state.status_neutral("Trajectory playback requires an open project");
         return;
     };
     let absolute = project.root.join(&relative);
     if !absolute.exists() {
-        state.set_message(format!(
+        state.status_error(format!(
             "Trajectory file is missing: {}",
             absolute.display()
         ));
@@ -84,7 +85,7 @@ pub(crate) fn load_trajectory(
         base_structure,
         include_cell,
     ));
-    state.set_message("Loading trajectory…");
+    state.status_neutral("Loading trajectory…");
     ctx.request_repaint_after(engine_poll_frame());
 }
 
@@ -154,9 +155,11 @@ pub(crate) fn save_qm_artifacts(
     outcome: &crate::engines::qm::QmOutcome,
 ) {
     if let Err(error) = std::fs::create_dir_all(run_dir) {
-        state
-            .output_log
-            .push(format!("failed to create QM run directory: {error}"));
+        state.log_system(
+            SystemSubsystem::Storage,
+            LogLevel::Warn,
+            format!("failed to create QM run directory: {error}"),
+        );
         return;
     }
 
@@ -166,12 +169,16 @@ pub(crate) fn save_qm_artifacts(
         text.push('\n');
     }
     match std::fs::write(&path, text) {
-        Ok(()) => state
-            .output_log
-            .push(format!("QM output saved to {}", path.display())),
-        Err(error) => state
-            .output_log
-            .push(format!("failed to save QM output: {error}")),
+        Ok(()) => state.log_system(
+            SystemSubsystem::File,
+            LogLevel::Info,
+            format!("QM output saved to {}", path.display()),
+        ),
+        Err(error) => state.log_system(
+            SystemSubsystem::Storage,
+            LogLevel::Warn,
+            format!("failed to save QM output: {error}"),
+        ),
     }
 
     let series = crate::backend::runs::QmSeries::from_outcome(outcome);
@@ -179,12 +186,16 @@ pub(crate) fn save_qm_artifacts(
         return;
     }
     match crate::backend::runs::save_qm_series_file(run_dir, &series) {
-        Ok(path) => state
-            .output_log
-            .push(format!("QM series saved to {}", path.display())),
-        Err(error) => state
-            .output_log
-            .push(format!("failed to save QM series: {error}")),
+        Ok(path) => state.log_system(
+            SystemSubsystem::File,
+            LogLevel::Info,
+            format!("QM series saved to {}", path.display()),
+        ),
+        Err(error) => state.log_system(
+            SystemSubsystem::Storage,
+            LogLevel::Warn,
+            format!("failed to save QM series: {error}"),
+        ),
     }
 }
 
@@ -220,7 +231,7 @@ pub(crate) fn show_qm_output(state: &mut AppState, entry_id: u64) {
     };
     let entry_name = entry.name.clone();
     let Some(path) = entry_qm_run_dir(state, entry_id).map(|dir| dir.join(QM_OUTPUT_FILE)) else {
-        state.set_message("This entry has no saved QM output".to_string());
+        state.status_neutral("This entry has no saved QM output".to_string());
         return;
     };
     match std::fs::read_to_string(&path) {
@@ -230,7 +241,7 @@ pub(crate) fn show_qm_output(state: &mut AppState, entry_id: u64) {
                 text,
             });
         }
-        Err(error) => state.set_message(format!(
+        Err(error) => state.status_error(format!(
             "Could not read QM output {}: {error}",
             path.display()
         )),
@@ -246,7 +257,7 @@ pub(crate) fn show_dock_poses(state: &mut AppState, entry_id: u64) {
     };
     let entry_name = entry.name.clone();
     let Some(relative) = entry.origin.dock_poses().map(Path::to_path_buf) else {
-        state.set_message("This entry has no saved docking poses".to_string());
+        state.status_neutral("This entry has no saved docking poses".to_string());
         return;
     };
     // Stored relative to the project root (absolute when the run directory
@@ -262,7 +273,7 @@ pub(crate) fn show_dock_poses(state: &mut AppState, entry_id: u64) {
                 text,
             });
         }
-        Err(error) => state.set_message(format!(
+        Err(error) => state.status_error(format!(
             "Could not read docking poses {}: {error}",
             absolute.display()
         )),

--- a/src/frontend/dispatcher/jobs/compute.rs
+++ b/src/frontend/dispatcher/jobs/compute.rs
@@ -4,6 +4,7 @@ use super::{JobContext, JobPoll, JobRuntime, drive};
 use crate::frontend::jobs::{
     EngineSuccess, LocalJobSlot, RunningEngineJob, RunningOptimization, RunningQmJob,
 };
+use crate::frontend::state::{LogLevel, SystemSubsystem};
 use crate::job::CancelSignal;
 
 /// Persist a locally-run QM calculation's artifacts into the active task's run
@@ -21,9 +22,10 @@ pub(crate) fn save_qm_run_artifacts(state: &mut AppState, outcome: &crate::engin
     }
     match ensure_active_task_run_dir(state, kind, None) {
         Ok(run_dir) => save_qm_artifacts(state, &run_dir, outcome),
-        Err(error) => state
-            .output_log
-            .push(format!("failed to create QM run directory: {error}")),
+        Err(error) => state.report_system_error(
+            SystemSubsystem::Storage,
+            format!("failed to create QM run directory: {error}"),
+        ),
     }
     state.ui.task_chart_thumbnails.remove(&task_run_id);
 }
@@ -47,7 +49,12 @@ impl JobRuntime for RunningEngineJob {
         // killed and the pipeline stops between stages.
         self.cancel
             .store(true, std::sync::atomic::Ordering::Relaxed);
-        state.set_message(format!("{} {} stopping", self.engine, self.job_kind));
+        if let Some(job_id) = state.jobs.local_execution(self.slot()) {
+            state.job_notice(
+                job_id,
+                format!("{} {} stopping", self.engine, self.job_kind),
+            );
+        }
         CancelSignal::Accepted
     }
 
@@ -56,10 +63,13 @@ impl JobRuntime for RunningEngineJob {
         loop {
             match self.receiver.try_recv() {
                 Ok(EngineWorkerMessage::Stage(stage)) => {
-                    state.set_message(format!("{engine_name}: {stage}"));
                     self.latest_stage = Some(stage);
                 }
-                Ok(EngineWorkerMessage::Log(line)) => self.append_log(line),
+                Ok(EngineWorkerMessage::Log(line)) => {
+                    if let Some(job_id) = cx.job_id {
+                        state.append_job_log(job_id, LogLevel::Info, line);
+                    }
+                }
                 Ok(EngineWorkerMessage::Finished(success)) => {
                     apply_engine_outcome(state, cx, *success);
                     // A completed build discards its pre-build undo snapshot.
@@ -67,7 +77,9 @@ impl JobRuntime for RunningEngineJob {
                     return JobPoll::Terminal(TaskStatus::Completed);
                 }
                 Ok(EngineWorkerMessage::Failed(error)) => {
-                    state.set_message(format!("{engine_name} failed: {error}"));
+                    if let Some(job_id) = cx.job_id {
+                        state.job_failed(job_id, format!("{engine_name} failed: {error}"));
+                    }
                     state.optimization_origin = None;
                     return JobPoll::Terminal(TaskStatus::Failed);
                 }
@@ -102,8 +114,8 @@ fn apply_engine_outcome(state: &mut AppState, cx: &JobContext, success: EngineSu
             Some(entry_id),
             &[entry_id],
         );
+        state.job_succeeded(job_id, success.summary);
     }
-    state.set_message(success.summary);
 }
 
 pub(crate) fn poll_optimization_job(state: &mut AppState, ctx: &egui::Context) {
@@ -123,17 +135,22 @@ impl JobRuntime for RunningOptimization {
     fn request_cancel(&mut self, state: &mut AppState) -> CancelSignal {
         self.cancel
             .store(true, std::sync::atomic::Ordering::Relaxed);
-        state.set_message(match self.latest_report {
-            Some(report) => format!(
-                "forcefield optimization stopping: energy {:.3} -> {:.3} in {} steps",
-                report.initial_energy, report.final_energy, report.steps
-            ),
-            None => "forcefield optimization stopping".to_string(),
-        });
+        if let Some(job_id) = state.jobs.local_execution(self.slot()) {
+            state.job_notice(
+                job_id,
+                match self.latest_report {
+                    Some(report) => format!(
+                        "forcefield optimization stopping: energy {:.3} -> {:.3} in {} steps",
+                        report.initial_energy, report.final_energy, report.steps
+                    ),
+                    None => "forcefield optimization stopping".to_string(),
+                },
+            );
+        }
         CancelSignal::Accepted
     }
 
-    fn poll(&mut self, state: &mut AppState, _cx: &JobContext) -> JobPoll {
+    fn poll(&mut self, state: &mut AppState, cx: &JobContext) -> JobPoll {
         // Optimization streams into the *live* active structure, so its pre-run
         // snapshot is committed to undo history when it produced a result and
         // restored (reverting the geometry) when it was stopped before any step.
@@ -142,6 +159,9 @@ impl JobRuntime for RunningOptimization {
         let outcome = loop {
             match self.receiver.try_recv() {
                 Ok(OptimizationWorkerMessage::Progress { structure, report }) => {
+                    // Per-step energy is structured progress (the energy trace and
+                    // latest report Activity reads), never an appended log row.
+                    let first = self.latest_report.is_none();
                     *state.structure_mut() = structure;
                     state.mark_structure_changed();
                     self.latest_report = Some(report);
@@ -153,10 +173,9 @@ impl JobRuntime for RunningOptimization {
                         .push([report.steps as f64, f64::from(report.final_energy)]);
                     saw_progress = true;
                     state.set_source_path(None);
-                    state.set_message(format!(
-                        "forcefield optimizing: step {}, energy {:.3}; press Esc to stop",
-                        report.steps, report.final_energy
-                    ));
+                    if first {
+                        state.status_neutral("Optimizing forcefield… press Esc to stop");
+                    }
                 }
                 Ok(OptimizationWorkerMessage::Finished { structure, report }) => {
                     *state.structure_mut() = structure;
@@ -164,11 +183,20 @@ impl JobRuntime for RunningOptimization {
                     self.latest_report = Some(report);
                     saw_progress = true;
                     state.set_source_path(None);
-                    state.set_message(optimization_finished_message(report));
+                    match cx.job_id {
+                        Some(job_id) => {
+                            state.job_succeeded(job_id, optimization_finished_message(report))
+                        }
+                        None => state.status_success(optimization_finished_message(report)),
+                    }
                     break JobPoll::Terminal(TaskStatus::Completed);
                 }
                 Ok(OptimizationWorkerMessage::Failed(error)) => {
-                    state.set_message(format!("forcefield optimization failed: {error}"));
+                    let text = format!("forcefield optimization failed: {error}");
+                    match cx.job_id {
+                        Some(job_id) => state.job_failed(job_id, text),
+                        None => state.status_neutral(text),
+                    }
                     break JobPoll::Terminal(TaskStatus::Failed);
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => break JobPoll::Running,
@@ -213,7 +241,9 @@ impl JobRuntime for RunningQmJob {
         // flag re-labels a `Finished`/`Failed` that races the kill as cancelled.
         self.cancel_requested = true;
         self.cancel.cancel();
-        state.set_message("QM calculation stopping".to_string());
+        if let Some(job_id) = state.jobs.local_execution(self.slot()) {
+            state.job_notice(job_id, "QM calculation stopping");
+        }
         CancelSignal::Accepted
     }
 
@@ -221,12 +251,13 @@ impl JobRuntime for RunningQmJob {
         loop {
             match self.receiver.try_recv() {
                 Ok(QmWorkerMessage::Progress { stage }) => {
-                    state.set_message(format!("QM: {stage}; press Esc to stop"));
                     self.latest_stage = Some(stage);
                 }
                 Ok(QmWorkerMessage::Finished(outcome)) => {
                     if self.cancel_requested {
-                        state.set_message("QM calculation cancelled".to_string());
+                        if let Some(job_id) = cx.job_id {
+                            state.job_notice(job_id, "QM calculation cancelled");
+                        }
                         return JobPoll::Terminal(TaskStatus::Cancelled);
                     }
                     apply_qm_outcome(state, cx, *outcome);
@@ -234,10 +265,14 @@ impl JobRuntime for RunningQmJob {
                 }
                 Ok(QmWorkerMessage::Failed(error)) => {
                     if self.cancel_requested {
-                        state.set_message("QM calculation cancelled".to_string());
+                        if let Some(job_id) = cx.job_id {
+                            state.job_notice(job_id, "QM calculation cancelled");
+                        }
                         return JobPoll::Terminal(TaskStatus::Cancelled);
                     }
-                    state.set_message(format!("QM calculation failed: {error}"));
+                    if let Some(job_id) = cx.job_id {
+                        state.job_failed(job_id, format!("QM calculation failed: {error}"));
+                    }
                     return JobPoll::Terminal(TaskStatus::Failed);
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => return JobPoll::Running,
@@ -251,8 +286,10 @@ impl JobRuntime for RunningQmJob {
 /// geometry as a new entry (or record a report for an entry-less run), and record
 /// the outcome in the ledger so a re-poll never re-imports it.
 fn apply_qm_outcome(state: &mut AppState, cx: &JobContext, outcome: crate::engines::qm::QmOutcome) {
-    for line in outcome.summary.lines() {
-        state.output_log.push(line.to_string());
+    if let Some(job_id) = cx.job_id {
+        for line in outcome.summary.lines() {
+            state.append_job_log(job_id, LogLevel::Info, line);
+        }
     }
     // Persist the raw report to the task's run directory before any new entry is
     // added, so the run's source entry is the input structure, not the result.
@@ -293,7 +330,7 @@ fn apply_qm_outcome(state: &mut AppState, cx: &JobContext, outcome: crate::engin
     // new geometry, or the input structure when there is none — so the memoized
     // per-entry chart availability is stale.
     state.ui.chart_availability.clear();
-    state.set_message(format!(
+    let summary = format!(
         "QM complete: energy {:.6} Eh{}",
         outcome.energy_hartree,
         if outcome.converged {
@@ -301,5 +338,9 @@ fn apply_qm_outcome(state: &mut AppState, cx: &JobContext, outcome: crate::engin
         } else {
             " (not converged)"
         }
-    ));
+    );
+    match cx.job_id {
+        Some(job_id) => state.job_succeeded(job_id, summary),
+        None => state.status_success(summary),
+    }
 }

--- a/src/frontend/dispatcher/jobs/poll.rs
+++ b/src/frontend/dispatcher/jobs/poll.rs
@@ -1,5 +1,7 @@
 use super::super::*;
 
+use crate::frontend::state::{LogLevel, SystemSubsystem};
+
 /// Drain the background GitHub release check. A found update is surfaced in
 /// the status bar (message + persistent link); "up to date" and failures
 /// (offline, rate-limited, no releases yet) are logged quietly to the Output
@@ -10,7 +12,7 @@ pub(crate) fn poll_update_check(state: &mut AppState, ctx: &egui::Context) {
     };
     match check.receiver.try_recv() {
         Ok(Ok(Some(update))) => {
-            state.set_message(format!(
+            state.status_neutral(format!(
                 "SilicoLab {} is available (you have {})",
                 update.version,
                 env!("CARGO_PKG_VERSION")
@@ -22,14 +24,19 @@ pub(crate) fn poll_update_check(state: &mut AppState, ctx: &egui::Context) {
             maybe_auto_install_update(state);
         }
         Ok(Ok(None)) => {
-            state
-                .output_log
-                .push("Update check: SilicoLab is up to date".to_string());
+            // A routine "nothing changed" success — the quietest level, never a status.
+            state.log_system(
+                SystemSubsystem::Update,
+                LogLevel::Trace,
+                "Update check: SilicoLab is up to date".to_string(),
+            );
         }
         Ok(Err(error)) => {
-            state
-                .output_log
-                .push(format!("Update check failed: {error}"));
+            state.log_system(
+                SystemSubsystem::Update,
+                LogLevel::Warn,
+                format!("Update check failed: {error}"),
+            );
         }
         Err(std::sync::mpsc::TryRecvError::Empty) => {
             // Request still in flight; keep the handle and look again shortly.
@@ -37,9 +44,11 @@ pub(crate) fn poll_update_check(state: &mut AppState, ctx: &egui::Context) {
             ctx.request_repaint_after(Duration::from_millis(500));
         }
         Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-            state
-                .output_log
-                .push("Update check failed: worker stopped".to_string());
+            state.log_system(
+                SystemSubsystem::Update,
+                LogLevel::Warn,
+                "Update check failed: worker stopped".to_string(),
+            );
         }
     }
 }
@@ -54,14 +63,11 @@ pub(crate) fn poll_self_update(state: &mut AppState, ctx: &egui::Context) {
     };
     match job.receiver.try_recv() {
         Ok(Ok(version)) => {
-            state.set_message(format!("SilicoLab {version} installed — restart to apply"));
+            state.status_success(format!("SilicoLab {version} installed — restart to apply"));
             state.ui.self_update = SelfUpdateStatus::Installed { version };
         }
         Ok(Err(error)) => {
-            state.set_message(format!("Update failed: {error}"));
-            state
-                .output_log
-                .push(format!("Self-update failed: {error}"));
+            state.report_system_error(SystemSubsystem::Update, format!("Update failed: {error}"));
             state.ui.self_update = SelfUpdateStatus::Failed {
                 error: error.to_string(),
             };
@@ -72,7 +78,10 @@ pub(crate) fn poll_self_update(state: &mut AppState, ctx: &egui::Context) {
             ctx.request_repaint_after(Duration::from_millis(500));
         }
         Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-            state.set_message("Update failed: worker stopped".to_string());
+            state.report_system_error(
+                SystemSubsystem::Update,
+                "Update failed: worker stopped".to_string(),
+            );
             state.ui.self_update = SelfUpdateStatus::Failed {
                 error: "worker stopped".to_string(),
             };
@@ -141,17 +150,20 @@ pub(crate) fn poll_remote_hardware(state: &mut AppState, ctx: &egui::Context) {
                 .settings
                 .remote_hardware
                 .insert(fetch.host_id, info);
-            state.set_message("Fetched remote hardware".to_string());
+            state.status_success("Fetched remote hardware".to_string());
         }
         Ok(RemoteHardwareOutcome::Failed(error)) => {
-            state.set_message(format!("Could not read remote hardware: {error}"));
+            state.report_remote_error(
+                fetch.host_id,
+                format!("Could not read remote hardware: {error}"),
+            );
         }
         Err(std::sync::mpsc::TryRecvError::Empty) => {
             state.jobs.remote_hardware = Some(fetch);
             ctx.request_repaint_after(std::time::Duration::from_millis(400));
         }
         Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-            state.set_message("Remote hardware probe stopped unexpectedly".to_string());
+            state.report_remote_error(fetch.host_id, "Remote hardware probe stopped unexpectedly");
         }
     }
 }
@@ -277,7 +289,7 @@ pub(crate) fn poll_remote_probe(state: &mut AppState, ctx: &egui::Context) {
             {
                 state.ui.settings.remote_bootstrap = None;
             }
-            state.set_message("Connected: passwordless login works".to_string());
+            state.status_success("Connected: passwordless login works".to_string());
         }
         Ok(RemoteProbeOutcome::Passwordless(false)) => {
             state
@@ -285,7 +297,7 @@ pub(crate) fn poll_remote_probe(state: &mut AppState, ctx: &egui::Context) {
                 .settings
                 .remote_status
                 .insert(probe.host_id, RemoteHostStatus::NeedsSetup);
-            state.set_message(
+            state.status_neutral(
                 "Reachable, but passwordless login isn't set up — use 'Set up passwordless login'."
                     .to_string(),
             );
@@ -296,7 +308,7 @@ pub(crate) fn poll_remote_probe(state: &mut AppState, ctx: &egui::Context) {
             } else {
                 "sacct unavailable; using scontrol fallback"
             };
-            state.set_message(format!("Detected {} ({accounting})", detection.version));
+            state.status_neutral(format!("Detected {} ({accounting})", detection.version));
         }
         Ok(RemoteProbeOutcome::SlurmCapabilities(capabilities)) => {
             state
@@ -304,18 +316,23 @@ pub(crate) fn poll_remote_probe(state: &mut AppState, ctx: &egui::Context) {
                 .settings
                 .slurm_capabilities
                 .insert(probe.host_id.clone(), capabilities);
-            state.set_message("Slurm capabilities refreshed".to_string());
+            state.status_success("Slurm capabilities refreshed".to_string());
         }
         Ok(RemoteProbeOutcome::SlurmTested(console, deployment_id)) => {
             if let Some(host) = state.config.remote_hosts.get_mut(&probe.host_id) {
                 host.worker_deployment = Some(deployment_id);
                 let _ = save_config(&state.config);
             }
-            state.output_log.push(console);
-            state.set_message("Slurm test job completed successfully".to_string());
+            state.log_remote(Some(probe.host_id.clone()), LogLevel::Info, console);
+            state.status_success("Slurm test job completed successfully".to_string());
         }
         Ok(RemoteProbeOutcome::Failed(error)) => {
-            state.set_message(format!("Remote scheduler check failed: {error}"));
+            // Host-scoped so a later successful probe of the same host recovers it,
+            // and the detail is revisitable in Remote output.
+            state.report_remote_error(
+                probe.host_id.clone(),
+                format!("Remote scheduler check failed: {error}"),
+            );
         }
         Err(std::sync::mpsc::TryRecvError::Empty) => {
             state.jobs.remote_probe = Some(probe);
@@ -337,7 +354,7 @@ pub(crate) fn poll_trajectory_jobs(state: &mut AppState, ctx: &egui::Context) {
         match load.receiver.try_recv() {
             Ok(Ok(trajectory)) => {
                 if trajectory.is_empty() {
-                    state.set_message("Trajectory contains no frames");
+                    state.status_neutral("Trajectory contains no frames");
                 } else {
                     let (view_center, view_radius) =
                         view_center_and_radius(&load.base_structure, load.include_cell);
@@ -360,17 +377,17 @@ pub(crate) fn poll_trajectory_jobs(state: &mut AppState, ctx: &egui::Context) {
                     playback.sync_scratch();
                     state.ui.trajectory = Some(playback);
                     if subsampled {
-                        state.set_message(format!(
+                        state.status_success(format!(
                             "Playing trajectory: {frames} of {source_frames} frames (subsampled)"
                         ));
                     } else {
-                        state.set_message(format!("Playing trajectory: {frames} frames"));
+                        state.status_success(format!("Playing trajectory: {frames} frames"));
                     }
                     ctx.request_repaint();
                 }
             }
             Ok(Err(error)) => {
-                state.set_message(format!("Trajectory load failed: {error}"));
+                state.status_error(format!("Trajectory load failed: {error}"));
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {
                 // Still decoding; keep the handle and poll again next frame.
@@ -378,7 +395,7 @@ pub(crate) fn poll_trajectory_jobs(state: &mut AppState, ctx: &egui::Context) {
                 ctx.request_repaint_after(engine_poll_frame());
             }
             Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                state.set_message("Trajectory load failed: worker stopped");
+                state.status_error("Trajectory load failed: worker stopped");
             }
         }
     }

--- a/src/frontend/dispatcher/jobs/tests.rs
+++ b/src/frontend/dispatcher/jobs/tests.rs
@@ -138,6 +138,10 @@ fn esc_still_requests_qm_cancel_with_stage_boundary_message() {
         latest_stage: Some("SCF".into()),
         cancel_requested: false,
     });
+    state.jobs.bind_local_execution(
+        crate::frontend::jobs::LocalJobSlot::Qm,
+        crate::job::JobId::new(),
+    );
     let ctx = egui::Context::default();
     ctx.input_mut(|input| {
         input.events.push(egui::Event::Key {
@@ -152,7 +156,10 @@ fn esc_still_requests_qm_cancel_with_stage_boundary_message() {
     poll_qm_job(&mut state, &ctx);
 
     assert!(cancel.load(std::sync::atomic::Ordering::Relaxed));
-    assert_eq!(state.message, "QM calculation stopping");
+    assert_eq!(
+        state.status_notice().map(|notice| notice.text.as_str()),
+        Some("QM calculation stopping")
+    );
     assert!(state.jobs.qm.is_some());
 }
 
@@ -482,6 +489,7 @@ fn esc_on_docking_flags_best_effort_but_does_not_claim_cancelling() {
     state.jobs.set_docking(RunningDockingJob {
         cancel: std::sync::Arc::clone(&cancel),
         receiver: rx,
+        latest_stage: None,
     });
 
     let ctx = egui::Context::default();

--- a/src/frontend/dispatcher/mod.rs
+++ b/src/frontend/dispatcher/mod.rs
@@ -58,6 +58,8 @@ mod disorder;
 mod dock;
 mod docking;
 mod export;
+#[cfg(test)]
+mod feedback_tests;
 mod files;
 mod gromacs;
 mod heavy_render;
@@ -444,6 +446,13 @@ pub fn dispatch(state: &mut AppState, action: AppAction, ctx: &egui::Context) {
         AppAction::ToggleDockArea(area) => toggle_dock_area(state, area, ctx),
         AppAction::ResetWorkbenchLayout => reset_workbench_layout(state),
         AppAction::DismissNotification => state.ui.notification = None,
+        AppAction::RevealOutput(target) => reveal_output(state, target),
+        AppAction::OpenDetailTarget(target) => open_detail_target(state, target),
+        AppAction::AcknowledgeStatus => state.acknowledge_status(),
+        AppAction::PostStatusNeutral(text) => state.status_neutral(text),
+        AppAction::ReportSystemError { subsystem, text } => {
+            state.report_system_error(subsystem, text)
+        }
         AppAction::UseWireframeForHeavyEntry(entry_id) => {
             use_wireframe_for_heavy_entry(state, entry_id)
         }
@@ -482,24 +491,21 @@ fn cancel_controlled_job_action(state: &mut AppState, id: &crate::frontend::jobs
         .into_iter()
         .find(|job| job.id == *id);
     match crate::frontend::jobs::cancel_controlled_job(state, id) {
-        Ok(outcome) => state.set_message(crate::frontend::jobs::format_cancel_outcome_for_job(
+        Ok(outcome) => state.status_neutral(crate::frontend::jobs::format_cancel_outcome_for_job(
             &outcome,
             job.as_ref(),
         )),
-        Err(error) => state.set_message(format!("Could not cancel job: {error}")),
+        Err(error) => state.status_error(format!("Could not cancel job: {error}")),
     }
 }
 
 pub(crate) fn run_console_command(state: &mut AppState, command: &str) {
-    let prompt = format!("sls> {command}");
-    state.output_log.push(prompt);
     state.ui.console.history.push(command.to_string());
-    match crate::frontend::console::execute_console_line(state, command) {
-        Ok(message) => {
-            if !message.is_empty() {
-                state.set_message(message);
-            }
-        }
-        Err(error) => state.set_message(format!("command failed: {error}")),
-    }
+    // The prompt and its result/error are recorded to the Console transcript; the
+    // transcript the user is looking at is the feedback, so no status is posted.
+    let _ = crate::frontend::console::record_console_command(
+        state,
+        command,
+        crate::frontend::state::CommandActor::User,
+    );
 }

--- a/src/frontend/dispatcher/project.rs
+++ b/src/frontend/dispatcher/project.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::frontend::actions::{LeaveConfirmation, LeaveIntent};
+use crate::frontend::state::{LogLevel, SystemSubsystem};
 
 /// Flush a coalesced autosave once its debounce window has elapsed. Called every
 /// frame from the app loop; a no-op when nothing is pending. While a save is
@@ -83,7 +84,10 @@ pub(crate) fn persist_project(state: &mut AppState, persist_history: bool) -> an
         Err(error) => {
             let message = error.to_string();
             state.mark_project_save_failed(message.clone());
-            state.set_message(format!("Project save failed: {message}"));
+            state.report_system_error(
+                SystemSubsystem::Project,
+                format!("Project save failed: {message}"),
+            );
             Err(error)
         }
     }
@@ -136,9 +140,11 @@ pub(crate) fn flush_dirty_task_runs(state: &mut AppState) {
     if let Err(error) = result {
         // Keep the ids dirty so the next flush or full save retries them.
         state.tasks.mark_task_runs_dirty(ids);
-        state
-            .output_log
-            .push(format!("failed to persist task status: {error}"));
+        state.log_system(
+            SystemSubsystem::Storage,
+            LogLevel::Error,
+            format!("failed to persist task status: {error}"),
+        );
     }
 }
 
@@ -170,9 +176,11 @@ pub(crate) fn flush_dirty_run_graph(state: &mut AppState) {
     })();
     match result {
         Ok(()) => state.tasks.runs.mark_saved(),
-        Err(error) => state
-            .output_log
-            .push(format!("failed to persist run graph: {error}")),
+        Err(error) => state.log_system(
+            SystemSubsystem::Storage,
+            LogLevel::Error,
+            format!("failed to persist run graph: {error}"),
+        ),
     }
 }
 
@@ -272,28 +280,34 @@ pub(crate) fn replace_workspace_from_project(
     state.load_viewport_for_active_entry();
     state.mark_project_saved();
     let set_current_dir_error = std::env::set_current_dir(&project.root).err();
-    if let Err(error) =
+    let mut message = if let Err(error) =
         remember_opened_project(&mut state.config, &mut state.recent_projects, &project)
     {
-        state.set_message(format!(
-            "Opened project, but settings update failed: {error}"
-        ));
+        let text = format!("Opened project, but settings update failed: {error}");
+        state.report_system_error(SystemSubsystem::Settings, text.clone());
+        text
     } else if let Some(error) = set_current_dir_error {
-        state.set_message(format!(
+        let text = format!(
             "Opened project {}, but working directory update failed: {error}",
             project.name
-        ));
+        );
+        state.report_system_error(SystemSubsystem::Application, text.clone());
+        text
     } else {
-        state.set_message(format!("Opened project {}", project.name));
-    }
+        let text = format!("Opened project {}", project.name);
+        state.status_success(text.clone());
+        text
+    };
     if recovered_from_crash {
-        state.set_message(format!(
+        let text = format!(
             "Opened project {} (recovered: previous session did not close cleanly)",
             project.name
-        ));
+        );
+        state.status_success(text.clone());
+        message = text;
     }
     if !warnings.is_empty() {
-        state.set_message(format!("{} — {}", state.message, warnings.join(" — ")));
+        state.status_warning(format!("{message} — {}", warnings.join(" — ")));
     }
 }
 
@@ -303,15 +317,15 @@ pub(crate) fn create_project_action(state: &mut AppState) {
         .set_file_name("New Project")
         .save_file()
     else {
-        state.set_message("Create project canceled");
+        state.status_neutral("Create project canceled");
         return;
     };
     let Some(parent) = path.parent() else {
-        state.set_message("Project path must have a parent directory");
+        state.status_neutral("Project path must have a parent directory");
         return;
     };
     let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-        state.set_message("Project name cannot be empty");
+        state.status_neutral("Project name cannot be empty");
         return;
     };
 
@@ -339,7 +353,10 @@ pub(crate) fn create_project_action(state: &mut AppState) {
         Ok((project, snapshot))
     }) {
         Ok((project, snapshot)) => replace_workspace_from_project(state, project, snapshot),
-        Err(error) => state.set_message(format!("Create project failed: {error}")),
+        Err(error) => state.report_system_error(
+            SystemSubsystem::Project,
+            format!("Create project failed: {error}"),
+        ),
     }
 }
 
@@ -359,7 +376,7 @@ fn open_project_action_without_persist(state: &mut AppState) {
 fn open_project_path_without_persist(state: &mut AppState, path: PathBuf) {
     match open_project_dir(&path) {
         Ok((project, snapshot)) => replace_workspace_from_project(state, project, snapshot),
-        Err(error) => state.set_message(error.to_string()),
+        Err(error) => state.report_system_error(SystemSubsystem::Project, error.to_string()),
     }
 }
 
@@ -368,7 +385,10 @@ fn close_project_without_persist(state: &mut AppState, run_maintenance: bool) {
     // Compact the databases and release the lock now that we are leaving cleanly.
     if let Some(project) = state.workspace.project().cloned() {
         if run_maintenance && let Err(error) = housekeeping::run_maintenance(&project) {
-            state.set_message(format!("Project maintenance failed: {error}"));
+            state.report_system_error(
+                SystemSubsystem::Project,
+                format!("Project maintenance failed: {error}"),
+            );
         }
         housekeeping::release_lock(&project);
     }
@@ -383,11 +403,12 @@ fn close_project_without_persist(state: &mut AppState, run_maintenance: bool) {
     state.config.closed_to_scratch = true;
     state.config.last_project_path = None;
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!(
-            "Closed project, but settings update failed: {error}"
-        ));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Closed project, but settings update failed: {error}"),
+        );
     } else {
-        state.set_message("Closed project; opened Scratch");
+        state.status_neutral("Closed project; opened Scratch");
     }
     reset_transient_state(state);
     reset_chart_caches(state);
@@ -407,7 +428,7 @@ fn cancel_agent_runtime(state: &mut AppState) {
 pub(crate) fn save_project(state: &mut AppState) {
     if state.workspace.is_project() {
         if persist_project(state, true).is_ok() {
-            state.set_message(format!("Saved project {}", state.workspace.label()));
+            state.status_success(format!("Saved project {}", state.workspace.label()));
         }
         return;
     }
@@ -543,7 +564,7 @@ pub(crate) fn require_active_entry(state: &mut AppState, action_label: &str) -> 
     if state.has_active_entry() {
         true
     } else {
-        state.set_message(format!("{action_label} requires an open entry"));
+        state.status_neutral(format!("{action_label} requires an open entry"));
         false
     }
 }
@@ -552,7 +573,7 @@ pub(crate) fn new_empty_entry(state: &mut AppState) {
     let structure = Structure::empty();
     let save_path = structure_io::default_structure_save_path(&structure, None);
     let entry_id = add_and_show_entry(state, structure, None, save_path);
-    state.set_message(format!("Created empty entry #{entry_id}"));
+    state.status_success(format!("Created empty entry #{entry_id}"));
 }
 
 /// Insert a freshly produced structure as a new entry and switch to it, running
@@ -594,7 +615,7 @@ pub(crate) fn activate_entry(state: &mut AppState, entry_id: u64) {
     state.entries.activate_entry(entry_id);
     state.ui.entry_list.selected_entry_ids.insert(entry_id);
     load_active_entry(state);
-    state.set_message(format!("Loaded entry {}", state.current_entry_label()));
+    state.status_neutral(format!("Loaded entry {}", state.current_entry_label()));
 }
 
 pub(crate) fn delete_entry(state: &mut AppState, entry_id: u64) {
@@ -603,7 +624,7 @@ pub(crate) fn delete_entry(state: &mut AppState, entry_id: u64) {
         .entry(entry_id)
         .map(|entry| entry.name.clone())
     else {
-        state.set_message("Cannot delete entry".to_string());
+        state.status_error("Cannot delete entry".to_string());
         return;
     };
     let active_before = state.entries.active_entry_id();
@@ -621,9 +642,9 @@ pub(crate) fn delete_entry(state: &mut AppState, entry_id: u64) {
             reset_transient_state(state);
             load_active_entry(state);
         }
-        state.set_message(format!("Deleted entry {name}"));
+        state.status_neutral(format!("Deleted entry {name}"));
     } else {
-        state.set_message("Cannot delete entry".to_string());
+        state.status_error("Cannot delete entry".to_string());
     }
 }
 

--- a/src/frontend/dispatcher/ptm.rs
+++ b/src/frontend/dispatcher/ptm.rs
@@ -31,7 +31,7 @@ pub(crate) fn start_pending_ptm(state: &mut AppState) {
     let request = match build_ptm_request(&prompt) {
         Ok(request) => request,
         Err(error) => {
-            state.set_message(error.to_string());
+            state.status_neutral(error.to_string());
             return;
         }
     };
@@ -43,21 +43,21 @@ pub(crate) fn start_pending_ptm(state: &mut AppState) {
                 .detail
                 .map(|detail| format!(" ({detail})"))
                 .unwrap_or_default();
-            state.set_message(format!(
+            state.status_success(format!(
                 "{} applied as entry #{entry_id}{detail}",
                 prompt.family.label()
             ));
             complete_active_task(state, TaskKind::ModifyProteinPtm, TaskStatus::Completed);
             close_active_task_panel(state);
         }
-        Err(error) => state.set_message(format!("modification failed: {error}")),
+        Err(error) => state.status_error(format!("modification failed: {error}")),
     }
 }
 
 pub(crate) fn cancel_pending_ptm_request(state: &mut AppState) {
     bind_active_panel_task(state, TaskPanelKind::PtmPrompt);
     state.ui.pending_ptm = None;
-    state.set_message("Protein modification canceled".to_string());
+    state.status_neutral("Protein modification canceled".to_string());
     complete_active_task(state, TaskKind::ModifyProteinPtm, TaskStatus::Failed);
     close_active_task_panel(state);
 }

--- a/src/frontend/dispatcher/remote_jobs.rs
+++ b/src/frontend/dispatcher/remote_jobs.rs
@@ -7,6 +7,7 @@
 use super::*;
 
 use crate::backend::storage::jobs as registry;
+use crate::frontend::state::{LogLevel, SystemSubsystem};
 
 /// One-shot reconnect read on the first frame: load the registry snapshot so a
 /// reopened session shows its in-flight remote jobs before any manual refresh.
@@ -44,7 +45,7 @@ pub(crate) fn start_remote_engine(
     resources: crate::backend::config::JobResources,
 ) {
     let Some(task_run_id) = state.active_task_run else {
-        state.set_message("no active task to run remotely".to_string());
+        state.status_neutral("no active task to run remotely");
         return;
     };
     let Some(task) = state.tasks.task_run(task_run_id).cloned() else {
@@ -52,14 +53,17 @@ pub(crate) fn start_remote_engine(
     };
     let engine_name = remote_engine_name(&engine);
     if let Err(error) = crate::engines::remote::ensure_ssh_available() {
-        state.set_message(format!("remote {engine_name} unavailable: {error}"));
+        state.status_error(format!("remote {engine_name} unavailable: {error}"));
         fail_active_task(state, task_run_id);
         return;
     }
     let local_run_dir = match ensure_active_task_run_dir(state, task.kind, None) {
         Ok(dir) => dir,
         Err(error) => {
-            state.set_message(format!("could not create run directory: {error}"));
+            state.report_system_error(
+                SystemSubsystem::Storage,
+                format!("could not create run directory: {error}"),
+            );
             fail_active_task(state, task_run_id);
             return;
         }
@@ -93,7 +97,7 @@ pub(crate) fn start_remote_engine(
     );
     state.jobs.remote_submit = Some(handle);
     mark_task_status(state, task_run_id, TaskStatus::Running);
-    state.set_message(format!(
+    state.status_neutral(format!(
         "Deploying & submitting {engine_name} to {} (use Refresh Remote to track it)…",
         host.label
     ));
@@ -153,9 +157,10 @@ pub(crate) fn poll_remote_submit(state: &mut AppState, ctx: &egui::Context) {
                         .cache_detected(detected.engine, detected.launch, detected.version);
                 }
                 if let Err(error) = save_config(&state.config) {
-                    state.output_log.push(format!(
-                        "could not persist worker deployment identity: {error}"
-                    ));
+                    state.report_system_error(
+                        SystemSubsystem::Settings,
+                        format!("could not persist worker deployment identity: {error}"),
+                    );
                 }
             }
             let row = registry::RemoteJob {
@@ -181,12 +186,13 @@ pub(crate) fn poll_remote_submit(state: &mut AppState, ctx: &egui::Context) {
                 unknown_since_ms: None,
             };
             if let Err(error) = registry::open().and_then(|conn| registry::upsert(&conn, &row)) {
-                state
-                    .output_log
-                    .push(format!("jobs.db write failed: {error}"));
+                state.report_system_error(
+                    SystemSubsystem::Storage,
+                    format!("jobs.db write failed: {error}"),
+                );
             }
             reload_remote_jobs(state);
-            state.set_message(format!(
+            state.status_success(format!(
                 "Submitted to {host_label}; use Refresh Remote to check status"
             ));
         }
@@ -194,7 +200,7 @@ pub(crate) fn poll_remote_submit(state: &mut AppState, ctx: &egui::Context) {
             if let Some(task_run_id) = submit.task_run_id {
                 mark_task_status(state, task_run_id, TaskStatus::Failed);
             }
-            state.set_message(format!("Remote submission failed: {error}"));
+            state.report_unscoped_remote_error(format!("Remote submission failed: {error}"));
         }
         Err(std::sync::mpsc::TryRecvError::Empty) => {
             state.jobs.remote_submit = Some(submit);
@@ -204,7 +210,7 @@ pub(crate) fn poll_remote_submit(state: &mut AppState, ctx: &egui::Context) {
             if let Some(task_run_id) = submit.task_run_id {
                 mark_task_status(state, task_run_id, TaskStatus::Failed);
             }
-            state.set_message("Remote submission worker stopped unexpectedly".to_string());
+            state.report_unscoped_remote_error("Remote submission worker stopped unexpectedly");
         }
     }
 }
@@ -232,13 +238,13 @@ pub(crate) fn refresh_remote_jobs(state: &mut AppState) {
         .collect();
     reload_remote_jobs(state);
     if items.is_empty() {
-        state.set_message("No active remote jobs to refresh".to_string());
+        state.status_neutral("No active remote jobs to refresh");
         return;
     }
     state.jobs.remote_jobs_refresh = Some(crate::frontend::remote_jobs::spawn_remote_jobs_refresh(
         items,
     ));
-    state.set_message("Refreshing remote jobs…".to_string());
+    state.status_neutral("Refreshing remote jobs…");
 }
 
 /// Drain a finished remote-jobs refresh: update each row's status in `jobs.db`,
@@ -254,14 +260,14 @@ pub(crate) fn poll_remote_jobs_refresh(state: &mut AppState, ctx: &egui::Context
                 apply_remote_observation(state, conn.as_ref(), &update.run_uuid, update.outcome);
             }
             reload_remote_jobs(state);
-            state.set_message("Remote jobs refreshed".to_string());
+            state.status_neutral("Remote jobs refreshed");
         }
         Err(std::sync::mpsc::TryRecvError::Empty) => {
             state.jobs.remote_jobs_refresh = Some(refresh);
             ctx.request_repaint_after(Duration::from_millis(400));
         }
         Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-            state.set_message("Remote refresh worker stopped unexpectedly".to_string());
+            state.status_error("Remote refresh worker stopped unexpectedly");
         }
     }
 }
@@ -326,15 +332,20 @@ fn apply_remote_observation(
                 .tasks
                 .runs
                 .set_import_state(run_uuid, crate::backend::run_attempt::ResultImport::Failed);
-            state.output_log.push(format!(
+            let text = format!(
                 "remote job {} finished but its outcome was unreadable: {error}",
                 short_uuid(run_uuid)
-            ));
+            );
+            match run_uuid.parse::<crate::job::JobId>() {
+                Ok(job_id) => state.job_failed(job_id, text),
+                Err(_) => state.log_remote(None, LogLevel::Error, text),
+            }
         }
-        RemoteJobOutcome::ProbeError(error) => state.output_log.push(format!(
-            "remote job {} probe error: {error}",
-            short_uuid(run_uuid)
-        )),
+        RemoteJobOutcome::ProbeError(error) => state.log_remote(
+            prior.as_ref().map(|row| row.host_id.clone()),
+            LogLevel::Warn,
+            format!("remote job {} probe error: {error}", short_uuid(run_uuid)),
+        ),
         RemoteJobOutcome::Observed(observation) => match observation.phase {
             crate::engines::remote::launcher::RemoteJobPhase::Failed
             | crate::engines::remote::launcher::RemoteJobPhase::Lost => {
@@ -356,26 +367,29 @@ pub(crate) fn poll_remote_cancel(state: &mut AppState, ctx: &egui::Context) {
     match cancel.receiver.try_recv() {
         Ok(Ok(outcome)) => {
             let conn = registry::open().ok();
-            match apply_remote_observation(state, conn.as_ref(), &cancel.run_uuid, outcome) {
-                Some(registry::RemoteJobStatus::Cancelled) => {
-                    state.set_message("Remote cancellation confirmed".to_string());
-                }
-                Some(status) => {
-                    state.set_message(format!("Remote job finished as {}", status.token()));
-                }
-                None => state.set_message("Remote job state could not be recorded".to_string()),
+            let text =
+                match apply_remote_observation(state, conn.as_ref(), &cancel.run_uuid, outcome) {
+                    Some(registry::RemoteJobStatus::Cancelled) => {
+                        "Remote cancellation confirmed".to_string()
+                    }
+                    Some(status) => format!("Remote job finished as {}", status.token()),
+                    None => "Remote job state could not be recorded".to_string(),
+                };
+            match cancel.run_uuid.parse::<crate::job::JobId>() {
+                Ok(job_id) => state.job_notice(job_id, text),
+                Err(_) => state.log_remote(None, LogLevel::Info, text),
             }
             reload_remote_jobs(state);
         }
         Ok(Err(error)) => {
-            state.set_message(format!("Remote cancellation failed: {error}"));
+            state.report_unscoped_remote_error(format!("Remote cancellation failed: {error}"));
         }
         Err(std::sync::mpsc::TryRecvError::Empty) => {
             state.jobs.remote_cancel = Some(cancel);
             ctx.request_repaint_after(Duration::from_millis(400));
         }
         Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-            state.set_message("Remote cancellation worker stopped unexpectedly".to_string());
+            state.report_unscoped_remote_error("Remote cancellation worker stopped unexpectedly");
         }
     }
 }
@@ -488,8 +502,17 @@ fn apply_remote_qm_outcome(
     row: &registry::RemoteJob,
     outcome: crate::engines::qm::QmOutcome,
 ) {
-    for line in outcome.summary.lines() {
-        state.output_log.push(line.to_string());
+    let job_id: Option<crate::job::JobId> = row.job_id.parse().ok();
+    if job_id.is_none() {
+        state.report_unscoped_remote_error(format!(
+            "Remote QM result has invalid job id `{}`",
+            row.job_id
+        ));
+    }
+    if let Some(job_id) = job_id {
+        for line in outcome.summary.lines() {
+            state.append_job_log(job_id, LogLevel::Info, line);
+        }
     }
     let run_dir = PathBuf::from(&row.local_run_dir);
     save_qm_artifacts(state, &run_dir, &outcome);
@@ -528,7 +551,7 @@ fn apply_remote_qm_outcome(
         mark_task_status(state, task_id, TaskStatus::Completed);
         state.ui.task_chart_thumbnails.remove(&task_id);
     }
-    state.set_message(format!(
+    let summary = format!(
         "Remote QM complete: energy {:.6} Eh{}",
         outcome.energy_hartree,
         if outcome.converged {
@@ -536,7 +559,10 @@ fn apply_remote_qm_outcome(
         } else {
             " (not converged)"
         }
-    ));
+    );
+    if let Some(job_id) = job_id {
+        state.job_succeeded(job_id, summary);
+    }
 }
 
 fn mark_remote_task(state: &mut AppState, job_id: &str, status: TaskStatus) {
@@ -592,11 +618,15 @@ pub(crate) fn import_completed_remote_jobs(state: &mut AppState, rows: Vec<regis
                     &row.job_id,
                     crate::backend::run_attempt::ResultImport::PendingRecovery,
                 );
-                state.output_log.push(format!(
-                    "remote job {} finished but its result is pending recovery \
-                     (outcome file missing); it will retry on the next Refresh Remote",
-                    short_uuid(&row.job_id)
-                ));
+                state.log_remote(
+                    Some(row.host_id.clone()),
+                    LogLevel::Warn,
+                    format!(
+                        "remote job {} finished but its result is pending recovery \
+                         (outcome file missing); it will retry on the next Refresh Remote",
+                        short_uuid(&row.job_id)
+                    ),
+                );
             }
         }
     }
@@ -604,12 +634,12 @@ pub(crate) fn import_completed_remote_jobs(state: &mut AppState, rows: Vec<regis
         // Persist the imported entries + ledger atomically now rather than waiting
         // for the debounced autosave, so the recovery is durable from open.
         let _ = persist_project(state, false);
-        state.set_message(format!(
+        state.status_success(format!(
             "Recovered {recovered} remote result(s) for this project"
         ));
     }
     if pending > 0 {
-        state.set_message(format!(
+        state.status_neutral(format!(
             "{pending} remote result(s) pending recovery — use Refresh Remote to retry"
         ));
     }
@@ -629,7 +659,7 @@ fn read_local_outcome(local_run_dir: &str) -> Option<crate::wire::EngineOutcome>
 /// run's own UUID-suffixed dir) and drop its registry row.
 pub(crate) fn remove_remote_job_scratch(state: &mut AppState, run_uuid: &str) {
     if state.jobs.remote_cleanup.is_some() {
-        state.set_message("A remote cleanup is already running".to_string());
+        state.status_neutral("A remote cleanup is already running");
         return;
     }
     let row = (|| -> anyhow::Result<Option<registry::RemoteJob>> {
@@ -641,18 +671,17 @@ pub(crate) fn remove_remote_job_scratch(state: &mut AppState, run_uuid: &str) {
         return;
     };
     if !row.status.is_terminal() {
-        state
-            .set_message("Cancel the remote job before removing its scratch directory".to_string());
+        state.status_neutral("Cancel the remote job before removing its scratch directory");
         return;
     }
     let Some(host) = state.config.remote_hosts.get(&row.host_id).cloned() else {
-        state.set_message("The host for this job is no longer configured".to_string());
+        state.status_neutral("The host for this job is no longer configured");
         return;
     };
     state.jobs.remote_cleanup = Some(crate::frontend::remote_jobs::spawn_remote_cleanup(
         row, host,
     ));
-    state.set_message("Removing remote scratch…".to_string());
+    state.status_neutral("Removing remote scratch…");
 }
 
 pub(crate) fn poll_remote_cleanup(state: &mut AppState, ctx: &egui::Context) {
@@ -665,15 +694,15 @@ pub(crate) fn poll_remote_cleanup(state: &mut AppState, ctx: &egui::Context) {
                 let _ = registry::remove(&conn, &cleanup.run_uuid);
             }
             reload_remote_jobs(state);
-            state.set_message("Removed the remote scratch directory".to_string());
+            state.status_success("Removed the remote scratch directory");
         }
-        Ok(Err(error)) => state.set_message(format!("Could not remove remote scratch: {error}")),
+        Ok(Err(error)) => state.status_error(format!("Could not remove remote scratch: {error}")),
         Err(std::sync::mpsc::TryRecvError::Empty) => {
             state.jobs.remote_cleanup = Some(cleanup);
             ctx.request_repaint_after(Duration::from_millis(400));
         }
         Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-            state.set_message("Remote cleanup worker stopped unexpectedly".to_string());
+            state.status_error("Remote cleanup worker stopped unexpectedly");
         }
     }
 }

--- a/src/frontend/dispatcher/remote_jobs/tests.rs
+++ b/src/frontend/dispatcher/remote_jobs/tests.rs
@@ -101,11 +101,14 @@ fn open_project_compensation_imports_present_outcome_and_flags_missing() {
         !state.materializations.contains("job-missing"),
         "a missing outcome stays pending, not marked done"
     );
+    let query = crate::frontend::state::LogQuery::new(crate::frontend::state::LogFilter::Source(
+        crate::frontend::state::OutputSource::Remote,
+    ));
     assert!(
         state
-            .output_log
-            .iter()
-            .any(|line| line.contains("pending recovery")),
+            .session_log()
+            .query(&query)
+            .any(|entry| entry.text.contains("pending recovery")),
         "the pending recovery is surfaced, not silently dropped"
     );
 }

--- a/src/frontend/dispatcher/selection.rs
+++ b/src/frontend/dispatcher/selection.rs
@@ -5,17 +5,17 @@ pub(crate) use residue::{select_residue, select_residue_range, select_residues};
 
 pub(crate) fn select_all(state: &mut AppState) {
     state.ui.selection.select_all(state.structure().atoms.len());
-    state.set_message(format!("Selected {} atom(s)", state.ui.selection.len()));
+    state.status_neutral(format!("Selected {} atom(s)", state.ui.selection.len()));
 }
 
 pub(crate) fn invert_selection(state: &mut AppState) {
     state.ui.selection.invert(state.structure().atoms.len());
-    state.set_message(format!("Selected {} atom(s)", state.ui.selection.len()));
+    state.status_neutral(format!("Selected {} atom(s)", state.ui.selection.len()));
 }
 
 pub(crate) fn clear_selection(state: &mut AppState) {
     state.ui.selection.clear();
-    state.set_message("Cleared atom selection".to_string());
+    state.status_neutral("Cleared atom selection".to_string());
 }
 
 pub(crate) fn select_category(state: &mut AppState, category: crate::domain::AtomCategory) {
@@ -28,9 +28,9 @@ pub(crate) fn select_category(state: &mut AppState, category: crate::domain::Ato
     let count = indices.len();
     state.ui.selection.select_indices(indices);
     if count == 0 {
-        state.set_message(format!("No {} atoms found", category.label()));
+        state.status_neutral(format!("No {} atoms found", category.label()));
     } else {
-        state.set_message(format!("Selected {count} {} atom(s)", category.label()));
+        state.status_neutral(format!("Selected {count} {} atom(s)", category.label()));
     }
 }
 
@@ -45,9 +45,9 @@ pub(crate) fn select_atom(state: &mut AppState, atom_index: usize, toggle: bool)
         .selection
         .retain_valid(state.structure().atoms.len());
     if state.ui.selection.is_empty() {
-        state.set_message("Cleared atom selection".to_string());
+        state.status_neutral("Cleared atom selection".to_string());
     } else {
-        state.set_message(format!("Selected {} atom(s)", state.ui.selection.len()));
+        state.status_neutral(format!("Selected {} atom(s)", state.ui.selection.len()));
     }
 }
 
@@ -79,14 +79,14 @@ pub(crate) fn scope_items(
 pub(crate) fn set_selection_style(state: &mut AppState, style: crate::frontend::state::AtomStyle) {
     let (indices, all) = style_scope(state);
     if indices.is_empty() {
-        state.set_message("No atoms to style".to_string());
+        state.status_neutral("No atoms to style".to_string());
         return;
     }
     let items = scope_items(state, &indices);
     let count = items.len();
     state.ui.viewport.apply_atom_styles(items, style);
     let scope = if all { "all" } else { "selected" };
-    state.set_message(format!("Set {count} {scope} atom(s) to {}", style.label()));
+    state.status_neutral(format!("Set {count} {scope} atom(s) to {}", style.label()));
 }
 
 /// Apply a visibility change to the Style panel's current scope. Visibility is a
@@ -99,7 +99,7 @@ pub(crate) fn set_selection_visibility(
     use crate::frontend::actions::VisibilityCommand;
     let atom_count = state.structure().atoms.len();
     if atom_count == 0 {
-        state.set_message("No atoms in the active entry".to_string());
+        state.status_neutral("No atoms in the active entry".to_string());
         return;
     }
     let (indices, all) = style_scope(state);
@@ -108,18 +108,18 @@ pub(crate) fn set_selection_visibility(
         VisibilityCommand::Show => {
             let count = indices.len();
             state.ui.viewport.set_atoms_hidden(indices, false);
-            state.set_message(format!("Showed {count} {scope} atom(s)"));
+            state.status_neutral(format!("Showed {count} {scope} atom(s)"));
         }
         VisibilityCommand::Hide => {
             let count = indices.len();
             state.ui.viewport.set_atoms_hidden(indices, true);
-            state.set_message(format!("Hid {count} {scope} atom(s)"));
+            state.status_neutral(format!("Hid {count} {scope} atom(s)"));
         }
         VisibilityCommand::ShowOnly => {
             let visible: std::collections::BTreeSet<usize> = indices.iter().copied().collect();
             let count = visible.len();
             state.ui.viewport.show_only(&visible, atom_count);
-            state.set_message(format!("Showing only {count} {scope} atom(s)"));
+            state.status_neutral(format!("Showing only {count} {scope} atom(s)"));
         }
     }
 }
@@ -132,7 +132,7 @@ pub(crate) fn set_hydrogen_display(
 ) {
     use crate::frontend::actions::HydrogenDisplay;
     if matches!(mode, HydrogenDisplay::PolarOnly) {
-        state.set_message("Polar-hydrogen detection is not yet implemented".to_string());
+        state.status_neutral("Polar-hydrogen detection is not yet implemented".to_string());
         return;
     }
     let (indices, _) = style_scope(state);
@@ -144,18 +144,18 @@ pub(crate) fn set_hydrogen_display(
             .collect()
     };
     if hydrogens.is_empty() {
-        state.set_message("No hydrogen atoms in scope".to_string());
+        state.status_neutral("No hydrogen atoms in scope".to_string());
         return;
     }
     let count = hydrogens.len();
     match mode {
         HydrogenDisplay::All => {
             state.ui.viewport.set_atoms_hidden(hydrogens, false);
-            state.set_message(format!("Showing {count} hydrogen(s)"));
+            state.status_neutral(format!("Showing {count} hydrogen(s)"));
         }
         HydrogenDisplay::None => {
             state.ui.viewport.set_atoms_hidden(hydrogens, true);
-            state.set_message(format!("Hid {count} hydrogen(s)"));
+            state.status_neutral(format!("Hid {count} hydrogen(s)"));
         }
         HydrogenDisplay::PolarOnly => unreachable!("handled above"),
     }
@@ -170,7 +170,7 @@ pub(crate) enum OverlayKind {
 pub(crate) fn set_overlay(state: &mut AppState, kind: OverlayKind, on: bool) {
     let (indices, _) = style_scope(state);
     if indices.is_empty() {
-        state.set_message("No atoms in the active entry".to_string());
+        state.status_neutral("No atoms in the active entry".to_string());
         return;
     }
     let items = scope_items(state, &indices);
@@ -229,13 +229,13 @@ pub(crate) fn set_overlay(state: &mut AppState, kind: OverlayKind, on: bool) {
         OverlayKind::Surface => "Surface",
     };
     let verb = if on { "Enabled" } else { "Disabled" };
-    state.set_message(format!("{verb} {label} overlay for {count} atom(s)"));
+    state.status_neutral(format!("{verb} {label} overlay for {count} atom(s)"));
 }
 
 pub(crate) fn reset_selection_style(state: &mut AppState) {
     let (indices, all) = style_scope(state);
     if indices.is_empty() {
-        state.set_message("No atoms to reset".to_string());
+        state.status_neutral("No atoms to reset".to_string());
         return;
     }
     let count = indices.len();
@@ -250,7 +250,7 @@ pub(crate) fn reset_selection_style(state: &mut AppState) {
         .set_atoms_hidden(indices.iter().copied(), false);
     state.ui.viewport.clear_atom_styles(indices);
     let scope = if all { "all" } else { "selected" };
-    state.set_message(format!("Reset style for {count} {scope} atom(s)"));
+    state.status_neutral(format!("Reset style for {count} {scope} atom(s)"));
 }
 
 pub(crate) fn undo(state: &mut AppState) {
@@ -260,7 +260,7 @@ pub(crate) fn undo(state: &mut AppState) {
     let current = state.capture_edit_snapshot();
     state.history.push_redo(current);
     state.restore_edit_snapshot(previous);
-    state.set_message("Undid last change".to_string());
+    state.status_neutral("Undid last change".to_string());
 }
 
 pub(crate) fn redo(state: &mut AppState) {
@@ -270,7 +270,7 @@ pub(crate) fn redo(state: &mut AppState) {
     let current = state.capture_edit_snapshot();
     state.history.push_undo(current);
     state.restore_edit_snapshot(next);
-    state.set_message("Redid last change".to_string());
+    state.status_neutral("Redid last change".to_string());
 }
 
 pub(crate) fn create_group(state: &mut AppState, name: String) {
@@ -279,9 +279,9 @@ pub(crate) fn create_group(state: &mut AppState, name: String) {
             state.ui.entry_list.creating_group = false;
             state.ui.entry_list.new_group_name.clear();
             state.ui.entry_list.collapsed_group_ids.remove(&group_id);
-            state.set_message(format!("Created group {}", name.trim()));
+            state.status_neutral(format!("Created group {}", name.trim()));
         }
-        None => state.set_message("Group name cannot be empty".to_string()),
+        None => state.status_neutral("Group name cannot be empty".to_string()),
     }
 }
 
@@ -298,9 +298,9 @@ pub(crate) fn delete_group(state: &mut AppState, group_id: &str) {
             state.ui.entry_list.renaming_group_id = None;
             state.ui.entry_list.rename_group_buffer.clear();
         }
-        state.set_message("Deleted group".to_string());
+        state.status_neutral("Deleted group".to_string());
     } else {
-        state.set_message("Cannot delete group".to_string());
+        state.status_neutral("Cannot delete group".to_string());
     }
 }
 
@@ -334,9 +334,9 @@ pub(crate) fn group_delete_summary(state: &AppState, group_id: &str) -> Option<(
 pub(crate) fn move_entry_to_group(state: &mut AppState, entry_id: u64, group_id: &str) {
     if state.entries.move_entry_to_group(entry_id, group_id) {
         if group_id.is_empty() {
-            state.set_message("Removed entry from group".to_string());
+            state.status_neutral("Removed entry from group".to_string());
         } else {
-            state.set_message("Moved entry to group".to_string());
+            state.status_neutral("Moved entry to group".to_string());
         }
     }
 }

--- a/src/frontend/dispatcher/selection/residue.rs
+++ b/src/frontend/dispatcher/selection/residue.rs
@@ -6,7 +6,7 @@ pub(crate) fn select_residue(state: &mut AppState, residue_index: usize, toggle:
     let atom_count = state.structure().atoms.len();
     let Some(atom_indices) = residue_atom_indices(state, residue_index, atom_count) else {
         state.ui.selection.retain_valid(atom_count);
-        state.set_message("Residue selection is unavailable for the active entry".to_string());
+        state.status_neutral("Residue selection is unavailable for the active entry".to_string());
         return;
     };
 
@@ -33,8 +33,9 @@ pub(crate) fn select_residue_range(
     let Some(atom_indices) = residue_range_atom_indices(state, chain_id, start, end, atom_count)
     else {
         state.ui.selection.retain_valid(atom_count);
-        state
-            .set_message("Residue range selection is unavailable for the active entry".to_string());
+        state.status_neutral(
+            "Residue range selection is unavailable for the active entry".to_string(),
+        );
         return;
     };
 
@@ -58,7 +59,7 @@ pub(crate) fn select_residues(
     let atom_count = state.structure().atoms.len();
     let Some(atom_indices) = residue_set_atom_indices(state, residue_indices, atom_count) else {
         state.ui.selection.retain_valid(atom_count);
-        state.set_message("Residue selection is unavailable for the active entry".to_string());
+        state.status_neutral("Residue selection is unavailable for the active entry".to_string());
         return;
     };
 
@@ -79,7 +80,7 @@ fn select_residue_atoms(
     let atom_count = state.structure().atoms.len();
     if atom_indices.is_empty() {
         state.ui.selection.retain_valid(atom_count);
-        state.set_message(empty_message.to_string());
+        state.status_neutral(empty_message.to_string());
         return;
     }
 
@@ -104,9 +105,9 @@ fn select_residue_atoms(
     state.ui.selection.retain_valid(atom_count);
 
     if state.ui.selection.is_empty() {
-        state.set_message("Cleared atom selection".to_string());
+        state.status_neutral("Cleared atom selection".to_string());
     } else {
-        state.set_message(format!("Selected {} atom(s)", state.ui.selection.len()));
+        state.status_neutral(format!("Selected {} atom(s)", state.ui.selection.len()));
     }
 }
 

--- a/src/frontend/dispatcher/settings.rs
+++ b/src/frontend/dispatcher/settings.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use crate::frontend::state::SystemSubsystem;
+
 /// Apply and persist the light/dark appearance preference. egui switches the
 /// active theme immediately; the choice is written to the global settings file.
 pub(crate) fn set_theme_mode(
@@ -10,7 +12,10 @@ pub(crate) fn set_theme_mode(
     state.config.theme = mode;
     crate::frontend::theme::set_preference(ctx, mode);
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save theme preference: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save theme preference: {error}"),
+        );
     }
 }
 
@@ -23,7 +28,10 @@ pub(crate) fn set_color_scheme(
     // Rebuild the visuals live; the scheme is read back by `theme::palette`.
     crate::frontend::theme::set_scheme(ctx, scheme);
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save color scheme: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save color scheme: {error}"),
+        );
     }
 }
 
@@ -36,7 +44,10 @@ pub(crate) fn set_default_compute_target(
 ) {
     state.config.default_compute_target = target;
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save default compute target: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save default compute target: {error}"),
+        );
     }
 }
 
@@ -46,9 +57,10 @@ pub(crate) fn set_default_task_panel_placement(
 ) {
     state.config.default_task_panel_placement = placement;
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!(
-            "Could not save default task panel location: {error}"
-        ));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save default task panel location: {error}"),
+        );
     }
 }
 
@@ -62,7 +74,10 @@ pub(crate) fn set_representation(
 ) {
     state.config.representation.apply(edit);
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save representation defaults: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save representation defaults: {error}"),
+        );
     }
 }
 
@@ -73,7 +88,10 @@ pub(crate) fn reset_representation_group(
 ) {
     state.config.representation.reset_group(group);
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save representation defaults: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save representation defaults: {error}"),
+        );
     }
 }
 
@@ -81,7 +99,10 @@ pub(crate) fn reset_representation_group(
 pub(crate) fn reset_representation_defaults(state: &mut AppState) {
     state.config.representation = crate::backend::representation::RepresentationPrefs::default();
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save representation defaults: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save representation defaults: {error}"),
+        );
     }
 }
 
@@ -91,7 +112,10 @@ pub(crate) fn reset_representation_defaults(state: &mut AppState) {
 pub(crate) fn set_check_updates(state: &mut AppState, on: bool) {
     state.config.check_updates = on;
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save update preference: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save update preference: {error}"),
+        );
     }
     if on && state.jobs.update_check.is_none() && state.ui.available_update.is_none() {
         state.jobs.update_check = Some(spawn_update_check());
@@ -105,7 +129,10 @@ pub(crate) fn set_check_updates(state: &mut AppState, on: bool) {
 pub(crate) fn set_show_utilization_bars(state: &mut AppState, on: bool) {
     state.config.show_utilization_bars = on;
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save utilization preference: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save utilization preference: {error}"),
+        );
     }
     let initial = crate::frontend::jobs::refresh_interval(state.config.monitor_refresh);
     crate::frontend::jobs::apply_metrics_sampler(&mut state.jobs, on, initial);
@@ -129,7 +156,10 @@ pub(crate) fn set_monitor_refresh(
 ) {
     state.config.monitor_refresh = rate;
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save monitor refresh rate: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save monitor refresh rate: {error}"),
+        );
     }
     ctx.request_repaint();
 }
@@ -141,7 +171,10 @@ pub(crate) fn set_monitor_refresh(
 pub(crate) fn set_auto_install_updates(state: &mut AppState, on: bool) {
     state.config.auto_install_updates = on;
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save update preference: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save update preference: {error}"),
+        );
     }
     if on {
         maybe_auto_install_update(state);
@@ -165,11 +198,10 @@ pub(crate) fn maybe_auto_install_update(state: &mut AppState) {
     // once per discovered update) and point at the manual fallback, rather than
     // returning silently as if nothing were pending.
     if !crate::io::self_update::is_self_update_supported() {
-        state.set_message(
+        state.status_neutral(
             "Auto-install is unavailable here because SilicoLab's install location \
              is read-only. Use the update link in the title bar to download the new \
-             version manually."
-                .to_string(),
+             version manually.",
         );
         return;
     }
@@ -181,7 +213,7 @@ pub(crate) fn maybe_auto_install_update(state: &mut AppState) {
         .unwrap_or_default();
     state.ui.self_update = SelfUpdateStatus::Downloading;
     state.jobs.self_update = Some(spawn_self_update());
-    state.set_message(format!("Downloading SilicoLab {version}…"));
+    state.status_neutral(format!("Downloading SilicoLab {version}…"));
 }
 
 /// Persist whether the next launch reopens the last project. The stored field
@@ -190,7 +222,10 @@ pub(crate) fn maybe_auto_install_update(state: &mut AppState) {
 pub(crate) fn set_reopen_last_project(state: &mut AppState, reopen: bool) {
     state.config.closed_to_scratch = !reopen;
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save startup preference: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save startup preference: {error}"),
+        );
     }
 }
 
@@ -206,9 +241,12 @@ pub(crate) fn pick_default_project_dir(state: &mut AppState) {
     };
     state.config.default_project_dir = path;
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save default project folder: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save default project folder: {error}"),
+        );
     } else {
-        state.set_message(format!(
+        state.status_success(format!(
             "Default project folder set to {}",
             state.config.default_project_dir.display()
         ));
@@ -229,9 +267,9 @@ pub(crate) fn reveal_settings_file(state: &mut AppState) {
         false
     };
     if revealed {
-        state.set_message(format!("Revealed {}", path.display()));
+        state.status_success(format!("Revealed {}", path.display()));
     } else {
-        state.set_message(format!("Settings file: {}", path.display()));
+        state.status_neutral(format!("Settings file: {}", path.display()));
     }
 }
 
@@ -281,9 +319,12 @@ pub(crate) fn reset_all_settings(state: &mut AppState, ctx: &egui::Context) {
     crate::frontend::theme::set_preference(ctx, state.config.theme);
     crate::frontend::theme::set_scheme(ctx, state.config.color_scheme);
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save reset settings: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save reset settings: {error}"),
+        );
     } else {
-        state.set_message("All settings reset to defaults".to_string());
+        state.status_success("All settings reset to defaults");
     }
 }
 
@@ -298,8 +339,11 @@ pub(crate) fn export_settings(state: &mut AppState) {
         return;
     };
     match crate::backend::config::save_config_to(&path, &state.config) {
-        Ok(()) => state.set_message(format!("Exported settings to {}", path.display())),
-        Err(error) => state.set_message(format!("Could not export settings: {error}")),
+        Ok(()) => state.status_success(format!("Exported settings to {}", path.display())),
+        Err(error) => state.report_system_error(
+            SystemSubsystem::File,
+            format!("Could not export settings: {error}"),
+        ),
     }
 }
 
@@ -320,12 +364,18 @@ pub(crate) fn import_settings(state: &mut AppState, ctx: &egui::Context) {
             crate::frontend::theme::set_preference(ctx, state.config.theme);
             crate::frontend::theme::set_scheme(ctx, state.config.color_scheme);
             if let Err(error) = save_config(&state.config) {
-                state.set_message(format!("Imported settings, but could not save: {error}"));
+                state.report_system_error(
+                    SystemSubsystem::Settings,
+                    format!("Imported settings, but could not save: {error}"),
+                );
             } else {
-                state.set_message(format!("Imported settings from {}", path.display()));
+                state.status_success(format!("Imported settings from {}", path.display()));
             }
         }
-        Err(error) => state.set_message(format!("Could not import settings: {error}")),
+        Err(error) => state.report_system_error(
+            SystemSubsystem::File,
+            format!("Could not import settings: {error}"),
+        ),
     }
 }
 
@@ -370,7 +420,10 @@ pub(crate) fn reset_sidebar(state: &mut AppState, ctx: &egui::Context) {
 pub(crate) fn set_glass(state: &mut AppState, on: bool) {
     state.config.glass = on;
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save glass preference: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save glass preference: {error}"),
+        );
     }
 }
 
@@ -382,7 +435,10 @@ pub(crate) fn set_compute_core_count(state: &mut AppState, cores: usize) {
         crate::backend::hardware::info().logical_cores,
     );
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save core-count preference: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save core-count preference: {error}"),
+        );
     }
 }
 
@@ -393,6 +449,9 @@ pub(crate) fn set_compute_core_count(state: &mut AppState, cores: usize) {
 pub(crate) fn set_glass_intensity(state: &mut AppState, value: f32, commit: bool) {
     state.config.glass_intensity = value.clamp(0.0, 1.0);
     if commit && let Err(error) = save_config(&state.config) {
-        state.set_message(format!("Could not save glass intensity: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("Could not save glass intensity: {error}"),
+        );
     }
 }

--- a/src/frontend/dispatcher/simulation.rs
+++ b/src/frontend/dispatcher/simulation.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::backend::config::ComputeTarget;
-use crate::frontend::state::{EngineDraft, EngineProbeState};
+use crate::frontend::state::{EngineDraft, EngineProbeState, SystemSubsystem};
 
 mod md_build;
 mod remote;
@@ -21,11 +21,11 @@ pub(crate) fn start_pending_md_run(state: &mut AppState) {
         return;
     };
     if state.jobs.engine_running() {
-        state.set_message("another external engine job is already running".to_string());
+        state.status_neutral("another external engine job is already running");
         return;
     }
     if state.structure().cell.is_none() {
-        state.set_message("MD runs need a structure with a simulation box".to_string());
+        state.status_neutral("MD runs need a structure with a simulation box");
         return;
     }
     // Validate the neutral stage sequence against the effective context; errors
@@ -41,18 +41,18 @@ pub(crate) fn start_pending_md_run(state: &mut AppState) {
                 })
                 .map(|issue| issue.message.clone())
                 .unwrap_or_default();
-            state.set_message(format!("Cannot run: {first}"));
+            state.status_neutral(format!("Cannot run: {first}"));
             return;
         }
     }
     if prompt.stages.is_empty() {
-        state.set_message("Add at least one MD stage".to_string());
+        state.status_neutral("Add at least one MD stage");
         return;
     }
     let topology = match resolve_md_topology_source(state, &prompt) {
         Ok(topology) => topology,
         Err(error) => {
-            state.set_message(error.to_string());
+            state.status_neutral(error.to_string());
             return;
         }
     };
@@ -83,7 +83,7 @@ pub(crate) fn start_pending_md_run(state: &mut AppState) {
         let topology = match crate::workflows::gromacs::WireTopology::from_source(&topology) {
             Ok(topology) => topology,
             Err(error) => {
-                state.set_message(format!("could not read the run topology: {error}"));
+                state.status_error(format!("could not read the run topology: {error}"));
                 return;
             }
         };
@@ -109,7 +109,7 @@ pub(crate) fn start_pending_md_run(state: &mut AppState) {
     let mut compute = match resolve_md_compute(state, prompt.engine) {
         Ok(compute) => compute,
         Err(error) => {
-            state.set_message(error.to_string());
+            state.status_neutral(error.to_string());
             return;
         }
     };
@@ -123,7 +123,10 @@ pub(crate) fn start_pending_md_run(state: &mut AppState) {
         match ensure_active_task_run_dir(state, TaskKind::RunMd, Some(prompt.run_name.as_str())) {
             Ok(path) => path,
             Err(error) => {
-                state.set_message(format!("failed to create run directory: {error}"));
+                state.report_system_error(
+                    SystemSubsystem::Storage,
+                    format!("failed to create run directory: {error}"),
+                );
                 complete_active_task(state, TaskKind::RunMd, TaskStatus::Failed);
                 return;
             }
@@ -154,7 +157,7 @@ pub(crate) fn start_pending_md_run(state: &mut AppState) {
         );
         mark_task_status(state, task_run_id, TaskStatus::Running);
     }
-    state.set_message(format!(
+    state.status_neutral(format!(
         "{} MD running; press Esc to stop",
         prompt.engine.label()
     ));
@@ -171,7 +174,7 @@ pub(crate) fn cancel_pending_md_run_request(state: &mut AppState) {
         );
     }
     state.ui.pending_md_run = None;
-    state.set_message("MD run canceled".to_string());
+    state.status_neutral("MD run canceled");
     complete_active_task(state, TaskKind::RunMd, TaskStatus::Failed);
     close_active_task_panel(state);
 }
@@ -349,7 +352,7 @@ pub(crate) fn verify_engine(state: &mut AppState, target: ComputeTarget, engine:
     use crate::frontend::jobs::VerifyTarget;
 
     if state.jobs.engine_verify.is_some() {
-        state.set_message("An engine check is already running".to_string());
+        state.status_neutral("An engine check is already running");
         return;
     }
     let launches = match &target {
@@ -359,13 +362,13 @@ pub(crate) fn verify_engine(state: &mut AppState, target: ComputeTarget, engine:
         }
         ComputeTarget::Remote(id) => {
             if let Err(error) = crate::engines::remote::ensure_ssh_available() {
-                state.set_message(error.to_string());
+                state.status_neutral(error.to_string());
                 return;
             }
             match super::commit_remote_host_draft(state, id) {
                 Ok(host) => VerifyTarget::Remote(Box::new(host)),
                 Err(error) => {
-                    state.set_message(error.to_string());
+                    state.status_neutral(error.to_string());
                     return;
                 }
             }
@@ -411,7 +414,7 @@ pub(crate) fn apply_verify_outcome(
     let key = (target.clone(), engine.as_str());
     state.ui.settings.engine_probe.remove(&key);
     if current_engine_draft_launch(state, &target, engine) != checked_launch {
-        state.set_message("Engine check ignored because the launch was edited".to_string());
+        state.status_neutral("Engine check ignored because the launch was edited");
         return;
     }
     let message = match outcome {
@@ -441,7 +444,7 @@ pub(crate) fn apply_verify_outcome(
             return;
         }
     };
-    state.set_message(message);
+    state.status_success(message);
 }
 
 fn current_engine_draft_launch(
@@ -541,7 +544,7 @@ pub(crate) fn clear_engine_launch(state: &mut AppState, target: ComputeTarget, e
         .engine_probe
         .remove(&(target.clone(), engine.as_str()));
     set_engine_launch(state, &target, engine, None);
-    state.set_message("Engine launch cleared; using auto-detection".to_string());
+    state.status_success("Engine launch cleared; using auto-detection");
 }
 
 pub(crate) fn browse_engine_program(state: &mut AppState, id: EngineId) {
@@ -558,8 +561,11 @@ pub(crate) fn browse_engine_program(state: &mut AppState, id: EngineId) {
 
 pub(crate) fn persist_engine_config(state: &mut AppState, message: &str) {
     match save_config(&state.config) {
-        Ok(()) => state.set_message(message.to_string()),
-        Err(error) => state.set_message(format!("failed to save engine settings: {error}")),
+        Ok(()) => state.status_success(message),
+        Err(error) => state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("failed to save engine settings: {error}"),
+        ),
     }
 }
 
@@ -576,7 +582,7 @@ pub(crate) fn add_hydrogens(state: &mut AppState) {
         .selection
         .retain_valid(state.structure().atoms.len());
     state.history.push_undo(before);
-    state.set_message(format!("Added {added} hydrogens"));
+    state.status_success(format!("Added {added} hydrogens"));
 }
 
 pub(crate) fn recompute_bonds(state: &mut AppState) {
@@ -592,7 +598,7 @@ pub(crate) fn recompute_bonds(state: &mut AppState) {
         .selection
         .retain_valid(state.structure().atoms.len());
     state.history.push_undo(before);
-    state.set_message(format!(
+    state.status_success(format!(
         "Recomputed bonds: {} bonds detected",
         state.structure().bonds.len()
     ));
@@ -603,7 +609,7 @@ pub(crate) fn translate_atoms_into_first_unit_cell(state: &mut AppState) {
         state.structure(),
         "translating atoms into the first unit cell requires a periodic structure",
     ) {
-        state.set_message(error.to_string());
+        state.status_neutral(error.to_string());
         return;
     }
 
@@ -621,7 +627,7 @@ pub(crate) fn translate_atoms_into_first_unit_cell(state: &mut AppState) {
         .selection
         .retain_valid(state.structure().atoms.len());
     state.history.push_undo(before);
-    state.set_message("Translated atoms into the first unit cell".to_string());
+    state.status_success("Translated atoms into the first unit cell");
 }
 
 pub(crate) fn expand_supercell(state: &mut AppState, repeats: [u32; 3]) {
@@ -634,7 +640,7 @@ pub(crate) fn expand_supercell(state: &mut AppState, repeats: [u32; 3]) {
     state.mark_structure_changed();
     state.ui.selection.clear();
     state.history.push_undo(before);
-    state.set_message(format!(
+    state.status_success(format!(
         "Expanded to {}x{}x{} supercell ({} atoms, {} bonds)",
         repeats[0],
         repeats[1],

--- a/src/frontend/dispatcher/simulation/md_build.rs
+++ b/src/frontend/dispatcher/simulation/md_build.rs
@@ -1,5 +1,7 @@
 use super::super::*;
 
+use crate::frontend::state::SystemSubsystem;
+
 /// Build the MD system with the engine the panel selected. Returns `true` once
 /// the work is launched/finished and the panel may close; `false` leaves the
 /// panel open with a reported reason so the user can adjust inputs and retry.
@@ -50,7 +52,7 @@ pub(crate) fn start_material_md_build(
     use crate::engines::gromacs::MaterialBuildRequest;
 
     if state.jobs.engine_running() {
-        state.set_message("another external engine job is already running".to_string());
+        state.status_neutral("another external engine job is already running");
         return false;
     }
     let run_dir = match ensure_active_task_run_dir(
@@ -60,7 +62,10 @@ pub(crate) fn start_material_md_build(
     ) {
         Ok(path) => path,
         Err(error) => {
-            state.set_message(format!("failed to create run directory: {error}"));
+            state.report_system_error(
+                SystemSubsystem::Storage,
+                format!("failed to create run directory: {error}"),
+            );
             complete_active_task(state, TaskKind::BuildMdSystem, TaskStatus::Failed);
             return false;
         }
@@ -97,7 +102,7 @@ pub(crate) fn start_material_md_build(
     let compute = match resolve_md_compute(state, crate::frontend::state::MdEngineChoice::Gromacs) {
         Ok(compute) => compute,
         Err(error) => {
-            state.set_message(error.to_string());
+            state.status_neutral(error.to_string());
             return false;
         }
     };
@@ -130,7 +135,7 @@ pub(crate) fn start_material_md_build(
             task_run_id,
         );
     }
-    state.set_message("Building framework MD system; press Esc to stop".to_string());
+    state.status_neutral("Building framework MD system; press Esc to stop");
     true
 }
 
@@ -143,7 +148,7 @@ pub(crate) fn start_gromacs_md_build(
     prompt: &crate::frontend::state::MdSystemPrompt,
 ) -> bool {
     if state.jobs.engine_running() {
-        state.set_message("another external engine job is already running".to_string());
+        state.status_neutral("another external engine job is already running");
         return false;
     }
     let run_dir = match ensure_active_task_run_dir(
@@ -153,7 +158,10 @@ pub(crate) fn start_gromacs_md_build(
     ) {
         Ok(path) => path,
         Err(error) => {
-            state.set_message(format!("failed to create run directory: {error}"));
+            state.report_system_error(
+                SystemSubsystem::Storage,
+                format!("failed to create run directory: {error}"),
+            );
             complete_active_task(state, TaskKind::BuildMdSystem, TaskStatus::Failed);
             return false;
         }
@@ -196,7 +204,7 @@ pub(crate) fn start_gromacs_md_build(
     let compute = match resolve_md_compute(state, crate::frontend::state::MdEngineChoice::Gromacs) {
         Ok(compute) => compute,
         Err(error) => {
-            state.set_message(error.to_string());
+            state.status_neutral(error.to_string());
             return false;
         }
     };
@@ -228,7 +236,7 @@ pub(crate) fn start_gromacs_md_build(
             task_run_id,
         );
     }
-    state.set_message("GROMACS building MD system; press Esc to stop".to_string());
+    state.status_neutral("GROMACS building MD system; press Esc to stop");
     true
 }
 
@@ -245,7 +253,7 @@ pub(crate) fn build_md_system_builtin(
     let (boxed, report) = match result {
         Ok(value) => value,
         Err(error) => {
-            state.set_message(format!("MD system build failed: {error}"));
+            state.status_error(format!("MD system build failed: {error}"));
             return false;
         }
     };
@@ -257,7 +265,7 @@ pub(crate) fn build_md_system_builtin(
         Some(options) => match crate::workflows::molecular_dynamics::solvate(&boxed, &options) {
             Ok(out) => Some(out),
             Err(error) => {
-                state.set_message(format!("MD system solvation failed: {error}"));
+                state.status_error(format!("MD system solvation failed: {error}"));
                 return false;
             }
         },
@@ -271,7 +279,10 @@ pub(crate) fn build_md_system_builtin(
     ) {
         Ok(path) => path,
         Err(error) => {
-            state.set_message(format!("failed to create run directory: {error}"));
+            state.report_system_error(
+                SystemSubsystem::Storage,
+                format!("failed to create run directory: {error}"),
+            );
             complete_active_task(state, TaskKind::BuildMdSystem, TaskStatus::Failed);
             return false;
         }
@@ -328,7 +339,7 @@ pub(crate) fn build_md_system_builtin(
     } else {
         ""
     };
-    state.set_message(format!(
+    state.status_success(format!(
         "Built MD system: {a:.1} x {b:.1} x {c:.1} A box, {} atoms{replaced}{solvation_note}",
         state.structure().atoms.len()
     ));

--- a/src/frontend/dispatcher/simulation/remote.rs
+++ b/src/frontend/dispatcher/simulation/remote.rs
@@ -1,5 +1,7 @@
 use super::super::*;
 
+use crate::frontend::state::SystemSubsystem;
+
 /// Build a validated [`RemoteHost`] from a settings draft. `prior` is the host as
 /// stored, carrying the state the draft does not expose: the worker deployment
 /// identity, and each engine's verification.
@@ -177,7 +179,7 @@ pub(crate) fn add_remote_host(state: &mut AppState) {
             persist_engine_config(state, &format!("Added remote host {label}"));
         }
         // The form stays open with the draft intact, beside the field to fix.
-        Err(error) => state.set_message(error.to_string()),
+        Err(error) => state.status_neutral(error.to_string()),
     }
 }
 
@@ -212,15 +214,18 @@ pub(crate) fn commit_remote_host_draft(
         .remote_hosts
         .insert(id.to_string(), host.clone());
     if let Err(error) = save_config(&state.config) {
-        state.set_message(format!("failed to save engine settings: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Settings,
+            format!("failed to save engine settings: {error}"),
+        );
     }
     Ok(host)
 }
 
 pub(crate) fn save_remote_host(state: &mut AppState, id: String) {
     match commit_remote_host_draft(state, &id) {
-        Ok(host) => state.set_message(format!("Saved remote host {}", host.label)),
-        Err(error) => state.set_message(error.to_string()),
+        Ok(host) => state.status_success(format!("Saved remote host {}", host.label)),
+        Err(error) => state.status_neutral(error.to_string()),
     }
 }
 
@@ -233,7 +238,7 @@ pub(crate) fn remove_remote_host(state: &mut AppState, id: String) {
     })()
     .unwrap_or(true);
     if has_active_jobs {
-        state.set_message("This host has active remote jobs and cannot be removed".to_string());
+        state.status_neutral("This host has active remote jobs and cannot be removed");
         return;
     }
     state.config.remote_hosts.remove(&id);
@@ -263,17 +268,17 @@ fn begin_remote_probe(
     id: &str,
 ) -> Option<crate::backend::config::RemoteHost> {
     if state.jobs.remote_probe.is_some() {
-        state.set_message("A remote-host check is already running".to_string());
+        state.status_neutral("A remote-host check is already running");
         return None;
     }
     if let Err(error) = crate::engines::remote::ensure_ssh_available() {
-        state.set_message(error.to_string());
+        state.status_neutral(error.to_string());
         return None;
     }
     match commit_remote_host_draft(state, id) {
         Ok(host) => Some(host),
         Err(error) => {
-            state.set_message(error.to_string());
+            state.status_neutral(error.to_string());
             None
         }
     }
@@ -287,7 +292,7 @@ pub(crate) fn detect_remote_slurm(state: &mut AppState, id: String) {
         host,
         crate::frontend::jobs::RemoteProbeKind::DetectSlurm,
     ));
-    state.set_message("Detecting Slurm…".to_string());
+    state.status_neutral("Detecting Slurm…");
 }
 
 pub(crate) fn refresh_slurm_capabilities(state: &mut AppState, id: String) {
@@ -298,7 +303,7 @@ pub(crate) fn refresh_slurm_capabilities(state: &mut AppState, id: String) {
         host,
         crate::frontend::jobs::RemoteProbeKind::SlurmCapabilities,
     ));
-    state.set_message("Refreshing Slurm capabilities…".to_string());
+    state.status_neutral("Refreshing Slurm capabilities…");
 }
 
 pub(crate) fn test_remote_slurm(state: &mut AppState, id: String) {
@@ -309,29 +314,29 @@ pub(crate) fn test_remote_slurm(state: &mut AppState, id: String) {
         host,
         crate::frontend::jobs::RemoteProbeKind::TestSlurm,
     ));
-    state.set_message("Submitting a Slurm test job…".to_string());
+    state.status_neutral("Submitting a Slurm test job…");
 }
 
 /// Fetch the static hardware inventory of a remote host over SSH (CPU/memory/GPU)
 /// on a worker thread, for the Hardware ▸ Remote settings panel.
 pub(crate) fn fetch_remote_hardware(state: &mut AppState, id: String) {
     if state.jobs.remote_hardware.is_some() {
-        state.set_message("Already fetching remote hardware…".to_string());
+        state.status_neutral("Already fetching remote hardware…");
         return;
     }
     if let Err(error) = crate::engines::remote::ensure_ssh_available() {
-        state.set_message(error.to_string());
+        state.status_neutral(error.to_string());
         return;
     }
     let host = match commit_remote_host_draft(state, &id) {
         Ok(host) => host,
         Err(error) => {
-            state.set_message(error.to_string());
+            state.status_neutral(error.to_string());
             return;
         }
     };
     state.jobs.remote_hardware = Some(crate::frontend::jobs::spawn_remote_hardware_fetch(host));
-    state.set_message("Fetching remote hardware…".to_string());
+    state.status_neutral("Fetching remote hardware…");
 }
 
 /// Point the sidebar system monitor at `src` (Local or a remote host), reconciling
@@ -406,7 +411,7 @@ pub(crate) fn set_monitor_source(state: &mut AppState, src: crate::frontend::sta
 pub(crate) fn check_remote_host(state: &mut AppState, id: String) {
     // The BatchMode test uses the dedicated key, so make sure it exists first.
     if let Err(error) = crate::engines::remote::bootstrap::ensure_key() {
-        state.set_message(format!("Could not prepare the SSH key: {error}"));
+        state.status_error(format!("Could not prepare the SSH key: {error}"));
         return;
     }
     let Some(host) = begin_remote_probe(state, &id) else {
@@ -421,30 +426,28 @@ pub(crate) fn check_remote_host(state: &mut AppState, id: String) {
         host,
         crate::frontend::jobs::RemoteProbeKind::Passwordless,
     ));
-    state.set_message("Testing connection to the remote host…".to_string());
+    state.status_neutral("Testing connection to the remote host…");
 }
 
 pub(crate) fn setup_remote_host_key(state: &mut AppState, id: String) {
     if let Err(error) = crate::engines::remote::ensure_ssh_available() {
-        state.set_message(error.to_string());
+        state.status_neutral(error.to_string());
         return;
     }
     if let Err(error) = crate::engines::remote::bootstrap::ensure_key() {
-        state.set_message(format!("Could not prepare the SSH key: {error}"));
+        state.status_error(format!("Could not prepare the SSH key: {error}"));
         return;
     }
     let pubkey = match crate::engines::remote::bootstrap::public_key() {
         Ok(key) => key,
         Err(error) => {
-            state.set_message(format!("Could not read the public key: {error}"));
+            state.status_error(format!("Could not read the public key: {error}"));
             return;
         }
     };
     let command = crate::engines::remote::bootstrap::install_command(&pubkey);
     state.ui.settings.remote_bootstrap = Some((id, command));
-    state.set_message(
-        "Run the shown command once on the remote host, then click Verify.".to_string(),
-    );
+    state.status_neutral("Run the shown command once on the remote host, then click Verify.");
 }
 
 #[cfg(test)]

--- a/src/frontend/dispatcher/sketch.rs
+++ b/src/frontend/dispatcher/sketch.rs
@@ -15,7 +15,7 @@ use super::add_and_show_entry;
 /// Open an empty sketcher.
 pub(crate) fn sketch_molecule(state: &mut AppState) {
     state.ui.sketcher = Some(SketcherState::new());
-    state.set_message("Sketching a new molecule".to_string());
+    state.status_neutral("Sketching a new molecule".to_string());
 }
 
 /// Build the current sketch into a relaxed 3D structure and add it as a new,
@@ -43,7 +43,7 @@ pub(crate) fn commit_sketch(state: &mut AppState) {
     let atom_count = structure.atoms.len();
     let save_path = structure_io::default_structure_save_path(&structure, None);
     let entry_id = add_and_show_entry(state, structure, None, save_path);
-    state.set_message(format!(
+    state.status_success(format!(
         "Built sketched molecule as entry #{entry_id} ({atom_count} atoms)"
     ));
 }
@@ -51,5 +51,5 @@ pub(crate) fn commit_sketch(state: &mut AppState) {
 /// Discard the sketch and close the sketcher.
 pub(crate) fn cancel_sketch(state: &mut AppState) {
     state.ui.sketcher = None;
-    state.set_message("Sketch canceled".to_string());
+    state.status_neutral("Sketch canceled".to_string());
 }

--- a/src/frontend/dispatcher/tasks.rs
+++ b/src/frontend/dispatcher/tasks.rs
@@ -1,8 +1,9 @@
 use super::*;
+use crate::frontend::state::SystemSubsystem;
 
 pub(crate) fn create_task_from_template(state: &mut AppState, template_id: &'static str) {
     let Some(controller) = task_controller_by_id(template_id).copied() else {
-        state.set_message(format!("Unknown task: {template_id}"));
+        state.status_error(format!("Unknown task: {template_id}"));
         return;
     };
 
@@ -19,7 +20,7 @@ pub(crate) fn create_task_from_template(state: &mut AppState, template_id: &'sta
             .dock
             .add_task(task_run_id, state.config.default_task_panel_placement);
     }
-    state.set_message(format!(
+    state.status_success(format!(
         "Opened task #{}: {}",
         task_run_id, controller.title
     ));
@@ -28,7 +29,7 @@ pub(crate) fn create_task_from_template(state: &mut AppState, template_id: &'sta
 
 pub(crate) fn run_task(state: &mut AppState, task_run_id: u64) {
     let Some(task) = state.tasks.task_run(task_run_id).cloned() else {
-        state.set_message(format!("Task #{task_run_id} not found"));
+        state.status_error(format!("Task #{task_run_id} not found"));
         return;
     };
     // Direct (non-panel) tasks act on the active structure immediately, so they
@@ -37,13 +38,13 @@ pub(crate) fn run_task(state: &mut AppState, task_run_id: u64) {
     // the action, so they open even on an empty workspace.
     if task.panel == TaskPanelKind::None && !state.has_active_entry() {
         state.tasks.mark_status(task_run_id, TaskStatus::Failed);
-        state.set_message("Open or create an entry before running tasks".to_string());
+        state.status_neutral("Open or create an entry before running tasks".to_string());
         return;
     }
 
     let Some(executor) = task_executor(task.kind) else {
         state.tasks.mark_status(task_run_id, TaskStatus::Failed);
-        state.set_message(format!("No executor registered for task {}", task.title));
+        state.status_error(format!("No executor registered for task {}", task.title));
         return;
     };
     (executor.run)(state, task_run_id);
@@ -87,14 +88,20 @@ pub(crate) fn complete_active_task(state: &mut AppState, kind: TaskKind, status:
 
 pub(crate) fn sync_task_manifest(state: &mut AppState, task_run_id: u64) {
     if let Err(error) = crate::frontend::task_executor::sync_task_manifest(state, task_run_id) {
-        state.set_message(format!("failed to write run manifest: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Storage,
+            format!("failed to write run manifest: {error}"),
+        );
     }
 }
 
 pub(crate) fn mark_task_status(state: &mut AppState, task_run_id: u64, status: TaskStatus) {
     if let Err(error) = crate::frontend::task_executor::mark_task_status(state, task_run_id, status)
     {
-        state.set_message(format!("failed to update task status: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Storage,
+            format!("failed to update task status: {error}"),
+        );
     }
 }
 
@@ -155,7 +162,10 @@ pub(crate) fn record_task_result_entry(state: &mut AppState, task_run_id: u64, e
     if let Err(error) =
         crate::frontend::task_executor::record_task_result_entry(state, task_run_id, entry_id)
     {
-        state.set_message(format!("failed to record task result entry: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Storage,
+            format!("failed to record task result entry: {error}"),
+        );
     }
 }
 

--- a/src/frontend/jobs/agent.rs
+++ b/src/frontend/jobs/agent.rs
@@ -55,6 +55,11 @@ pub struct TrackedAgentJob {
     pub label: String,
     /// The unified `TaskRun` this worker reports into, so the run shows in the Task Monitor.
     pub task_run_id: u64,
+    /// The bound execution identity — minted at launch exactly as a manually
+    /// submitted job's is, so an assistant-launched run is first-class: its logs
+    /// are Job-scoped and its lifecycle resolves through the same run graph. The
+    /// assistant is only the launcher, recorded by `conversation`/`label`.
+    pub job_id: crate::job::JobId,
     pub job: AgentHeavyJob,
 }
 

--- a/src/frontend/jobs/control.rs
+++ b/src/frontend/jobs/control.rs
@@ -2,8 +2,8 @@ use std::sync::atomic::Ordering;
 
 use crate::backend::storage::jobs as registry;
 use crate::backend::tasks::TaskStatus;
-use crate::frontend::state::AppState;
-use crate::job::CancelCapability;
+use crate::frontend::state::{AppState, SystemSubsystem};
+use crate::job::{CancelCapability, JobId};
 
 use super::agent::AgentHeavyJob;
 use super::manager::JobManager;
@@ -146,6 +146,10 @@ pub struct LiveJobSnapshot {
     pub job_kind: Option<String>,
     pub stage: Option<String>,
     pub task_run_id: Option<u64>,
+    /// The stable execution identity this card projects, when known — the key
+    /// Activity uses to read its exact-job log tail and to deep-link Output. `None`
+    /// for assistant-launched jobs, which carry no bound execution id.
+    pub job_id: Option<JobId>,
     pub run_uuid: Option<String>,
     pub host_label: Option<String>,
     /// Observability of a remote job — `None` for local and agent jobs, which
@@ -203,6 +207,7 @@ impl JobManager {
                 JobKind::Optimizer,
                 "forcefield optimization",
                 active_task_run,
+                self.local_execution(LocalJobSlot::Optimizer),
                 running
                     .latest_report
                     .map(|report| format!("step {}", report.steps)),
@@ -214,6 +219,7 @@ impl JobManager {
                 JobKind::Disorder,
                 "build disordered system",
                 active_task_run,
+                self.local_execution(LocalJobSlot::Disorder),
                 running.latest_report.as_ref().map(|report| {
                     format!(
                         "{} / {} placed",
@@ -229,6 +235,7 @@ impl JobManager {
                 JobKind::Qm,
                 "QM calculation",
                 active_task_run,
+                self.local_execution(LocalJobSlot::Qm),
                 running.latest_stage.clone(),
             );
             if running.cancel_requested {
@@ -236,13 +243,14 @@ impl JobManager {
             }
             jobs.push(snapshot);
         }
-        if self.docking.is_some() {
+        if let Some(running) = self.docking.as_ref() {
             jobs.push(local_snapshot(
                 LocalJobSlot::Docking,
                 JobKind::Docking,
                 "molecular docking",
                 active_task_run,
-                None,
+                self.local_execution(LocalJobSlot::Docking),
+                running.latest_stage.clone(),
             ));
         }
         if let Some(running) = self.engine.as_ref() {
@@ -251,6 +259,7 @@ impl JobManager {
                 JobKind::Engine,
                 format!("{} {}", running.engine, running.job_kind),
                 active_task_run,
+                self.local_execution(LocalJobSlot::Engine),
                 running.latest_stage.clone(),
             );
             snapshot.engine_id = Some(running.engine.to_string());
@@ -554,6 +563,9 @@ pub fn remote_job_snapshot(row: &registry::RemoteJob) -> LiveJobSnapshot {
             (None, None) => None,
         },
         task_run_id: None,
+        // The registry's run identity is the stable `JobId`, so a remote job's
+        // engine text is Job-scoped exactly like a local one.
+        job_id: row.job_id.parse().ok(),
         run_uuid: Some(row.job_id.clone()),
         host_label: Some(row.host_label.clone()),
         observation: Some(row.observation_state()),
@@ -648,7 +660,10 @@ fn mark_task_cancelling(state: &mut AppState, task_run_id: u64) {
     if let Err(error) =
         crate::frontend::task_executor::mark_task_status(state, task_run_id, TaskStatus::Cancelling)
     {
-        state.set_message(format!("failed to update task status: {error}"));
+        state.report_system_error(
+            SystemSubsystem::Project,
+            format!("failed to update task status: {error}"),
+        );
     }
 }
 
@@ -682,6 +697,7 @@ fn local_snapshot(
     kind: JobKind,
     label: impl Into<String>,
     task_run_id: Option<u64>,
+    job_id: Option<JobId>,
     stage: Option<String>,
 ) -> LiveJobSnapshot {
     LiveJobSnapshot {
@@ -695,6 +711,7 @@ fn local_snapshot(
         job_kind: None,
         stage,
         task_run_id,
+        job_id,
         run_uuid: None,
         host_label: None,
         observation: None,
@@ -745,6 +762,7 @@ fn agent_snapshot(tracked: &super::agent::TrackedAgentJob) -> LiveJobSnapshot {
         job_kind,
         stage,
         task_run_id: Some(tracked.task_run_id),
+        job_id: Some(tracked.job_id),
         run_uuid: None,
         host_label: None,
         observation: None,

--- a/src/frontend/jobs/docking.rs
+++ b/src/frontend/jobs/docking.rs
@@ -9,6 +9,7 @@ use crate::workflows::docking::{DockingProgress, run_docking_calculation};
 pub struct RunningDockingJob {
     pub cancel: Arc<AtomicBool>,
     pub receiver: Receiver<DockingWorkerMessage>,
+    pub latest_stage: Option<String>,
 }
 
 pub enum DockingWorkerMessage {
@@ -46,5 +47,9 @@ pub fn spawn_docking_job(request: DockingRequest) -> RunningDockingJob {
         }
     });
 
-    RunningDockingJob { cancel, receiver }
+    RunningDockingJob {
+        cancel,
+        receiver,
+        latest_stage: None,
+    }
 }

--- a/src/frontend/jobs/engine.rs
+++ b/src/frontend/jobs/engine.rs
@@ -49,24 +49,15 @@ pub struct GromacsPipelineRequest {
     pub freeze: Option<crate::engines::gromacs::FreezeSelection>,
 }
 
-/// A background engine job that the UI is currently polling.
+/// A background engine job that the UI is currently polling. Its streamed log
+/// lines are applied to the canonical session log by the dispatcher, scoped to
+/// this job's `JobId`; the handle keeps no second buffer.
 pub struct RunningEngineJob {
     pub engine: &'static str,
     pub job_kind: &'static str,
     pub cancel: Arc<AtomicBool>,
     pub receiver: Receiver<EngineWorkerMessage>,
     pub latest_stage: Option<String>,
-    pub log_tail: Vec<String>,
-}
-
-impl RunningEngineJob {
-    pub fn append_log(&mut self, line: String) {
-        self.log_tail.push(line);
-        if self.log_tail.len() > 200 {
-            let drop = self.log_tail.len() - 200;
-            self.log_tail.drain(0..drop);
-        }
-    }
 }
 
 /// Spawn a multi-step GROMACS pipeline as a background engine job and return
@@ -120,7 +111,6 @@ pub fn spawn_gromacs_pipeline_job(request: GromacsPipelineRequest) -> RunningEng
         cancel,
         receiver,
         latest_stage: None,
-        log_tail: Vec::new(),
     }
 }
 
@@ -197,7 +187,6 @@ pub fn spawn_gromacs_build_job(request: BuildRequest) -> RunningEngineJob {
         cancel,
         receiver,
         latest_stage: None,
-        log_tail: Vec::new(),
     }
 }
 
@@ -276,7 +265,6 @@ pub fn spawn_material_build_job(request: MaterialBuildRequest) -> RunningEngineJ
         cancel,
         receiver,
         latest_stage: None,
-        log_tail: Vec::new(),
     }
 }
 

--- a/src/frontend/jobs/tests.rs
+++ b/src/frontend/jobs/tests.rs
@@ -165,7 +165,6 @@ fn local_job_snapshots_enumerate_live_slots() {
         cancel: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         receiver: engine_rx,
         latest_stage: Some("nvt".to_string()),
-        log_tail: Vec::new(),
     });
 
     let snapshots = jobs.list_live_snapshots(Some(42));
@@ -202,6 +201,7 @@ fn agent_job_cancel_routes_through_control_plane() {
         conversation: state.ui.agent.active_conversation,
         label: "qm energy".to_string(),
         task_run_id,
+        job_id: crate::job::JobId::new(),
         job: AgentHeavyJob::Qm(RunningQmJob {
             cancel: qm_cancel(std::sync::Arc::clone(&cancel)),
             receiver: rx,
@@ -267,6 +267,7 @@ fn agent_job_snapshots_include_latest_stage() {
         conversation: crate::frontend::agent::AssistantConversationId::new(1),
         label: "qm energy".to_string(),
         task_run_id: 44,
+        job_id: crate::job::JobId::new(),
         job: AgentHeavyJob::Qm(RunningQmJob {
             cancel: qm_cancel(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
                 false,
@@ -332,6 +333,7 @@ fn qm_cancel_alias_refuses_multiple_qm_jobs_without_cancelling_any() {
         conversation: state.ui.agent.active_conversation,
         label: "qm optimize".to_string(),
         task_run_id,
+        job_id: crate::job::JobId::new(),
         job: AgentHeavyJob::Qm(RunningQmJob {
             cancel: qm_cancel(std::sync::Arc::clone(&agent_cancel)),
             receiver: agent_rx,
@@ -367,6 +369,7 @@ fn jobs_status_shows_agent_job_and_remote_status_as_last_known() {
         conversation: state.ui.agent.active_conversation,
         label: "qm optimize".to_string(),
         task_run_id,
+        job_id: crate::job::JobId::new(),
         job: AgentHeavyJob::Qm(RunningQmJob {
             cancel: qm_cancel(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
                 false,
@@ -410,6 +413,7 @@ fn jobs_cancel_and_control_plane_cancel_have_matching_qm_message_and_effect() {
             conversation: state.ui.agent.active_conversation,
             label: "qm optimize".to_string(),
             task_run_id,
+            job_id: crate::job::JobId::new(),
             job: AgentHeavyJob::Qm(RunningQmJob {
                 cancel: qm_cancel(std::sync::Arc::clone(&cancel)),
                 receiver: rx,
@@ -461,6 +465,7 @@ fn task_monitor_action_and_assistant_cancel_have_same_agent_job_effect() {
             conversation: state.ui.agent.active_conversation,
             label: "qm optimize".to_string(),
             task_run_id,
+            job_id: crate::job::JobId::new(),
             job: AgentHeavyJob::Qm(RunningQmJob {
                 cancel: qm_cancel(std::sync::Arc::clone(&cancel)),
                 receiver: rx,
@@ -505,7 +510,12 @@ fn task_monitor_action_and_assistant_cancel_have_same_agent_job_effect() {
             .status,
         crate::backend::tasks::TaskStatus::Cancelling
     );
-    assert_eq!(monitor_state.message, outcome.content);
+    assert_eq!(
+        monitor_state
+            .status_notice()
+            .map(|notice| notice.text.as_str()),
+        Some(outcome.content.as_str())
+    );
 }
 
 fn remote_row(

--- a/src/frontend/shortcuts.rs
+++ b/src/frontend/shortcuts.rs
@@ -287,7 +287,7 @@ fn apply_ui_command(state: &mut AppState, command: ShortcutCommand, ctx: &egui::
         }
         ShortcutCommand::ResetViewportCamera => {
             state.ui.camera = Default::default();
-            state.set_message("Reset viewport camera".to_string());
+            state.status_neutral("Reset viewport camera".to_string());
             ctx.request_repaint();
         }
         ShortcutCommand::ZoomViewport(delta) => {

--- a/src/frontend/state.rs
+++ b/src/frontend/state.rs
@@ -18,6 +18,8 @@ mod layout;
 mod md_prompts;
 mod ptm_prompts;
 mod qm_prompts;
+mod session_log;
+mod status;
 
 pub use app::*;
 pub use atom_style::*;
@@ -32,6 +34,8 @@ pub use layout::*;
 pub use md_prompts::*;
 pub use ptm_prompts::*;
 pub use qm_prompts::*;
+pub use session_log::*;
+pub use status::*;
 
 #[cfg(test)]
 mod tests;

--- a/src/frontend/state/app.rs
+++ b/src/frontend/state/app.rs
@@ -1,3 +1,4 @@
+mod feedback;
 mod monitor;
 mod ui_state;
 
@@ -49,15 +50,20 @@ pub struct AppState {
     pub materializations: MaterializationLedger,
     pub jobs: JobManager,
     pub ui: UiState,
-    pub message: String,
-    pub output_log: Vec<String>,
+    /// The typed, byte-bounded owner of every free-text feedback event — the
+    /// command transcript (Console) and the system/agent/remote/job detail
+    /// (Output). Read-only to UI code through [`AppState::session_log`].
+    session_log: SessionLogStore,
+    /// The single status-bar notice with its expiry/priority/pause bookkeeping.
+    status: StatusState,
+    /// Monotonic source of [`CommandId`] for the console transcript.
+    next_command_id: CommandId,
     pub active_task_run: Option<u64>,
     pub edit_origin: Option<EditSnapshot>,
     pub builder_origin: Option<EditSnapshot>,
     pub optimization_origin: Option<EditSnapshot>,
     workspace_structure: Structure,
     workspace_save_path: PathBuf,
-    last_logged_message: String,
     last_saved_entries_fingerprint: u64,
     last_saved_assistant_fingerprint: u64,
     project_save_error: Option<String>,
@@ -93,7 +99,6 @@ impl AppState {
                 let trimmed_title = structure.title.trim();
                 !trimmed_title.is_empty() && trimmed_title != "Untitled"
             };
-        let message = "Ready to open or edit a structure".to_string();
         let entries = if let Some(snapshot) = project_snapshot.as_ref() {
             snapshot.entries.clone()
         } else if has_initial_entry {
@@ -119,15 +124,15 @@ impl AppState {
             materializations,
             jobs: JobManager::default(),
             ui: UiState::default(),
-            message: message.clone(),
-            output_log: vec![message.clone()],
+            session_log: SessionLogStore::default(),
+            status: StatusState::default(),
+            next_command_id: 0,
             active_task_run: None,
             edit_origin: None,
             builder_origin: None,
             optimization_origin: None,
             workspace_structure: structure,
             workspace_save_path: save_path,
-            last_logged_message: message,
             last_saved_entries_fingerprint: 0,
             last_saved_assistant_fingerprint: 0,
             project_save_error: None,
@@ -485,7 +490,10 @@ impl AppState {
                     entry.loaded = true;
                 }
             }
-            Err(error) => self.set_message(format!("Failed to load entry #{entry_id}: {error}")),
+            Err(error) => self.report_system_error(
+                SystemSubsystem::Storage,
+                format!("Failed to load entry #{entry_id}: {error}"),
+            ),
         }
     }
 
@@ -571,23 +579,6 @@ impl AppState {
 
     pub fn can_redo(&self) -> bool {
         self.history_navigation_enabled() && self.history.can_redo()
-    }
-
-    pub fn set_message(&mut self, message: impl Into<String>) {
-        self.message = message.into();
-        self.record_message_change();
-    }
-
-    pub fn record_message_change(&mut self) {
-        if self.message == self.last_logged_message {
-            return;
-        }
-        self.output_log.push(self.message.clone());
-        self.last_logged_message = self.message.clone();
-        if self.output_log.len() > 400 {
-            let excess = self.output_log.len() - 400;
-            self.output_log.drain(0..excess);
-        }
     }
 
     pub fn cancel_transient_jobs(&mut self) {

--- a/src/frontend/state/app/feedback.rs
+++ b/src/frontend/state/app/feedback.rs
@@ -1,0 +1,212 @@
+//! The [`AppState`](super::AppState) feedback API: the single sanctioned write
+//! path into the session log and the status slot. Producers call these; UI code
+//! reads through [`AppState::session_log`]/[`AppState::status_notice`] and emits
+//! actions. The methods live beside the state that owns the private
+//! `session_log`/`status`/`next_command_id` fields.
+
+use crate::frontend::state::{
+    CommandId, DetailTarget, LogLevel, LogScope, NewLogEntry, OutputSource, OutputTarget,
+    SessionLogStore, StatusNotice, StatusScope, SystemSubsystem,
+};
+use crate::job::JobId;
+
+use super::AppState;
+
+impl AppState {
+    /// Immutable access to the session log for UI rendering.
+    pub fn session_log(&self) -> &SessionLogStore {
+        &self.session_log
+    }
+
+    /// The visible status notice, or `None` when the slot is empty.
+    pub fn status_notice(&self) -> Option<&StatusNotice> {
+        self.status.current()
+    }
+
+    /// Expire the current ephemeral notice if its lifetime has elapsed. Driven
+    /// once per frame from the update loop.
+    pub fn tick_status(&mut self, now: std::time::Instant) {
+        self.status.tick(now);
+    }
+
+    /// Freeze or resume status expiry while a linked notice is hovered/focused.
+    pub fn set_status_paused(&mut self, paused: bool, now: std::time::Instant) {
+        self.status.set_paused(paused, now);
+    }
+
+    /// Dismiss the current status notice. Its canonical log/job record is untouched.
+    pub fn acknowledge_status(&mut self) {
+        self.status.acknowledge();
+    }
+
+    /// Allocate a fresh [`CommandId`] for one console invocation, so its prompt,
+    /// result, and error entries can share it.
+    pub fn allocate_command_id(&mut self) -> CommandId {
+        let id = self.next_command_id;
+        self.next_command_id += 1;
+        id
+    }
+
+    /// Append one session-log entry. The single write path into the store from
+    /// state/dispatcher code.
+    pub fn append_log(&mut self, entry: NewLogEntry) {
+        self.session_log.append(entry);
+    }
+
+    pub fn clear_log_fold_boundary(&mut self) -> crate::frontend::state::SessionSeq {
+        self.session_log.break_folding()
+    }
+
+    /// Append engine/workflow text scoped to one exact execution.
+    pub fn append_job_log(&mut self, job_id: JobId, level: LogLevel, text: impl Into<String>) {
+        self.append_log(NewLogEntry::new(LogScope::Job { job_id }, level, text));
+    }
+
+    /// Append control-plane detail (application/project/settings/file/persistence/
+    /// update/rendering).
+    pub fn log_system(
+        &mut self,
+        subsystem: SystemSubsystem,
+        level: LogLevel,
+        text: impl Into<String>,
+    ) {
+        self.append_log(NewLogEntry::new(
+            LogScope::System { subsystem },
+            level,
+            text,
+        ));
+    }
+
+    /// Append remote control-plane detail (SSH/Slurm/transfer/probe). The id is a
+    /// stable host configuration id, never a display label.
+    pub fn log_remote(
+        &mut self,
+        host_id: Option<String>,
+        level: LogLevel,
+        text: impl Into<String>,
+    ) {
+        self.append_log(NewLogEntry::new(
+            LogScope::RemoteControl { host_id },
+            level,
+            text,
+        ));
+    }
+
+    /// Append assistant infrastructure/tool audit detail (not narration, not a
+    /// `.sls` command).
+    pub fn log_agent(&mut self, turn_id: Option<u64>, level: LogLevel, text: impl Into<String>) {
+        self.append_log(NewLogEntry::new(LogScope::Agent { turn_id }, level, text));
+    }
+
+    /// Post a status notice, subject to the expiry/priority rules.
+    pub fn show_status(&mut self, notice: StatusNotice) {
+        self.status.post(notice);
+    }
+
+    /// A transient neutral confirmation (selection/view/dock changes).
+    pub fn status_neutral(&mut self, text: impl Into<String>) {
+        self.show_status(StatusNotice::neutral(StatusScope::General, text));
+    }
+
+    /// A transient success confirmation for a completed action.
+    pub fn status_success(&mut self, text: impl Into<String>) {
+        self.show_status(StatusNotice::success(StatusScope::General, text));
+    }
+
+    /// A sticky warning that needs acknowledgement but no separate log record.
+    pub fn status_warning(&mut self, text: impl Into<String>) {
+        self.show_status(StatusNotice::warning(StatusScope::General, text));
+    }
+
+    /// A sticky error that needs acknowledgement but no separate log record — for
+    /// a failure whose full detail the immediate message already carries.
+    pub fn status_error(&mut self, text: impl Into<String>) {
+        self.show_status(StatusNotice::error(StatusScope::General, text));
+    }
+
+    /// Record a subsystem failure the user may revisit: one canonical System error
+    /// entry plus one linked sticky error status, from a single message. A Settings
+    /// failure links to the Settings panel; the rest link to their System log.
+    pub fn report_system_error(&mut self, subsystem: SystemSubsystem, text: impl Into<String>) {
+        let text = text.into();
+        let target = match subsystem {
+            SystemSubsystem::Settings => DetailTarget::Settings,
+            _ => DetailTarget::Output(OutputTarget::Source(OutputSource::System)),
+        };
+        self.apply_log_and_status(
+            NewLogEntry::new(
+                LogScope::System { subsystem },
+                LogLevel::Error,
+                text.clone(),
+            ),
+            StatusNotice::error(StatusScope::Subsystem(subsystem), text).with_target(target),
+        );
+    }
+
+    /// Record a remote control-plane failure the user may revisit: one canonical
+    /// Remote log plus a host-scoped sticky error status, so a later successful
+    /// observation of the same host recovers it.
+    pub fn report_remote_error(&mut self, host_id: impl Into<String>, text: impl Into<String>) {
+        let host_id = host_id.into();
+        let text = text.into();
+        self.apply_log_and_status(
+            NewLogEntry::new(
+                LogScope::RemoteControl {
+                    host_id: Some(host_id.clone()),
+                },
+                LogLevel::Error,
+                text.clone(),
+            ),
+            StatusNotice::error(StatusScope::Remote(host_id), text).with_target(
+                DetailTarget::Output(OutputTarget::Source(OutputSource::Remote)),
+            ),
+        );
+    }
+
+    pub fn report_unscoped_remote_error(&mut self, text: impl Into<String>) {
+        let text = text.into();
+        self.apply_log_and_status(
+            NewLogEntry::new(
+                LogScope::RemoteControl { host_id: None },
+                LogLevel::Error,
+                text.clone(),
+            ),
+            StatusNotice::error(StatusScope::General, text).with_target(DetailTarget::Output(
+                OutputTarget::Source(OutputSource::Remote),
+            )),
+        );
+    }
+
+    /// A transient neutral notice about one job (e.g. a cancel acknowledgement),
+    /// scoped so a later same-job notice supersedes it.
+    pub fn job_notice(&mut self, job_id: JobId, text: impl Into<String>) {
+        self.show_status(StatusNotice::neutral(StatusScope::Job(job_id), text));
+    }
+
+    /// Record a job's successful completion: one lifecycle Job log plus a linked
+    /// success status that opens the job in Activity.
+    pub fn job_succeeded(&mut self, job_id: JobId, text: impl Into<String>) {
+        let text = text.into();
+        self.apply_log_and_status(
+            NewLogEntry::new(LogScope::Job { job_id }, LogLevel::Info, text.clone()),
+            StatusNotice::success(StatusScope::Job(job_id), text)
+                .with_target(DetailTarget::ActivityJob(job_id)),
+        );
+    }
+
+    /// Record a job's failure: one lifecycle Job error log plus a linked sticky
+    /// error status that opens the job in Activity.
+    pub fn job_failed(&mut self, job_id: JobId, text: impl Into<String>) {
+        let text = text.into();
+        self.apply_log_and_status(
+            NewLogEntry::new(LogScope::Job { job_id }, LogLevel::Error, text.clone()),
+            StatusNotice::error(StatusScope::Job(job_id), text)
+                .with_target(DetailTarget::ActivityJob(job_id)),
+        );
+    }
+
+    fn apply_log_and_status(&mut self, log: NewLogEntry, status: StatusNotice) {
+        self.append_log(log);
+        self.show_status(status);
+    }
+}

--- a/src/frontend/state/app/ui_state.rs
+++ b/src/frontend/state/app/ui_state.rs
@@ -5,8 +5,8 @@ use eframe::egui;
 use crate::frontend::actions::ResidueSelectionMode;
 use crate::frontend::state::{
     DisorderedSystemPrompt, DockingPrompt, EngineDraft, EngineProbeState, EntryListState,
-    LayoutState, MdRunPrompt, MdSystemPrompt, OptimizationPrompt, PendingPtm, ProteinPrepPrompt,
-    QmPrompt, RemoteHostDraft, RemoteHostStatus, SupercellPrompt,
+    LayoutState, MdRunPrompt, MdSystemPrompt, OptimizationPrompt, OutputTarget, PendingPtm,
+    ProteinPrepPrompt, QmPrompt, RemoteHostDraft, RemoteHostStatus, SessionSeq, SupercellPrompt,
 };
 use crate::frontend::{
     AtomSelection, BuildingBlockEditor, CommandConsoleState, NanosheetBuilderPanel,
@@ -88,6 +88,33 @@ pub struct SequenceDragState {
     pub mode: ResidueSelectionMode,
 }
 
+/// The Output tab's session state: the active source/job target, search, wrap,
+/// auto-follow, and the per-target clear-view and unread cursors. The log entries
+/// themselves are owned by the
+/// [`SessionLogStore`](crate::frontend::state::SessionLogStore).
+#[derive(Debug, Clone)]
+pub struct OutputViewState {
+    pub target: OutputTarget,
+    pub search: String,
+    pub wrap_lines: bool,
+    pub auto_follow: bool,
+    pub cleared_before_by_target: std::collections::HashMap<OutputTarget, SessionSeq>,
+    pub last_seen_by_target: std::collections::HashMap<OutputTarget, SessionSeq>,
+}
+
+impl Default for OutputViewState {
+    fn default() -> Self {
+        Self {
+            target: OutputTarget::All,
+            search: String::new(),
+            wrap_lines: true,
+            auto_follow: true,
+            cleared_before_by_target: std::collections::HashMap::new(),
+            last_seen_by_target: std::collections::HashMap::new(),
+        }
+    }
+}
+
 pub struct UiState {
     pub layout: LayoutState,
     pub entry_list: EntryListState,
@@ -119,6 +146,8 @@ pub struct UiState {
     pub entry_viewports: BTreeMap<u64, ViewportVisualState>,
     pub scripted_viewport_size: [u32; 2],
     pub console: CommandConsoleState,
+    pub output: OutputViewState,
+    pub activity_job_target: Option<crate::job::JobId>,
     pub editor: Option<StructureEditor>,
     pub sketcher: Option<crate::frontend::sketcher::SketcherState>,
     pub reticular_builder: Option<ReticularBuilderPanel>,
@@ -263,6 +292,8 @@ impl Default for UiState {
             entry_viewports: BTreeMap::new(),
             scripted_viewport_size: [1180, 760],
             console: CommandConsoleState::default(),
+            output: OutputViewState::default(),
+            activity_job_target: None,
             editor: None,
             sketcher: None,
             reticular_builder: None,

--- a/src/frontend/state/session_log.rs
+++ b/src/frontend/state/session_log.rs
@@ -1,0 +1,332 @@
+//! Typed, byte-bounded session log: the single owner of the application's
+//! free-text feedback (command transcript, system/agent/remote-control detail,
+//! and per-job engine output), read by Console and Output.
+//!
+//! Every entry carries an exact [`LogScope`], a [`LogLevel`], and a stable
+//! chronological sequence. Job output is keyed by the task-monitor [`JobId`], so
+//! two concurrent jobs of the same kind never share a log scope. Retention is
+//! bounded by bytes with per-scope fairness (see [`retention`]), and adjacent
+//! repeats fold into a single row with a count.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::num::NonZeroU32;
+
+use crate::job::JobId;
+
+mod query;
+mod retention;
+
+#[cfg(test)]
+mod tests;
+
+pub use query::{LogFilter, LogQuery, OutputSource, OutputTarget, short_job};
+
+/// Monotonic, session-local order of a log *event*. Every append allocates one,
+/// including a folded repeat (its sequence advances `last_seq`), so ordering is
+/// total and gap-tolerant. Not persisted.
+pub type SessionSeq = u64;
+
+/// Session-local identity of one `.sls` command invocation. Prompt, result, and
+/// error entries of the same invocation share it, so concurrent or nested command
+/// execution never cross-associates its output.
+pub type CommandId = u64;
+
+/// Severity of a log entry. Independent of scope, source, and placement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LogLevel {
+    Trace,
+    Info,
+    Warn,
+    Error,
+}
+
+/// Who issued a console command. The command transcript is the same question —
+/// "what command ran?" — regardless of actor, so assistant-issued `.sls` commands
+/// are Command-scoped with [`CommandActor::Agent`], not routed to Output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CommandActor {
+    User,
+    Agent,
+}
+
+/// The stable, closed vocabulary of application subsystems that own System-scoped
+/// detail. Kept typed so call sites can never drift subsystem names as ad-hoc
+/// strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SystemSubsystem {
+    Application,
+    Project,
+    File,
+    Settings,
+    Update,
+    Storage,
+}
+
+impl SystemSubsystem {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Application => "Application",
+            Self::Project => "Project",
+            Self::File => "File",
+            Self::Settings => "Settings",
+            Self::Update => "Update",
+            Self::Storage => "Storage",
+        }
+    }
+}
+
+/// The exact owner of a log entry. Job kind, placement, and engine label are not
+/// encoded here: they are display/filter facets resolved from the live-job
+/// projection by [`JobId`], not a second identity.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum LogScope {
+    /// A `.sls` command transcript line (prompt, result, or error).
+    Command {
+        command_id: CommandId,
+        actor: CommandActor,
+    },
+    /// Application/project/settings/file/persistence/update/rendering detail.
+    System { subsystem: SystemSubsystem },
+    /// Assistant infrastructure/tool audit detail — not assistant narration and
+    /// not assistant-issued `.sls` commands.
+    Agent { turn_id: Option<u64> },
+    /// SSH/Slurm/transfer/probe and other remote control-plane detail. The id is
+    /// the stable host configuration id, never a display label.
+    RemoteControl { host_id: Option<String> },
+    /// Engine/workflow text scoped to one exact execution, local or remote.
+    Job { job_id: JobId },
+}
+
+impl LogScope {
+    fn is_command(&self) -> bool {
+        matches!(self, Self::Command { .. })
+    }
+
+    /// Whether this scope counts against the reserved control-plane budget
+    /// (System, Agent, and Remote-control detail share one reserve).
+    fn is_control(&self) -> bool {
+        matches!(
+            self,
+            Self::System { .. } | Self::Agent { .. } | Self::RemoteControl { .. }
+        )
+    }
+}
+
+/// One retained log row. Adjacent identical events fold into it: `repeat` counts
+/// the occurrences and `last_seq` tracks the latest, while `first_seq` and list
+/// position are immutable so chronology never reorders. Wall-clock timestamps are
+/// deliberately absent.
+#[derive(Debug, Clone)]
+pub struct SessionLogEntry {
+    pub first_seq: SessionSeq,
+    pub last_seq: SessionSeq,
+    pub scope: LogScope,
+    pub level: LogLevel,
+    pub text: String,
+    pub repeat: NonZeroU32,
+}
+
+impl SessionLogEntry {
+    pub fn repeat_count(&self) -> u32 {
+        self.repeat.get()
+    }
+}
+
+/// A caller's request to append one log event. The store assigns sequence and
+/// timestamps and decides folding, truncation, and retention.
+#[derive(Debug, Clone)]
+pub struct NewLogEntry {
+    pub scope: LogScope,
+    pub level: LogLevel,
+    pub text: String,
+}
+
+impl NewLogEntry {
+    pub fn new(scope: LogScope, level: LogLevel, text: impl Into<String>) -> Self {
+        Self {
+            scope,
+            level,
+            text: text.into(),
+        }
+    }
+}
+
+/// The byte-bounded, scope-fair, chronology-preserving session log store. Only
+/// dispatcher/state-application code appends; UI code receives immutable queries.
+///
+/// Entries are keyed by their immutable `first_seq`, so iteration in key order is
+/// chronological and survives front eviction. Per-category ordered key sets and a
+/// per-scope index make retention and the Activity job-tail lookup logarithmic,
+/// never a full-store scan.
+#[derive(Default)]
+pub struct SessionLogStore {
+    entries: BTreeMap<SessionSeq, SessionLogEntry>,
+    next_seq: SessionSeq,
+    /// The entry that received the most recent sequence, for global-adjacency
+    /// folding. `None` after its entry is evicted (only possible when the store
+    /// is emptied, since eviction removes the oldest).
+    last_touched: Option<SessionSeq>,
+    retained_bytes: usize,
+    command_bytes: usize,
+    control_bytes: usize,
+    job_bytes: HashMap<JobId, usize>,
+    /// `first_seq` keys grouped by exact scope (for the job tail and per-job cap).
+    scope_index: HashMap<LogScope, BTreeSet<SessionSeq>>,
+    command_seqs: BTreeSet<SessionSeq>,
+    control_seqs: BTreeSet<SessionSeq>,
+    job_seqs: BTreeSet<SessionSeq>,
+    /// The live eviction-warning row per scope, so repeated eviction updates one
+    /// marker instead of flooding the scope with duplicates.
+    eviction_markers: HashMap<LogScope, SessionSeq>,
+}
+
+impl SessionLogStore {
+    /// Append one event: fold it into the previous globally-adjacent entry when
+    /// scope, level, and normalized text all match; otherwise truncate to the
+    /// single-entry limit, insert a new row, and enforce retention.
+    pub fn append(&mut self, entry: NewLogEntry) {
+        let NewLogEntry { scope, level, text } = entry;
+        let text = normalize_newlines(text);
+        let seq = self.alloc_seq();
+
+        if let Some(prev_key) = self.last_touched
+            && let Some(prev) = self.entries.get_mut(&prev_key)
+            && prev.scope == scope
+            && prev.level == level
+            && prev.text == text
+        {
+            prev.repeat = prev.repeat.saturating_add(1);
+            prev.last_seq = seq;
+            return;
+        }
+
+        let (text, _omitted) = truncate_entry_text(text);
+        let stored = SessionLogEntry {
+            first_seq: seq,
+            last_seq: seq,
+            scope,
+            level,
+            text,
+            repeat: NonZeroU32::MIN,
+        };
+        self.insert_entry(stored, true);
+        self.enforce_retention();
+    }
+
+    /// The last six (by default `limit`) canonical entries scoped to one exact
+    /// job, oldest-first — the Activity card's log tail. Indexed, never a scan.
+    pub fn tail_for_job(
+        &self,
+        job_id: JobId,
+        limit: usize,
+    ) -> impl Iterator<Item = &SessionLogEntry> {
+        let scope = LogScope::Job { job_id };
+        let keys = self.scope_index.get(&scope);
+        let start = keys.map(|set| set.len().saturating_sub(limit)).unwrap_or(0);
+        keys.into_iter()
+            .flat_map(|set| set.iter())
+            .skip(start)
+            .filter_map(move |seq| self.entries.get(seq))
+    }
+
+    /// The sequence the next event will take — the value a clear-view cursor is
+    /// set to so every current entry falls before it, and the high-water mark a
+    /// view compares against its last-seen cursor for unread state.
+    #[cfg(test)]
+    pub fn next_seq(&self) -> SessionSeq {
+        self.next_seq
+    }
+
+    /// Prevent the next event from folding into a row that a view has just
+    /// hidden behind a clear cursor.
+    pub fn break_folding(&mut self) -> SessionSeq {
+        self.last_touched = None;
+        self.next_seq
+    }
+
+    #[cfg(test)]
+    pub fn retained_bytes(&self) -> usize {
+        self.retained_bytes
+    }
+
+    fn alloc_seq(&mut self) -> SessionSeq {
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        seq
+    }
+
+    /// Insert a fully-formed entry, updating every index and byte counter.
+    /// `track_adjacency` is false for synthetic markers so they never become the
+    /// fold target of the next real event.
+    fn insert_entry(&mut self, entry: SessionLogEntry, track_adjacency: bool) {
+        let key = entry.first_seq;
+        let bytes = entry.text.len();
+        self.retained_bytes += bytes;
+        match &entry.scope {
+            scope if scope.is_command() => {
+                self.command_bytes += bytes;
+                self.command_seqs.insert(key);
+            }
+            scope if scope.is_control() => {
+                self.control_bytes += bytes;
+                self.control_seqs.insert(key);
+            }
+            LogScope::Job { job_id } => {
+                *self.job_bytes.entry(*job_id).or_default() += bytes;
+                self.job_seqs.insert(key);
+            }
+            _ => {}
+        }
+        self.scope_index
+            .entry(entry.scope.clone())
+            .or_default()
+            .insert(key);
+        self.entries.insert(key, entry);
+        if track_adjacency {
+            self.last_touched = Some(key);
+        }
+    }
+}
+
+/// Normalize only CRLF to LF so folding treats otherwise-identical lines from a
+/// Windows-native engine and a WSL engine as the same event. No other bytes move.
+fn normalize_newlines(text: String) -> String {
+    if text.contains('\r') {
+        text.replace("\r\n", "\n").replace('\r', "\n")
+    } else {
+        text
+    }
+}
+
+/// Longest char boundary at or before `index`, so oversized text truncates
+/// without splitting a UTF-8 code point.
+fn floor_char_boundary(text: &str, mut index: usize) -> usize {
+    if index >= text.len() {
+        return text.len();
+    }
+    while index > 0 && !text.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+/// Largest text a single entry may retain before it is truncated once, on a valid
+/// UTF-8 boundary, with a marker naming the omitted byte count.
+const ENTRY_MAX_BYTES: usize = 64 * 1024;
+
+/// Truncate an oversized entry to the single-entry limit, returning the kept text
+/// (ending in a visible marker) and the number of omitted bytes. Text within the
+/// limit is returned unchanged with zero omitted.
+fn truncate_entry_text(text: String) -> (String, usize) {
+    if text.len() <= ENTRY_MAX_BYTES {
+        return (text, 0);
+    }
+    // Reserve headroom for the marker so the retained string stays within budget.
+    let keep = floor_char_boundary(&text, ENTRY_MAX_BYTES.saturating_sub(64));
+    let omitted = text.len() - keep;
+    let mut kept = text[..keep].to_string();
+    kept.push_str(&format!(
+        "\n… [{omitted} bytes truncated to limit memory usage]"
+    ));
+    (kept, omitted)
+}

--- a/src/frontend/state/session_log/query.rs
+++ b/src/frontend/state/session_log/query.rs
@@ -1,0 +1,161 @@
+//! Read-side of the session log: the Output source/job facets and the immutable
+//! query UI code runs against the store. No query allocates or clones retained
+//! text; it yields references in chronological order.
+
+use crate::job::JobId;
+
+use super::{LogScope, SessionLogEntry, SessionLogStore, SessionSeq};
+
+/// The Output toolbar's non-command source facet. Placement is orthogonal: a
+/// remote job's stdout is a [`OutputSource::Jobs`] entry, not [`OutputSource::Remote`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OutputSource {
+    System,
+    Agent,
+    Remote,
+    Jobs,
+}
+
+impl OutputSource {
+    pub fn all() -> [Self; 4] {
+        [Self::System, Self::Agent, Self::Remote, Self::Jobs]
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::System => "System",
+            Self::Agent => "Agent",
+            Self::Remote => "Remote",
+            Self::Jobs => "Jobs",
+        }
+    }
+}
+
+/// What a "show Output" navigation points at. Job targets carry the exact
+/// [`JobId`], never only a kind, so a deep link resolves one execution.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum OutputTarget {
+    All,
+    Source(OutputSource),
+    Job(JobId),
+}
+
+/// A short, stable rendering of a job id for selectors and labels.
+pub fn short_job(job_id: JobId) -> String {
+    let text = job_id.to_string();
+    text.get(..8).unwrap_or(&text).to_string()
+}
+
+/// Which scopes a query admits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LogFilter {
+    /// The command transcript (Console).
+    Command,
+    /// Every non-command scope (Output's `All Output`).
+    OutputAll,
+    /// One Output source.
+    Source(OutputSource),
+    /// One exact job.
+    Job(JobId),
+}
+
+impl LogFilter {
+    pub fn from_output_target(target: &OutputTarget) -> Self {
+        match target {
+            OutputTarget::All => Self::OutputAll,
+            OutputTarget::Source(source) => Self::Source(*source),
+            OutputTarget::Job(job_id) => Self::Job(*job_id),
+        }
+    }
+
+    fn admits(&self, scope: &LogScope) -> bool {
+        match self {
+            Self::Command => matches!(scope, LogScope::Command { .. }),
+            Self::OutputAll => !matches!(scope, LogScope::Command { .. }),
+            Self::Source(OutputSource::System) => matches!(scope, LogScope::System { .. }),
+            Self::Source(OutputSource::Agent) => matches!(scope, LogScope::Agent { .. }),
+            Self::Source(OutputSource::Remote) => matches!(scope, LogScope::RemoteControl { .. }),
+            Self::Source(OutputSource::Jobs) => matches!(scope, LogScope::Job { .. }),
+            Self::Job(job_id) => matches!(scope, LogScope::Job { job_id: id } if id == job_id),
+        }
+    }
+}
+
+/// An immutable query: a scope filter, a clear-view cursor, and optional
+/// case-insensitive substring search. Built by view code and passed to
+/// [`SessionLogStore::query`].
+#[derive(Debug, Clone)]
+pub struct LogQuery {
+    filter: LogFilter,
+    /// Entries whose latest occurrence is before this sequence are hidden by the
+    /// active clear-view cursor. Zero shows everything.
+    min_seq: SessionSeq,
+    search_lower: Option<String>,
+}
+
+impl LogQuery {
+    pub fn new(filter: LogFilter) -> Self {
+        Self {
+            filter,
+            min_seq: 0,
+            search_lower: None,
+        }
+    }
+
+    pub fn cleared_before(mut self, cursor: SessionSeq) -> Self {
+        self.min_seq = cursor;
+        self
+    }
+
+    /// Set a case-insensitive substring search. A blank term clears it.
+    pub fn search(mut self, term: &str) -> Self {
+        let term = term.trim();
+        self.search_lower = (!term.is_empty()).then(|| term.to_lowercase());
+        self
+    }
+
+    fn matches(&self, entry: &SessionLogEntry) -> bool {
+        if entry.last_seq < self.min_seq {
+            return false;
+        }
+        if !self.filter.admits(&entry.scope) {
+            return false;
+        }
+        if let Some(term) = &self.search_lower {
+            return entry.text.to_lowercase().contains(term);
+        }
+        true
+    }
+}
+
+impl SessionLogStore {
+    /// Iterate the entries matching `query`, oldest-first. Yields references, so a
+    /// per-frame render never clones the retained strings.
+    pub fn query<'a>(&'a self, query: &'a LogQuery) -> impl Iterator<Item = &'a SessionLogEntry> {
+        self.entries
+            .values()
+            .filter(move |entry| query.matches(entry))
+    }
+
+    /// Whether any entry matches `query` — the Output empty-state decision.
+    pub fn any(&self, query: &LogQuery) -> bool {
+        self.entries.values().any(|entry| query.matches(entry))
+    }
+
+    /// The highest sequence among entries matching `query`, for a view's unread
+    /// cursor. `None` when the query is empty.
+    pub fn latest_matching_seq(&self, query: &LogQuery) -> Option<SessionSeq> {
+        self.entries
+            .values()
+            .filter(|entry| query.matches(entry))
+            .map(|entry| entry.last_seq)
+            .max()
+    }
+
+    /// The exact jobs that currently own at least one retained entry — the base
+    /// of the Output job selector, unioned by the caller with the live-job
+    /// projection so a job whose oldest text was evicted still appears.
+    pub fn logged_jobs(&self) -> impl Iterator<Item = JobId> + '_ {
+        self.job_bytes.keys().copied()
+    }
+}

--- a/src/frontend/state/session_log/retention.rs
+++ b/src/frontend/state/session_log/retention.rs
@@ -1,0 +1,195 @@
+//! Byte-bounded, scope-fair retention for [`SessionLogStore`]. A noisy job can
+//! never evict the command transcript or the control-plane diagnostics below
+//! their reserves, per-job output is capped, and every eviction leaves one
+//! visible marker in the scope it thinned.
+
+use std::num::NonZeroU32;
+
+use super::{LogLevel, LogScope, SessionLogEntry, SessionLogStore, SessionSeq};
+
+/// Total retained text across every scope.
+pub(super) const TOTAL_MAX_BYTES: usize = 8 * 1024 * 1024;
+/// Retained text ceiling for one exact job scope.
+pub(super) const JOB_SCOPE_MAX_BYTES: usize = 1024 * 1024;
+/// Command-transcript text a job flood can never evict.
+pub(super) const COMMAND_RESERVE_BYTES: usize = 256 * 1024;
+/// System/Agent/Remote-control text a job flood can never evict.
+pub(super) const CONTROL_RESERVE_BYTES: usize = 256 * 1024;
+
+const EVICTION_MESSAGE: &str = "Earlier output was discarded to limit memory usage.";
+
+impl SessionLogStore {
+    /// Bring every budget back within limits after an append: cap per-job scopes
+    /// first, then evict global-oldest eligible entries until the total fits.
+    /// Each thinned scope gets one folded eviction marker.
+    pub(super) fn enforce_retention(&mut self) {
+        let mut thinned: Vec<LogScope> = Vec::new();
+        self.evict_over_cap_jobs(&mut thinned);
+        while self.retained_bytes > TOTAL_MAX_BYTES {
+            match self.evict_one_global() {
+                Some(scope) => push_unique(&mut thinned, scope),
+                None => break,
+            }
+        }
+        for scope in thinned {
+            self.note_eviction(scope);
+        }
+        self.trim_marker_overflow();
+    }
+
+    /// Evict the oldest entries of any job scope over its per-job cap.
+    fn evict_over_cap_jobs(&mut self, thinned: &mut Vec<LogScope>) {
+        let over_cap: Vec<crate::job::JobId> = self
+            .job_bytes
+            .iter()
+            .filter(|&(_, &bytes)| bytes > JOB_SCOPE_MAX_BYTES)
+            .map(|(job_id, _)| *job_id)
+            .collect();
+        for job_id in over_cap {
+            let scope = LogScope::Job { job_id };
+            while self.job_bytes.get(&job_id).copied().unwrap_or(0) > JOB_SCOPE_MAX_BYTES {
+                let Some(oldest) = self
+                    .scope_index
+                    .get(&scope)
+                    .and_then(|set| set.iter().next().copied())
+                else {
+                    break;
+                };
+                if self.remove_entry(oldest).is_some() {
+                    push_unique(thinned, scope.clone());
+                }
+            }
+        }
+    }
+
+    /// Evict the globally-oldest entry eligible under the reserves: job entries are
+    /// always eligible; command and control entries only once their category
+    /// exceeds its reserve. Returns the scope thinned, or `None` when nothing is
+    /// eligible.
+    fn evict_one_global(&mut self) -> Option<LogScope> {
+        let mut victim: Option<SessionSeq> = None;
+        let mut consider = |seq: Option<SessionSeq>| {
+            if let Some(seq) = seq {
+                victim = Some(match victim {
+                    Some(current) => current.min(seq),
+                    None => seq,
+                });
+            }
+        };
+        consider(self.job_seqs.iter().next().copied());
+        if self.command_bytes > COMMAND_RESERVE_BYTES {
+            consider(self.command_seqs.iter().next().copied());
+        }
+        if self.control_bytes > CONTROL_RESERVE_BYTES {
+            consider(self.control_seqs.iter().next().copied());
+        }
+        let victim = victim?;
+        self.remove_entry(victim).map(|entry| entry.scope)
+    }
+
+    /// Remove one entry by key, updating every byte counter and index. Returns the
+    /// removed entry, or `None` if it was already gone. A removed eviction marker
+    /// is forgotten so its scope can grow a fresh one later.
+    fn remove_entry(&mut self, seq: SessionSeq) -> Option<SessionLogEntry> {
+        let entry = self.entries.remove(&seq)?;
+        let bytes = entry.text.len();
+        self.retained_bytes -= bytes;
+        match &entry.scope {
+            scope if scope.is_command() => {
+                self.command_bytes -= bytes;
+                self.command_seqs.remove(&seq);
+            }
+            scope if scope.is_control() => {
+                self.control_bytes -= bytes;
+                self.control_seqs.remove(&seq);
+            }
+            LogScope::Job { job_id } => {
+                if let Some(job_bytes) = self.job_bytes.get_mut(job_id) {
+                    *job_bytes -= bytes;
+                    if *job_bytes == 0 {
+                        self.job_bytes.remove(job_id);
+                    }
+                }
+                self.job_seqs.remove(&seq);
+            }
+            _ => {}
+        }
+        if let Some(set) = self.scope_index.get_mut(&entry.scope) {
+            set.remove(&seq);
+            if set.is_empty() {
+                self.scope_index.remove(&entry.scope);
+            }
+        }
+        if self.eviction_markers.get(&entry.scope) == Some(&seq) {
+            self.eviction_markers.remove(&entry.scope);
+        }
+        if self.last_touched == Some(seq) {
+            self.last_touched = None;
+        }
+        Some(entry)
+    }
+
+    /// Insert or fold the one eviction marker for a thinned scope. The marker is
+    /// itself bounded (a removed marker generates no new marker) so warnings can
+    /// never recurse.
+    fn note_eviction(&mut self, scope: LogScope) {
+        if let Some(&key) = self.eviction_markers.get(&scope)
+            && let Some(marker) = self.entries.get_mut(&key)
+        {
+            marker.repeat = marker.repeat.saturating_add(1);
+            marker.last_seq = self.next_seq;
+            self.next_seq += 1;
+            return;
+        }
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        let marker = SessionLogEntry {
+            first_seq: seq,
+            last_seq: seq,
+            scope: scope.clone(),
+            level: LogLevel::Warn,
+            text: EVICTION_MESSAGE.to_string(),
+            repeat: NonZeroU32::MIN,
+        };
+        // Markers never anchor folding of the next real event and are inserted
+        // without re-running retention, keeping the warning bounded.
+        self.insert_entry(marker, false);
+        self.eviction_markers.insert(scope, seq);
+    }
+
+    /// Markers are accounted like every other row, so inserting them may push a
+    /// scope or the store back over its hard ceiling. Trim that overflow without
+    /// producing markers for markers.
+    fn trim_marker_overflow(&mut self) {
+        let over_cap: Vec<_> = self
+            .job_bytes
+            .iter()
+            .filter(|&(_, &bytes)| bytes > JOB_SCOPE_MAX_BYTES)
+            .map(|(&job_id, _)| job_id)
+            .collect();
+        for job_id in over_cap {
+            let scope = LogScope::Job { job_id };
+            while self.job_bytes.get(&job_id).copied().unwrap_or(0) > JOB_SCOPE_MAX_BYTES {
+                let Some(oldest) = self
+                    .scope_index
+                    .get(&scope)
+                    .and_then(|set| set.iter().next().copied())
+                else {
+                    break;
+                };
+                self.remove_entry(oldest);
+            }
+        }
+        while self.retained_bytes > TOTAL_MAX_BYTES {
+            if self.evict_one_global().is_none() {
+                break;
+            }
+        }
+    }
+}
+
+fn push_unique(scopes: &mut Vec<LogScope>, scope: LogScope) {
+    if !scopes.contains(&scope) {
+        scopes.push(scope);
+    }
+}

--- a/src/frontend/state/session_log/tests.rs
+++ b/src/frontend/state/session_log/tests.rs
@@ -1,0 +1,274 @@
+use super::retention::{JOB_SCOPE_MAX_BYTES, TOTAL_MAX_BYTES};
+use super::*;
+use crate::job::JobId;
+
+fn command(id: CommandId, level: LogLevel, text: &str) -> NewLogEntry {
+    NewLogEntry::new(
+        LogScope::Command {
+            command_id: id,
+            actor: CommandActor::User,
+        },
+        level,
+        text,
+    )
+}
+
+fn system(text: &str) -> NewLogEntry {
+    NewLogEntry::new(
+        LogScope::System {
+            subsystem: SystemSubsystem::Storage,
+        },
+        LogLevel::Info,
+        text,
+    )
+}
+
+fn job(job_id: JobId, text: &str) -> NewLogEntry {
+    NewLogEntry::new(LogScope::Job { job_id }, LogLevel::Info, text)
+}
+
+#[test]
+fn sequence_is_monotonic_including_folds() {
+    let mut store = SessionLogStore::default();
+    store.append(system("a"));
+    store.append(system("a")); // fold
+    store.append(system("b"));
+    let seqs: Vec<_> = store
+        .query(&LogQuery::new(LogFilter::OutputAll))
+        .map(|e| (e.first_seq, e.last_seq))
+        .collect();
+    // Two rows: the folded "a" (first_seq 0, last_seq 1) and "b" (first_seq 2).
+    assert_eq!(seqs, vec![(0, 1), (2, 2)]);
+    assert_eq!(store.next_seq(), 3);
+}
+
+#[test]
+fn folding_requires_global_adjacency() {
+    let mut store = SessionLogStore::default();
+    let a = JobId::new();
+    let b = JobId::new();
+    store.append(job(a, "line"));
+    store.append(job(b, "line")); // different scope between
+    store.append(job(a, "line")); // not adjacent to the first -> new row
+    let rows: Vec<_> = store
+        .tail_for_job(a, 10)
+        .map(|e| e.repeat_count())
+        .collect();
+    assert_eq!(rows, vec![1, 1]);
+}
+
+#[test]
+fn folding_requires_matching_level_and_text() {
+    let mut store = SessionLogStore::default();
+    store.append(command(1, LogLevel::Info, "x"));
+    store.append(command(1, LogLevel::Error, "x")); // level differs
+    store.append(command(1, LogLevel::Error, "x")); // folds with previous
+    store.append(command(1, LogLevel::Error, "y")); // text differs
+    let rows: Vec<_> = store
+        .query(&LogQuery::new(LogFilter::Command))
+        .map(|e| (e.level, e.repeat_count()))
+        .collect();
+    assert_eq!(
+        rows,
+        vec![
+            (LogLevel::Info, 1),
+            (LogLevel::Error, 2),
+            (LogLevel::Error, 1),
+        ]
+    );
+}
+
+#[test]
+fn folding_preserves_first_seq_and_position() {
+    let mut store = SessionLogStore::default();
+    store.append(system("keep"));
+    for _ in 0..5 {
+        store.append(system("keep"));
+    }
+    let query = LogQuery::new(LogFilter::OutputAll);
+    let entry = store.query(&query).next().unwrap();
+    assert_eq!(entry.first_seq, 0);
+    assert_eq!(entry.repeat_count(), 6);
+    assert_eq!(entry.last_seq, 5);
+}
+
+#[test]
+fn crlf_normalizes_without_touching_other_text() {
+    let mut store = SessionLogStore::default();
+    store.append(system("a\r\nb"));
+    store.append(system("a\nb")); // identical after normalization -> fold
+    let query = LogQuery::new(LogFilter::OutputAll);
+    let entry = store.query(&query).next().unwrap();
+    assert_eq!(entry.text, "a\nb");
+    assert_eq!(entry.repeat_count(), 2);
+}
+
+#[test]
+fn oversized_entry_truncates_on_char_boundary_with_marker() {
+    let mut store = SessionLogStore::default();
+    // Multi-byte chars straddling the limit must not be split.
+    let text = "é".repeat(200_000);
+    store.append(system(&text));
+    let query = LogQuery::new(LogFilter::OutputAll);
+    let entry = store.query(&query).next().unwrap();
+    assert!(entry.text.is_char_boundary(entry.text.len()));
+    assert!(entry.text.len() <= 64 * 1024);
+    assert!(entry.text.contains("bytes truncated"));
+    // A truncated entry is a valid str (would panic on an invalid boundary).
+    assert!(entry.text.chars().count() > 0);
+}
+
+#[test]
+fn per_job_cap_bounds_one_scope() {
+    let mut store = SessionLogStore::default();
+    let noisy = JobId::new();
+    for i in 0..400 {
+        // Distinct text so lines never fold: 400 * ~4 KiB into a 1 MiB per-job cap.
+        store.append(job(noisy, &format!("line {i} {}", "x".repeat(4096))));
+    }
+    let job_bytes: usize = store
+        .tail_for_job(noisy, usize::MAX)
+        .map(|e| e.text.len())
+        .sum();
+    assert!(job_bytes <= JOB_SCOPE_MAX_BYTES);
+    // The thinned job scope carries exactly one eviction marker.
+    let markers = store
+        .tail_for_job(noisy, usize::MAX)
+        .filter(|e| e.text.contains("discarded"))
+        .count();
+    assert_eq!(markers, 1);
+}
+
+#[test]
+fn noisy_job_cannot_evict_the_command_reserve() {
+    let mut store = SessionLogStore::default();
+    // Seed command + system diagnostics well within their reserves.
+    for i in 0..20 {
+        store.append(command(i, LogLevel::Error, &format!("command error {i}")));
+        store.append(system(&format!("system detail {i}")));
+    }
+    let command_before = store.query(&LogQuery::new(LogFilter::Command)).count();
+    // Flood distinct jobs past the total budget.
+    let line = "y".repeat(8192);
+    for _ in 0..2400 {
+        let id = JobId::new();
+        store.append(job(id, &line));
+    }
+    assert!(store.retained_bytes() <= TOTAL_MAX_BYTES);
+    let command_after = store.query(&LogQuery::new(LogFilter::Command)).count();
+    assert_eq!(
+        command_before, command_after,
+        "command diagnostics within reserve must survive a job flood"
+    );
+}
+
+#[test]
+fn eviction_marker_does_not_recurse() {
+    let mut store = SessionLogStore::default();
+    let noisy = JobId::new();
+    for i in 0..600 {
+        store.append(job(noisy, &format!("{i} {}", "z".repeat(8192))));
+    }
+    // Repeated eviction from one scope keeps exactly one marker (folded), never a
+    // growing pile of warnings.
+    let markers = store
+        .tail_for_job(noisy, usize::MAX)
+        .filter(|e| e.text.contains("discarded"))
+        .count();
+    assert_eq!(markers, 1);
+}
+
+#[test]
+fn output_query_excludes_command() {
+    let mut store = SessionLogStore::default();
+    store.append(command(1, LogLevel::Info, "ran"));
+    store.append(system("system"));
+    let out: Vec<_> = store
+        .query(&LogQuery::new(LogFilter::OutputAll))
+        .map(|e| e.text.clone())
+        .collect();
+    assert_eq!(out, vec!["system".to_string()]);
+    let cmd: Vec<_> = store
+        .query(&LogQuery::new(LogFilter::Command))
+        .map(|e| e.text.clone())
+        .collect();
+    assert_eq!(cmd, vec!["ran".to_string()]);
+}
+
+#[test]
+fn exact_job_query_isolates_same_kind_jobs() {
+    let mut store = SessionLogStore::default();
+    let a = JobId::new();
+    let b = JobId::new();
+    store.append(job(a, "from a"));
+    store.append(job(b, "from b"));
+    store.append(job(a, "from a again"));
+    let only_a: Vec<_> = store
+        .query(&LogQuery::new(LogFilter::Job(a)))
+        .map(|e| e.text.clone())
+        .collect();
+    assert_eq!(
+        only_a,
+        vec!["from a".to_string(), "from a again".to_string()]
+    );
+    let tail_b: Vec<_> = store.tail_for_job(b, 10).map(|e| e.text.clone()).collect();
+    assert_eq!(tail_b, vec!["from b".to_string()]);
+}
+
+#[test]
+fn clear_view_cursor_hides_but_keeps_entries() {
+    let mut store = SessionLogStore::default();
+    store.append(system("old"));
+    let cursor = store.next_seq();
+    store.append(system("new"));
+    let visible: Vec<_> = store
+        .query(&LogQuery::new(LogFilter::OutputAll).cleared_before(cursor))
+        .map(|e| e.text.clone())
+        .collect();
+    assert_eq!(visible, vec!["new".to_string()]);
+    // Still present without the cursor: clear-view never deletes.
+    assert_eq!(store.query(&LogQuery::new(LogFilter::OutputAll)).count(), 2);
+}
+
+#[test]
+fn clear_view_prevents_a_repeat_from_resurrecting_the_hidden_row() {
+    let mut store = SessionLogStore::default();
+    store.append(system("same"));
+    let cursor = store.break_folding();
+    store.append(system("same"));
+    let query = LogQuery::new(LogFilter::OutputAll).cleared_before(cursor);
+    let visible: Vec<_> = store.query(&query).collect();
+    assert_eq!(visible.len(), 1);
+    assert_eq!(visible[0].first_seq, cursor);
+    assert_eq!(visible[0].repeat_count(), 1);
+}
+
+#[test]
+fn search_is_case_insensitive_substring() {
+    let mut store = SessionLogStore::default();
+    store.append(system("Deploy FAILED on host"));
+    store.append(system("all clear"));
+    let hits: Vec<_> = store
+        .query(&LogQuery::new(LogFilter::OutputAll).search("failed"))
+        .map(|e| e.text.clone())
+        .collect();
+    assert_eq!(hits, vec!["Deploy FAILED on host".to_string()]);
+}
+
+#[test]
+fn tail_for_job_returns_last_n_oldest_first() {
+    let mut store = SessionLogStore::default();
+    let id = JobId::new();
+    for i in 0..10 {
+        store.append(job(id, &format!("line {i}")));
+    }
+    let tail: Vec<_> = store.tail_for_job(id, 3).map(|e| e.text.clone()).collect();
+    assert_eq!(
+        tail,
+        vec![
+            "line 7".to_string(),
+            "line 8".to_string(),
+            "line 9".to_string()
+        ]
+    );
+}

--- a/src/frontend/state/status.rs
+++ b/src/frontend/state/status.rs
@@ -1,0 +1,329 @@
+//! The status-bar feedback slot: one transient [`StatusNotice`] with tested
+//! expiry, severity priority, sticky-error, same-scope recovery, and typed-link
+//! behavior. Status is presentation state — it is never the sole record of a
+//! failure, which always keeps a canonical session-log or structured-job owner.
+
+use std::time::{Duration, Instant};
+
+use crate::job::JobId;
+
+use super::{OutputTarget, SystemSubsystem};
+
+/// How long a neutral confirmation lingers before any newer notice may replace it.
+const NEUTRAL_LIFETIME: Duration = Duration::from_secs(4);
+/// How long a success confirmation lingers before it expires on its own.
+const SUCCESS_LIFETIME: Duration = Duration::from_secs(5);
+
+/// Visual and behavioral weight of a status notice. The renderer maps this to an
+/// icon and color; state never depends on a UI tone type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusSeverity {
+    Neutral,
+    Success,
+    Warning,
+    Error,
+}
+
+impl StatusSeverity {
+    /// Replacement priority: a newer notice replaces the current one when its
+    /// priority is at least as high (or it shares the current scope).
+    fn priority(self) -> u8 {
+        match self {
+            Self::Neutral => 0,
+            Self::Success => 1,
+            Self::Warning => 2,
+            Self::Error => 3,
+        }
+    }
+
+    pub fn is_sticky(self) -> bool {
+        matches!(self, Self::Warning | Self::Error)
+    }
+}
+
+/// Whether a notice expires on a timer or stays until acknowledged / recovered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusLifetime {
+    Ephemeral(Duration),
+    Sticky,
+}
+
+/// Identifies the producer well enough for same-scope replacement and recovery.
+/// A later Storage success recovers a Storage error; a job's completion notice
+/// replaces its own running notice; unrelated confirmations share `General`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StatusScope {
+    General,
+    Subsystem(SystemSubsystem),
+    Job(JobId),
+    Remote(String),
+}
+
+/// Where a status link navigates. Typed so a link never addresses a job by kind
+/// or a panel by string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DetailTarget {
+    Output(OutputTarget),
+    ActivityJob(JobId),
+    Settings,
+}
+
+/// One status-bar notice. `created_at` anchors expiry; pause bookkeeping lives on
+/// [`StatusState`], not here.
+#[derive(Debug, Clone)]
+pub struct StatusNotice {
+    pub scope: StatusScope,
+    pub severity: StatusSeverity,
+    pub text: String,
+    pub target: Option<DetailTarget>,
+    pub lifetime: StatusLifetime,
+    pub created_at: Instant,
+}
+
+impl StatusNotice {
+    fn new(scope: StatusScope, severity: StatusSeverity, text: impl Into<String>) -> Self {
+        let lifetime = match severity {
+            StatusSeverity::Neutral => StatusLifetime::Ephemeral(NEUTRAL_LIFETIME),
+            StatusSeverity::Success => StatusLifetime::Ephemeral(SUCCESS_LIFETIME),
+            StatusSeverity::Warning | StatusSeverity::Error => StatusLifetime::Sticky,
+        };
+        Self {
+            scope,
+            severity,
+            text: text.into(),
+            target: None,
+            lifetime,
+            created_at: Instant::now(),
+        }
+    }
+
+    pub fn neutral(scope: StatusScope, text: impl Into<String>) -> Self {
+        Self::new(scope, StatusSeverity::Neutral, text)
+    }
+
+    pub fn success(scope: StatusScope, text: impl Into<String>) -> Self {
+        Self::new(scope, StatusSeverity::Success, text)
+    }
+
+    pub fn warning(scope: StatusScope, text: impl Into<String>) -> Self {
+        Self::new(scope, StatusSeverity::Warning, text)
+    }
+
+    pub fn error(scope: StatusScope, text: impl Into<String>) -> Self {
+        Self::new(scope, StatusSeverity::Error, text)
+    }
+
+    pub fn with_target(mut self, target: DetailTarget) -> Self {
+        self.target = Some(target);
+        self
+    }
+}
+
+/// The single-slot status state: the visible notice plus the pause bookkeeping
+/// that freezes expiry while the user hovers or keyboard-focuses a linked notice.
+#[derive(Debug, Default)]
+pub struct StatusState {
+    current: Option<StatusNotice>,
+    paused: bool,
+    /// Time already spent paused for the current notice, excluded from expiry.
+    accumulated_pause: Duration,
+    paused_since: Option<Instant>,
+}
+
+impl StatusState {
+    pub fn current(&self) -> Option<&StatusNotice> {
+        self.current.as_ref()
+    }
+
+    /// Post a notice, honoring severity priority and same-scope recovery: a lower
+    /// priority notice with a different scope is dropped rather than queued, so
+    /// there is no unbounded status history and a failure is never masked by a
+    /// routine confirmation.
+    pub fn post(&mut self, notice: StatusNotice) {
+        if let Some(current) = &self.current
+            && !should_replace(current, &notice)
+        {
+            return;
+        }
+        self.current = Some(notice);
+        self.paused = false;
+        self.accumulated_pause = Duration::ZERO;
+        self.paused_since = None;
+    }
+
+    /// Dismiss the current notice (user acknowledgement). Its canonical log/job
+    /// record is untouched — that lives elsewhere.
+    pub fn acknowledge(&mut self) {
+        self.current = None;
+        self.paused = false;
+        self.accumulated_pause = Duration::ZERO;
+        self.paused_since = None;
+    }
+
+    /// Freeze or resume expiry (hover / keyboard focus on a linked notice).
+    pub fn set_paused(&mut self, paused: bool, now: Instant) {
+        if paused == self.paused {
+            return;
+        }
+        self.paused = paused;
+        match paused {
+            true => self.paused_since = Some(now),
+            false => {
+                if let Some(since) = self.paused_since.take() {
+                    self.accumulated_pause += now.saturating_duration_since(since);
+                }
+            }
+        }
+    }
+
+    /// Expire the current notice if its ephemeral lifetime has elapsed, excluding
+    /// paused time. Sticky notices never expire here.
+    pub fn tick(&mut self, now: Instant) {
+        let Some(current) = &self.current else {
+            return;
+        };
+        let StatusLifetime::Ephemeral(lifetime) = current.lifetime else {
+            return;
+        };
+        let mut paused = self.accumulated_pause;
+        if let Some(since) = self.paused_since {
+            paused += now.saturating_duration_since(since);
+        }
+        let elapsed = now
+            .saturating_duration_since(current.created_at)
+            .saturating_sub(paused);
+        if elapsed >= lifetime {
+            self.acknowledge();
+        }
+    }
+}
+
+/// Whether `next` should take the slot from `current`. A notice sharing the
+/// current scope always replaces it (same-scope recovery/refresh); otherwise the
+/// newer notice wins only when its severity priority is at least as high, so
+/// Neutral never masks a sticky Warning/Error.
+fn should_replace(current: &StatusNotice, next: &StatusNotice) -> bool {
+    next.scope == current.scope || next.severity.priority() >= current.severity.priority()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(base: Instant, secs: u64) -> Instant {
+        base + Duration::from_secs(secs)
+    }
+
+    #[test]
+    fn neutral_expires_after_its_lifetime() {
+        let mut state = StatusState::default();
+        let mut notice = StatusNotice::neutral(StatusScope::General, "selection changed");
+        let base = Instant::now();
+        notice.created_at = base;
+        state.post(notice);
+        state.tick(at(base, 3));
+        assert!(state.current().is_some());
+        state.tick(at(base, 4));
+        assert!(state.current().is_none());
+    }
+
+    #[test]
+    fn sticky_error_does_not_expire() {
+        let mut state = StatusState::default();
+        let mut notice =
+            StatusNotice::error(StatusScope::Subsystem(SystemSubsystem::Storage), "boom");
+        let base = Instant::now();
+        notice.created_at = base;
+        state.post(notice);
+        state.tick(at(base, 3600));
+        assert!(state.current().is_some());
+    }
+
+    #[test]
+    fn neutral_cannot_replace_sticky_error() {
+        let mut state = StatusState::default();
+        state.post(StatusNotice::error(
+            StatusScope::Subsystem(SystemSubsystem::Storage),
+            "save failed",
+        ));
+        state.post(StatusNotice::neutral(
+            StatusScope::General,
+            "selection changed",
+        ));
+        assert_eq!(state.current().unwrap().severity, StatusSeverity::Error);
+    }
+
+    #[test]
+    fn warning_or_error_replaces_success() {
+        let mut state = StatusState::default();
+        state.post(StatusNotice::success(StatusScope::General, "saved"));
+        state.post(StatusNotice::warning(
+            StatusScope::Subsystem(SystemSubsystem::Update),
+            "low memory",
+        ));
+        assert_eq!(state.current().unwrap().severity, StatusSeverity::Warning);
+    }
+
+    #[test]
+    fn same_scope_success_recovers_a_warning() {
+        let mut state = StatusState::default();
+        let scope = StatusScope::Remote("host-1".to_string());
+        state.post(StatusNotice::error(scope.clone(), "probe failed"));
+        assert_eq!(state.current().unwrap().severity, StatusSeverity::Error);
+        state.post(StatusNotice::success(scope, "probe ok"));
+        assert_eq!(state.current().unwrap().severity, StatusSeverity::Success);
+    }
+
+    #[test]
+    fn acknowledge_clears_the_slot() {
+        let mut state = StatusState::default();
+        state.post(StatusNotice::error(StatusScope::General, "boom"));
+        state.acknowledge();
+        assert!(state.current().is_none());
+    }
+
+    #[test]
+    fn pause_defers_expiry() {
+        let mut state = StatusState::default();
+        let mut notice = StatusNotice::neutral(StatusScope::General, "hint");
+        let base = Instant::now();
+        notice.created_at = base;
+        state.post(notice);
+        // Paused for the whole window: it must not expire.
+        state.set_paused(true, at(base, 1));
+        state.tick(at(base, 10));
+        assert!(state.current().is_some());
+        // Resume at +10 with 9s of paused time excluded (effective age 1s), so it
+        // lives ~3 more unpaused seconds.
+        state.set_paused(false, at(base, 10));
+        state.tick(at(base, 12));
+        assert!(state.current().is_some());
+        state.tick(at(base, 14));
+        assert!(state.current().is_none());
+    }
+
+    #[test]
+    fn replacing_a_paused_notice_resets_pause_bookkeeping() {
+        let mut state = StatusState::default();
+        let base = Instant::now();
+        let mut first = StatusNotice::neutral(StatusScope::General, "first");
+        first.created_at = base;
+        state.post(first);
+        state.set_paused(true, at(base, 1));
+
+        let mut second = StatusNotice::neutral(StatusScope::General, "second");
+        second.created_at = at(base, 2);
+        state.post(second);
+        state.set_paused(true, at(base, 2));
+        state.tick(at(base, 20));
+        assert_eq!(state.current().unwrap().text, "second");
+    }
+
+    #[test]
+    fn newer_same_priority_notice_wins_by_recency() {
+        let mut state = StatusState::default();
+        state.post(StatusNotice::neutral(StatusScope::General, "first"));
+        state.post(StatusNotice::neutral(StatusScope::General, "second"));
+        assert_eq!(state.current().unwrap().text, "second");
+    }
+}

--- a/src/frontend/ui/panel_bodies/console.rs
+++ b/src/frontend/ui/panel_bodies/console.rs
@@ -1,24 +1,316 @@
 use super::*;
 
+use eframe::egui::text::LayoutJob;
 use eframe::egui::{self, Align, Frame, Layout, Margin, ScrollArea, Stroke};
 
-use crate::frontend::{actions::AppAction, state::AppState};
+use crate::frontend::{
+    actions::AppAction,
+    state::{
+        AppState, CommandActor, LogFilter, LogLevel, LogQuery, LogScope, OutputSource,
+        OutputTarget, short_job,
+    },
+};
 
 pub(crate) fn render_output_panel(state: &mut AppState, ui: &mut egui::Ui) {
     ui.set_width(ui.available_width());
+    render_output_toolbar(state, ui);
+
+    let target = state.ui.output.target.clone();
+    let cleared = state
+        .ui
+        .output
+        .cleared_before_by_target
+        .get(&target)
+        .copied()
+        .unwrap_or(0);
+    let search = state.ui.output.search.trim().to_string();
+    let query = LogQuery::new(LogFilter::from_output_target(&target))
+        .cleared_before(cleared)
+        .search(&search);
+    let latest_seq = state.session_log().latest_matching_seq(&query);
+    let last_seen = state
+        .ui
+        .output
+        .last_seen_by_target
+        .get(&target)
+        .copied()
+        .unwrap_or(0);
+    let unread = latest_seq.is_some_and(|seq| seq > last_seen);
+    let auto_follow = state.ui.output.auto_follow;
+    let wrap_mode = if state.ui.output.wrap_lines {
+        egui::TextWrapMode::Wrap
+    } else {
+        egui::TextWrapMode::Extend
+    };
+    // Under a mixed view, a dim scope tag keeps interleaved sources legible; a
+    // single-source or single-job view needs none.
+    let show_prefix = matches!(
+        target,
+        OutputTarget::All | OutputTarget::Source(OutputSource::Jobs)
+    );
+
     let log_width = ui.available_width();
     let log_content_width = (log_width - ASSISTANT_SCROLLBAR_RESERVE).max(48.0);
-    ScrollArea::vertical()
+
+    let scroll = ScrollArea::vertical()
         .max_width(log_width)
         .auto_shrink([false, false])
         .content_margin(Margin::ZERO)
-        .stick_to_bottom(true)
+        .stick_to_bottom(auto_follow)
         .show(ui, |ui| {
             ui.set_width(log_content_width);
-            for line in &state.output_log {
-                ui.add(egui::Label::new(console_text(line)).wrap_mode(egui::TextWrapMode::Wrap));
+            let pal = crate::frontend::theme::palette(ui);
+            if state.session_log().any(&query) {
+                let transcript = build_output_transcript(state, &query, &pal, show_prefix);
+                ui.add(
+                    egui::Label::new(transcript)
+                        .selectable(true)
+                        .wrap_mode(wrap_mode),
+                );
+            } else {
+                ui.add_space(6.0);
+                ui.label(
+                    console_text(output_empty_text(&target, &search)).color(pal.text_tertiary),
+                );
             }
         });
+
+    let at_bottom =
+        scroll.state.offset.y >= scroll.content_size.y - scroll.inner_rect.height() - 2.0;
+    state.ui.output.auto_follow = at_bottom;
+    if at_bottom && let Some(seq) = latest_seq {
+        state
+            .ui
+            .output
+            .last_seen_by_target
+            .insert(target.clone(), seq);
+    }
+    if unread && !at_bottom {
+        ui.vertical_centered(|ui| {
+            if ui.small_button("New output ↓").clicked() {
+                state.ui.output.auto_follow = true;
+                if let Some(seq) = latest_seq {
+                    state
+                        .ui
+                        .output
+                        .last_seen_by_target
+                        .insert(target.clone(), seq);
+                }
+            }
+        });
+    }
+}
+
+/// The Output toolbar: the source selector, an exact-job selector when a job view
+/// is active, then (right-aligned) search, wrap, and clear-view.
+fn render_output_toolbar(state: &mut AppState, ui: &mut egui::Ui) {
+    let current = state.ui.output.target.clone();
+    let mut next_target: Option<OutputTarget> = None;
+    ui.horizontal(|ui| {
+        egui::ComboBox::from_id_salt("output_source_selector")
+            .selected_text(source_label(&current))
+            .show_ui(ui, |ui| {
+                let mut option = |ui: &mut egui::Ui, target: OutputTarget, label: &str| {
+                    if ui
+                        .selectable_label(source_matches(&current, &target), label)
+                        .clicked()
+                    {
+                        next_target = Some(target);
+                    }
+                };
+                option(ui, OutputTarget::All, "All Output");
+                for source in OutputSource::all() {
+                    option(ui, OutputTarget::Source(source), source.label());
+                }
+            });
+
+        if matches!(
+            current,
+            OutputTarget::Source(OutputSource::Jobs) | OutputTarget::Job(_)
+        ) {
+            let choices = output_job_choices(state);
+            let selected = match &current {
+                OutputTarget::Job(job_id) => choices
+                    .iter()
+                    .find(|(id, _)| id == job_id)
+                    .map(|(_, label)| label.clone())
+                    .unwrap_or_else(|| format!("Job {}", short_job(*job_id))),
+                _ => "All jobs".to_string(),
+            };
+            egui::ComboBox::from_id_salt("output_job_selector")
+                .selected_text(selected)
+                .show_ui(ui, |ui| {
+                    if ui
+                        .selectable_label(
+                            matches!(current, OutputTarget::Source(OutputSource::Jobs)),
+                            "All jobs",
+                        )
+                        .clicked()
+                    {
+                        next_target = Some(OutputTarget::Source(OutputSource::Jobs));
+                    }
+                    for (job_id, label) in &choices {
+                        if ui
+                            .selectable_label(current == OutputTarget::Job(*job_id), label)
+                            .clicked()
+                        {
+                            next_target = Some(OutputTarget::Job(*job_id));
+                        }
+                    }
+                });
+        }
+
+        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+            if ui
+                .button("Clear")
+                .on_hover_text("Hide the current output (does not delete it)")
+                .clicked()
+            {
+                let next = state.clear_log_fold_boundary();
+                state
+                    .ui
+                    .output
+                    .cleared_before_by_target
+                    .insert(current.clone(), next);
+                state
+                    .ui
+                    .output
+                    .last_seen_by_target
+                    .insert(current.clone(), next);
+                state.ui.output.auto_follow = true;
+            }
+            let wrap = state.ui.output.wrap_lines;
+            if ui
+                .selectable_label(wrap, "Wrap")
+                .on_hover_text("Wrap long lines")
+                .clicked()
+            {
+                state.ui.output.wrap_lines = !wrap;
+            }
+            ui.add(
+                egui::TextEdit::singleline(&mut state.ui.output.search)
+                    .hint_text("Search")
+                    .desired_width(140.0),
+            );
+        });
+    });
+    if let Some(target) = next_target {
+        state.ui.output.target = target;
+        state.ui.output.auto_follow = true;
+    }
+}
+
+/// The exact-job choices for the selector: live/recent jobs from the execution
+/// projection unioned with jobs that still own retained log entries, so a choice
+/// never vanishes merely because its oldest text was evicted.
+fn output_job_choices(state: &AppState) -> Vec<(crate::job::JobId, String)> {
+    let mut seen = std::collections::HashSet::new();
+    let mut choices = Vec::new();
+    for snapshot in crate::frontend::jobs::list_controlled_jobs(state) {
+        if let Some(job_id) = snapshot.job_id
+            && seen.insert(job_id)
+        {
+            choices.push((
+                job_id,
+                format!(
+                    "{} · {} ({})",
+                    snapshot.kind.label(),
+                    snapshot.label,
+                    short_job(job_id)
+                ),
+            ));
+        }
+    }
+    for job_id in state.session_log().logged_jobs() {
+        if seen.insert(job_id) {
+            choices.push((job_id, format!("Job {}", short_job(job_id))));
+        }
+    }
+    choices
+}
+
+fn source_label(target: &OutputTarget) -> String {
+    match target {
+        OutputTarget::All => "All Output".to_string(),
+        OutputTarget::Source(source) => source.label().to_string(),
+        // A job target keeps the source selector reading "Jobs"; the job selector
+        // beside it names the exact job.
+        OutputTarget::Job(_) => OutputSource::Jobs.label().to_string(),
+    }
+}
+
+/// Whether the source selector should mark `option` as the current source (a Job
+/// target counts as the Jobs source).
+fn source_matches(current: &OutputTarget, option: &OutputTarget) -> bool {
+    match (current, option) {
+        (OutputTarget::Job(_), OutputTarget::Source(OutputSource::Jobs)) => true,
+        _ => current == option,
+    }
+}
+
+fn output_empty_text(target: &OutputTarget, search: &str) -> String {
+    if !search.is_empty() {
+        return format!("No output matches \"{search}\".");
+    }
+    match target {
+        OutputTarget::Job(_) => "No output captured for this job yet.".to_string(),
+        OutputTarget::Source(source) => format!("No {} output yet.", source.label()),
+        OutputTarget::All => "No output yet.".to_string(),
+    }
+}
+
+/// Build the Output body as one selectable, copyable [`LayoutJob`], coloring Warn
+/// and Error even without a level filter and, in a mixed view, tagging each line
+/// with its scope.
+fn build_output_transcript(
+    state: &AppState,
+    query: &LogQuery,
+    pal: &crate::frontend::theme::Palette,
+    show_prefix: bool,
+) -> LayoutJob {
+    let font = console_font_id();
+    let mut job = LayoutJob::default();
+    for entry in state.session_log().query(query) {
+        if show_prefix {
+            push_run(
+                &mut job,
+                &scope_prefix(&entry.scope),
+                &font,
+                pal.text_tertiary,
+            );
+        }
+        let color = level_color(entry.level, pal);
+        push_run(&mut job, &entry.text, &font, color);
+        if entry.repeat_count() > 1 {
+            push_run(
+                &mut job,
+                &format!("  ×{}", entry.repeat_count()),
+                &font,
+                pal.text_tertiary,
+            );
+        }
+        push_run(&mut job, "\n", &font, color);
+    }
+    job
+}
+
+fn level_color(level: LogLevel, pal: &crate::frontend::theme::Palette) -> egui::Color32 {
+    match level {
+        LogLevel::Error => pal.status_red,
+        LogLevel::Warn => pal.status_amber,
+        LogLevel::Trace => pal.text_tertiary,
+        LogLevel::Info => pal.text_primary,
+    }
+}
+
+fn scope_prefix(scope: &LogScope) -> String {
+    match scope {
+        LogScope::System { subsystem } => format!("{}: ", subsystem.label().to_lowercase()),
+        LogScope::Agent { .. } => "agent: ".to_string(),
+        LogScope::RemoteControl { .. } => "remote: ".to_string(),
+        LogScope::Job { job_id } => format!("job {}: ", short_job(*job_id)),
+        LogScope::Command { .. } => String::new(),
+    }
 }
 
 pub(crate) fn render_console_panel(
@@ -27,39 +319,89 @@ pub(crate) fn render_console_panel(
     actions: &mut Vec<AppAction>,
 ) {
     const PROMPT_ROW_HEIGHT: f32 = 34.0;
+    const TOOLBAR_HEIGHT: f32 = 22.0;
     const INPUT_OUTER_HEIGHT: f32 = 28.0;
     const INPUT_X_MARGIN: f32 = 8.0;
     const DIVIDER_HEIGHT: f32 = 1.0;
     const BOTTOM_PADDING: f32 = 4.0;
 
     ui.set_width(ui.available_width());
+
+    let query = LogQuery::new(LogFilter::Command).cleared_before(state.ui.console.cleared_before);
+    let latest_seq = state.session_log().latest_matching_seq(&query);
+    let unread = latest_seq.is_some_and(|seq| seq > state.ui.console.last_seen);
+
+    render_console_toolbar(state, ui);
+
     // Keep chronological output in top-down visual order while reserving fixed
     // space for the prompt row so the panel cannot grow frame-over-frame.
-    let log_height =
-        (ui.available_height() - PROMPT_ROW_HEIGHT - DIVIDER_HEIGHT - BOTTOM_PADDING).max(0.0);
+    let log_height = (ui.available_height()
+        - PROMPT_ROW_HEIGHT
+        - TOOLBAR_HEIGHT
+        - DIVIDER_HEIGHT
+        - BOTTOM_PADDING)
+        .max(0.0);
     let log_width = ui.available_width();
     let log_content_width = (log_width - ASSISTANT_SCROLLBAR_RESERVE).max(48.0);
-    let log_text = state.output_log.join("\n");
+    let wrap_mode = if state.ui.console.wrap_lines {
+        egui::TextWrapMode::Wrap
+    } else {
+        egui::TextWrapMode::Extend
+    };
+    let auto_follow = state.ui.console.auto_follow;
 
-    ui.allocate_ui_with_layout(
-        egui::vec2(log_width, log_height),
-        Layout::top_down(Align::Min),
-        |ui| {
-            ScrollArea::vertical()
-                .max_width(log_width)
-                .auto_shrink([false, false])
-                .content_margin(Margin::ZERO)
-                .stick_to_bottom(true)
-                .show(ui, |ui| {
-                    ui.set_width(log_content_width);
-                    ui.add(
-                        egui::Label::new(console_text(log_text))
-                            .selectable(true)
-                            .wrap_mode(egui::TextWrapMode::Wrap),
-                    );
-                });
-        },
-    );
+    let scroll = ui
+        .allocate_ui_with_layout(
+            egui::vec2(log_width, log_height),
+            Layout::top_down(Align::Min),
+            |ui| {
+                ScrollArea::vertical()
+                    .max_width(log_width)
+                    .auto_shrink([false, false])
+                    .content_margin(Margin::ZERO)
+                    .stick_to_bottom(auto_follow)
+                    .show(ui, |ui| {
+                        ui.set_width(log_content_width);
+                        let pal = crate::frontend::theme::palette(ui);
+                        if state.session_log().any(&query) {
+                            let transcript = build_transcript(state, &query, &pal);
+                            ui.add(
+                                egui::Label::new(transcript)
+                                    .selectable(true)
+                                    .wrap_mode(wrap_mode),
+                            );
+                        } else {
+                            ui.add_space(6.0);
+                            ui.label(
+                                console_text("Run a .sls command below — try `help`. Enter runs.")
+                                    .color(pal.text_tertiary),
+                            );
+                        }
+                    })
+            },
+        )
+        .inner;
+
+    // Auto-follow tracks whether the view is parked at the bottom, so incoming
+    // output only steals the scroll position when the user was already there.
+    let at_bottom =
+        scroll.state.offset.y >= scroll.content_size.y - scroll.inner_rect.height() - 2.0;
+    state.ui.console.auto_follow = at_bottom;
+    if at_bottom && let Some(seq) = latest_seq {
+        state.ui.console.last_seen = seq;
+    }
+
+    if unread && !at_bottom {
+        ui.vertical_centered(|ui| {
+            if ui.small_button("New output ↓").clicked() {
+                state.ui.console.auto_follow = true;
+                if let Some(seq) = latest_seq {
+                    state.ui.console.last_seen = seq;
+                }
+            }
+        });
+    }
+
     weak_panel_hairline(ui, 14);
     ui.allocate_ui_with_layout(
         egui::vec2(ui.available_width(), PROMPT_ROW_HEIGHT),
@@ -115,4 +457,94 @@ pub(crate) fn render_console_panel(
         },
     );
     ui.add_space(BOTTOM_PADDING);
+}
+
+/// The Console's slim control row: wrap toggle and clear-view, right-aligned.
+fn render_console_toolbar(state: &mut AppState, ui: &mut egui::Ui) {
+    ui.allocate_ui_with_layout(
+        egui::vec2(ui.available_width(), 20.0),
+        Layout::right_to_left(Align::Center),
+        |ui| {
+            if ui
+                .button("Clear")
+                .on_hover_text("Hide the current transcript (does not delete it)")
+                .clicked()
+            {
+                let next = state.clear_log_fold_boundary();
+                state.ui.console.cleared_before = next;
+                state.ui.console.last_seen = next;
+                state.ui.console.auto_follow = true;
+            }
+            let wrap = state.ui.console.wrap_lines;
+            if ui
+                .selectable_label(wrap, "Wrap")
+                .on_hover_text("Wrap long lines")
+                .clicked()
+            {
+                state.ui.console.wrap_lines = !wrap;
+            }
+        },
+    );
+}
+
+/// Build the Console transcript as one selectable, copyable [`LayoutJob`]:
+/// each command's prompt line is prefixed by its actor, and result/error lines
+/// carry level color and an `×N` repetition badge.
+fn build_transcript(
+    state: &AppState,
+    query: &LogQuery,
+    pal: &crate::frontend::theme::Palette,
+) -> LayoutJob {
+    let font = console_font_id();
+    let mut job = LayoutJob::default();
+    let mut current: Option<u64> = None;
+    for entry in state.session_log().query(query) {
+        let LogScope::Command { command_id, actor } = entry.scope else {
+            continue;
+        };
+        if current != Some(command_id) {
+            current = Some(command_id);
+            let prefix = match actor {
+                CommandActor::User => "sls> ",
+                CommandActor::Agent => "agent> ",
+            };
+            push_run(&mut job, prefix, &font, pal.text_tertiary);
+            push_run(
+                &mut job,
+                &format!("{}\n", entry.text),
+                &font,
+                pal.text_primary,
+            );
+            continue;
+        }
+        let color = match entry.level {
+            LogLevel::Error => pal.status_red,
+            LogLevel::Warn => pal.status_amber,
+            LogLevel::Trace => pal.text_tertiary,
+            LogLevel::Info => pal.text_primary,
+        };
+        push_run(&mut job, &entry.text, &font, color);
+        if entry.repeat_count() > 1 {
+            push_run(
+                &mut job,
+                &format!("  ×{}", entry.repeat_count()),
+                &font,
+                pal.text_tertiary,
+            );
+        }
+        push_run(&mut job, "\n", &font, color);
+    }
+    job
+}
+
+fn push_run(job: &mut LayoutJob, text: &str, font: &egui::FontId, color: egui::Color32) {
+    job.append(
+        text,
+        0.0,
+        egui::TextFormat {
+            font_id: font.clone(),
+            color,
+            ..Default::default()
+        },
+    );
 }

--- a/src/frontend/ui/panel_bodies/task_monitor.rs
+++ b/src/frontend/ui/panel_bodies/task_monitor.rs
@@ -4,7 +4,7 @@ use crate::{
     backend::tasks::{TaskPanelKind, TaskStatus},
     frontend::{
         actions::AppAction,
-        state::{AppState, PrimaryView},
+        state::{AppState, OutputTarget, PrimaryView, StatusSeverity},
         status_text,
     },
 };
@@ -21,7 +21,6 @@ pub(crate) fn render_status_bar(
                 .color(pal.text_primary),
         );
         ui.separator();
-        ui.label(RichText::new(&state.message).color(pal.text_primary));
 
         // The system monitor normally lives in the primary-sidebar footer; only
         // fall back to the status bar when that sidebar is hidden, so the gauges
@@ -29,9 +28,72 @@ pub(crate) fn render_status_bar(
         if state.config.show_utilization_bars && !state.ui.layout.show_primary_sidebar {
             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                 super::render_status_monitor(state, ui, actions);
+                ui.separator();
+                ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
+                    render_status_notice(state, ui, actions, &pal);
+                });
             });
+        } else {
+            render_status_notice(state, ui, actions, &pal);
         }
     });
+}
+
+/// Render the single status notice: a severity icon and color, the (visually
+/// truncated) text as a link when it carries a detail target, a dismiss control
+/// for sticky notices, and expiry paused while it is hovered or focused.
+fn render_status_notice(
+    state: &mut AppState,
+    ui: &mut egui::Ui,
+    actions: &mut Vec<AppAction>,
+    pal: &crate::frontend::theme::Palette,
+) {
+    let Some(notice) = state.status_notice() else {
+        state.set_status_paused(false, std::time::Instant::now());
+        return;
+    };
+    let severity = notice.severity;
+    let text = notice.text.clone();
+    let target = notice.target.clone();
+    let (icon, color) = severity_style(severity, pal);
+
+    ui.label(RichText::new(icon).color(color));
+    let label = RichText::new(&text).color(color);
+    let response = match &target {
+        Some(_) => ui.link(label).on_hover_text(&text),
+        None => ui.label(label).on_hover_text(&text),
+    };
+    // Hovering or focusing a notice (linked ones are focusable) freezes its expiry
+    // so it cannot vanish while the user reads or reaches for it.
+    let paused = response.hovered() || response.has_focus();
+    state.set_status_paused(paused, std::time::Instant::now());
+    if response.clicked()
+        && let Some(target) = target
+    {
+        actions.push(AppAction::OpenDetailTarget(target));
+    }
+    if severity.is_sticky()
+        && ui
+            .add(egui::Button::new(RichText::new(egui_phosphor::regular::X).small()).frame(false))
+            .on_hover_text("Dismiss")
+            .clicked()
+    {
+        actions.push(AppAction::AcknowledgeStatus);
+    }
+}
+
+/// Map severity to a text/icon and color pair, so severity is never signalled by
+/// color alone.
+fn severity_style(
+    severity: StatusSeverity,
+    pal: &crate::frontend::theme::Palette,
+) -> (&'static str, egui::Color32) {
+    match severity {
+        StatusSeverity::Neutral => (egui_phosphor::regular::INFO, pal.text_primary),
+        StatusSeverity::Success => (egui_phosphor::regular::CHECK_CIRCLE, pal.status_green),
+        StatusSeverity::Warning => (egui_phosphor::regular::WARNING, pal.status_amber),
+        StatusSeverity::Error => (egui_phosphor::regular::WARNING_OCTAGON, pal.status_red),
+    }
 }
 
 /// One shared visual tone for a run's status, so a Task row and a live Job card
@@ -336,7 +398,14 @@ fn render_controlled_jobs(state: &AppState, ui: &mut egui::Ui, actions: &mut Vec
     }
     ui.add_space(4.0);
     for job in &jobs {
-        Frame::group(ui.style())
+        let targeted = job.job_id == state.ui.activity_job_target;
+        let stroke = if targeted {
+            egui::Stroke::new(2.0_f32, pal.accent)
+        } else {
+            egui::Stroke::default()
+        };
+        let response = Frame::group(ui.style())
+            .stroke(stroke)
             .inner_margin(Margin::same(8))
             .show(ui, |ui| {
                 ui.set_width(ui.available_width());
@@ -376,7 +445,26 @@ fn render_controlled_jobs(state: &AppState, ui: &mut egui::Ui, actions: &mut Vec
                         ));
                     });
                 });
+                // The card projects the canonical exact-`JobId` log tail (it owns no
+                // second buffer) and deep-links Output to that same execution.
+                if let Some(job_id) = job.job_id {
+                    if ui
+                        .small_button(format!(
+                            "{}  Open in Output",
+                            egui_phosphor::regular::ARROW_SQUARE_OUT
+                        ))
+                        .clicked()
+                    {
+                        actions.push(AppAction::RevealOutput(OutputTarget::Job(job_id)));
+                    }
+                    for entry in state.session_log().tail_for_job(job_id, 6) {
+                        ui.monospace(&entry.text);
+                    }
+                }
             });
+        if targeted {
+            response.response.scroll_to_me(Some(Align::Center));
+        }
         ui.add_space(4.0);
     }
     ui.add_space(8.0);
@@ -451,8 +539,13 @@ fn render_active_task_summary(state: &AppState, ui: &mut egui::Ui) {
                         .color(pal.text_tertiary),
                 );
             }
-            for line in engine_job.log_tail.iter().rev().take(6).rev() {
-                ui.monospace(line);
+            if let Some(job_id) = state
+                .jobs
+                .local_execution(crate::frontend::jobs::LocalJobSlot::Engine)
+            {
+                for entry in state.session_log().tail_for_job(job_id, 6) {
+                    ui.monospace(&entry.text);
+                }
             }
         } else if let Some(optimizer) = state.jobs.optimizer.as_ref() {
             ui.add_space(6.0);

--- a/src/frontend/ui/title_bar.rs
+++ b/src/frontend/ui/title_bar.rs
@@ -400,7 +400,10 @@ pub(crate) fn render_title_bar(
                     if response.clicked()
                         && let Err(error) = crate::io::self_update::restart_into_new_binary()
                     {
-                        state.set_message(format!("Restart failed: {error}"));
+                        actions.push(AppAction::ReportSystemError {
+                            subsystem: crate::frontend::state::SystemSubsystem::Update,
+                            text: format!("Restart failed: {error}"),
+                        });
                     }
                 }
                 SelfUpdateStatus::Downloading => {
@@ -426,7 +429,9 @@ pub(crate) fn render_title_bar(
                                 state.ui.self_update = SelfUpdateStatus::Downloading;
                                 state.jobs.self_update =
                                     Some(crate::frontend::jobs::spawn_self_update());
-                                state.set_message(format!("Downloading SilicoLab {version}…"));
+                                actions.push(AppAction::PostStatusNeutral(format!(
+                                    "Downloading SilicoLab {version}…"
+                                )));
                             }
                         } else {
                             let hover = match &status {

--- a/src/frontend/ui/views.rs
+++ b/src/frontend/ui/views.rs
@@ -230,7 +230,9 @@ pub(crate) fn render_structure_editor_window(
     if let Some(draft) = preview_update {
         *state.structure_mut() = draft;
         state.mark_structure_changed();
-        state.set_message("Editing preview updated".to_string());
+        actions.push(AppAction::PostStatusNeutral(
+            "Editing preview updated".to_string(),
+        ));
     }
 
     if apply {

--- a/src/frontend/ui/workspace.rs
+++ b/src/frontend/ui/workspace.rs
@@ -148,7 +148,10 @@ pub(super) fn render_workspace(
                             }
                         }
                         if let Some(index) = assigned_atom {
-                            state.set_message(format!("Assigned atom {}", index + 1));
+                            actions.push(AppAction::PostStatusNeutral(format!(
+                                "Assigned atom {}",
+                                index + 1
+                            )));
                         }
                     }
                 } else if !state.workspace.is_project() && state.entries.tabs.is_empty() {


### PR DESCRIPTION
## What

Replaces the overloaded `set_message` path — which both set the status bar and appended to an untyped `output_log` firehose rendered by every surface — with surfaces that have exclusive responsibilities and canonical owners.

## Changes

- **`SessionLogStore`** — a typed, byte-bounded session log. Each entry carries an exact scope; job entries are keyed by `JobId`, never by `JobKind` alone. Adjacent, scope- and level-aware repetition folding with per-scope and global retention.
- **`StatusNotice`** — a single transient status-bar slot with severity priority, ephemeral/sticky lifetimes, same-scope recovery, and typed links. A status line is never the sole record of a failure the user may need to revisit.
- **Feedback helpers on `AppState`** that route each event to its owner in place of `set_message`.

## Surface responsibilities

- **Console** renders only the command transcript.
- **Output** renders the system, agent, remote-control, and job-detail streams.
- **Activity** queries the canonical log for its per-job tail instead of owning a second copy.
- **Progress** remains structured runtime state and is never appended as a log line.

## Notes

- All former `set_message` call sites across the dispatcher, jobs, and agent loop are migrated to the new surfaces.
- Bottom-panel tab order and saved layout identity are unchanged.
- `cargo pr-check` passes.
