### PR TITLE
ci(docs): migrate docs site from GitHub Pages to Cloudflare Workers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,13 @@
 name: Docs
 
-# Mirrors ci.yml's shape: `Docs complete` is a single always-reporting gate the
-# branch ruleset can require without deadlocking PRs that don't touch the docs.
+# Validation-only. Cloudflare Workers Builds (Git integration) does the actual
+# build + deploy on push to main, reading docs-site/wrangler.toml. This runs on
+# PRs that touch the docs, solely to stop a broken internal link from merging.
+# It is NOT a required status check (main's ruleset requires only `CI
+# complete`), so a plain paths filter is safe here — a PR that changes nothing
+# under these paths simply skips the workflow, which never blocks the merge.
 on:
-  push:
+  pull_request:
     branches: [main]
     paths:
       - 'docs-site/**'
@@ -12,12 +16,6 @@ on:
       - 'branding/**'
       - 'docs/images/main-window.png'
       - 'assets/icon/hicolor/256x256/apps/silicolab.png'
-  pull_request:
-    branches: [main]
-    # No paths filter: the workflow must run on every PR so the required
-    # `Docs complete` context always reports (a path-skipped workflow never
-    # reports its context and would block the PR forever). The changes job
-    # below decides whether to actually build.
 
 permissions:
   contents: read
@@ -27,40 +25,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changes:
-    name: Detect docs changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      docs: ${{ steps.filter.outputs.docs }}
-    steps:
-      - id: filter
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Push events are already path-filtered by `on.push.paths`, so build.
-          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
-            echo "docs=true" | tee -a "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate -q '.[].filename') || files=""
-          echo "Changed files:"
-          printf '%s\n' "$files"
-          # Build when a PR touches the site or a canonical source it syncs in.
-          docs='(^docs-site/|^branding/|^\.github/workflows/docs\.yml$|^docs/images/main-window\.png$|^assets/icon/hicolor/256x256/apps/silicolab\.png$)'
-          if [ -z "$files" ] || printf '%s\n' "$files" | grep -qE "$docs"; then
-            echo "docs=true" | tee -a "$GITHUB_OUTPUT"
-          else
-            echo "docs=false" | tee -a "$GITHUB_OUTPUT"
-          fi
-
   build:
     name: Build
-    needs: changes
-    if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -72,41 +38,6 @@ jobs:
       - run: npm ci
         working-directory: docs-site
       # Runs the Starlight link validator (astro.config.mjs): a broken internal
-      # link fails the build.
+      # link fails the build. Deploy is Cloudflare's job, not this workflow's.
       - run: npm run build
         working-directory: docs-site
-      - uses: actions/upload-pages-artifact@v3
-        if: github.event_name == 'push'
-        with:
-          path: docs-site/dist
-
-  deploy:
-    if: github.event_name == 'push'
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
-
-  # The single required status check for docs, mirroring `CI complete`. Always
-  # reports: a PR that doesn't touch docs skips the build, and a skipped job is
-  # not a failure, so this still goes green and never blocks the PR.
-  docs-complete:
-    name: Docs complete
-    if: always()
-    needs: [changes, build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Require the build to have succeeded or been skipped
-        run: |
-          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
-            echo "::error::the docs build failed or was cancelled"
-            exit 1
-          fi
-          echo "Docs build succeeded or was skipped."

--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@
 <p align="left"><em>Computational environment for chemistry, biology &amp; materials research.</em></p>
 
 <p align="left">
-  <a href="https://silicolab.github.io/silicolab/"><img alt="Documentation" src="https://img.shields.io/badge/docs-silicolab.github.io-2563eb"></a>
+  <a href="https://docs.silicolab.workers.dev/"><img alt="Documentation" src="https://img.shields.io/badge/docs-docs.silicolab.workers.dev-2563eb"></a>
   <a href="https://github.com/silicolab/silicolab/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/silicolab/silicolab/actions/workflows/ci.yml/badge.svg?branch=main"></a>
-  <a href="https://github.com/silicolab/silicolab/actions/workflows/docs.yml"><img alt="Docs" src="https://github.com/silicolab/silicolab/actions/workflows/docs.yml/badge.svg?branch=main"></a>
   <a href="https://github.com/silicolab/silicolab/releases"><img alt="Release" src="https://img.shields.io/github/v/release/silicolab/silicolab?include_prereleases&sort=semver"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-GPL--3.0--or--later%20OR%20commercial-blue"></a>
 </p>
 
-**Read the [user manual](https://silicolab.github.io/silicolab/) or download a
+**Read the [user manual](https://docs.silicolab.workers.dev/) or download a
 prebuilt executable from [GitHub Releases](https://github.com/silicolab/silicolab/releases).**
 
 ![SilicoLab screenshot](docs/images/main-window.png)
@@ -70,7 +69,7 @@ silicolab workflow.sls
 ```
 
 The same scripts also run interactively in the GUI console. The full user
-manual in English and Chinese lives at <https://silicolab.github.io/silicolab/>.
+manual in English and Chinese lives at <https://docs.silicolab.workers.dev/>.
 
 ## External tools
 
@@ -79,8 +78,8 @@ need them. Molecular dynamics requires GROMACS. Quantum chemistry uses the
 built-in Hartree engine by default, with ORCA available as an optional external
 engine when the user configures its executable path. See the manual for setup details:
 
-- [External tools](https://silicolab.github.io/silicolab/getting-started/external-tools/)
-- [Remote execution over SSH](https://silicolab.github.io/silicolab/getting-started/remote-execution/)
+- [External tools](https://docs.silicolab.workers.dev/getting-started/external-tools/)
+- [Remote execution over SSH](https://docs.silicolab.workers.dev/getting-started/remote-execution/)
 
 ## Development
 

--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .astro/
+.wrangler/
 
 # synced from canonical repo assets by scripts/sync-assets.mjs
 src/assets/wordmark-light.svg

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -3,18 +3,16 @@ import starlight from '@astrojs/starlight';
 import starlightLinksValidator from 'starlight-links-validator';
 
 export default defineConfig({
-  site: 'https://silicolab.github.io',
-  base: '/silicolab',
+  site: 'https://docs.silicolab.workers.dev',
   integrations: [
     starlight({
       title: 'SilicoLab',
       description:
         'Computational environment for chemistry, biology & materials research.',
       // Fail the build on broken internal links. Relative links are allowed
-      // (pages use them so they survive the /silicolab base) and skipped by the
-      // check; absolute links are resolution-checked, so a base-missing one —
-      // the classic mistake, and the bug that shipped in the first docs PR —
-      // fails the build.
+      // (pages use them so they survive) and skipped by the check; absolute
+      // links are resolution-checked, so a broken one — the classic mistake,
+      // and the bug that shipped in the first docs PR — fails the build.
       plugins: [starlightLinksValidator({ errorOnRelativeLinks: false })],
       social: [
         {

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -9,7 +9,7 @@ hero:
     alt: SilicoLab main window showing a molecular structure in the 3D viewer
   actions:
     - text: Get started
-      link: /silicolab/getting-started/installation/
+      link: /getting-started/installation/
       icon: right-arrow
     - text: View on GitHub
       link: https://github.com/silicolab/silicolab

--- a/docs-site/src/content/docs/zh/index.mdx
+++ b/docs-site/src/content/docs/zh/index.mdx
@@ -9,7 +9,7 @@ hero:
     alt: SilicoLab 主窗口，3D 查看器中显示一个分子结构
   actions:
     - text: 开始使用
-      link: /silicolab/zh/getting-started/installation/
+      link: /zh/getting-started/installation/
       icon: right-arrow
     - text: 前往 GitHub
       link: https://github.com/silicolab/silicolab

--- a/docs-site/wrangler.toml
+++ b/docs-site/wrangler.toml
@@ -1,0 +1,11 @@
+# Cloudflare Workers static-assets deployment for the docs site.
+# The worker name plus the account's workers.dev subdomain form the URL:
+#   docs + silicolab.workers.dev  ->  https://docs.silicolab.workers.dev
+name = "docs"
+compatibility_date = "2025-07-01"
+
+# Serve the Astro/Starlight build output directly; no worker script needed.
+# `404-page` makes unmatched paths return the generated 404.html.
+[assets]
+directory = "./dist"
+not_found_handling = "404-page"


### PR DESCRIPTION
## What & why

Migrates the docs site hosting from **GitHub Pages** (`https://silicolab.github.io/silicolab/`) to **Cloudflare Workers** (`https://docs.silicolab.workers.dev`).

The workers.dev URL serves the site at the **root**, so the old `/silicolab` base path is removed everywhere. Build + deploy now happen on Cloudflare Workers Builds (Git integration, reads `docs-site/wrangler.toml` on push to `main`); GitHub Actions is reduced to a PR-time link-validation gate only.

## Changes

- **`docs-site/astro.config.mjs`** — `site` → `docs.silicolab.workers.dev`; drop `base: '/silicolab'`.
- **`docs-site/wrangler.toml`** (new) — static-assets Worker named `docs`, serves `./dist`, `not_found_handling = "404-page"`.
- **`index.mdx` / `zh/index.mdx`** — de-base the hero "Get started" links.
- **`README.md`** — docs badge + manual links → new domain; removed the stale `docs.yml` workflow badge.
- **`.github/workflows/docs.yml`** — validation-only now: a single `build` job (`npm run build` runs the Starlight link validator), `paths:`-filtered and PR-only. `Docs complete` is not a required check (the `main` ruleset requires only `CI complete`), so the always-reporting scaffolding and the deploy job were removed.
- **`docs-site/.gitignore`** — ignore `.wrangler/`.

## CI behavior after this

- Non-docs PRs → docs workflow does not trigger.
- PRs touching `docs-site/**` → `npm run build` validates the docs compile and links resolve, protecting the Cloudflare deploy.
- Merge to `main` → no GitHub Actions docs run; Cloudflare builds and deploys.

## Manual setup on Cloudflare (one-time)

Connect the repo under Workers → Git integration: root dir `docs-site`, build `npm run build`, deploy via `wrangler.toml`. Confirm the account workers.dev subdomain is `silicolab`. Then retire the old GitHub Pages deployment.

## Verification

`npm run build` passes locally: 11 pages built, all internal links valid, root-relative output, `404.html` present.