### PR TITLE
fix(viewport): render continuous rounded stick bonds

### DIFF
--- a/src/frontend/viewport/gpu.rs
+++ b/src/frontend/viewport/gpu.rs
@@ -1,7 +1,7 @@
 //! GPU-accelerated molecular rendering.
 //!
 //! Atoms are drawn as instanced billboard sphere impostors and bonds as
-//! instanced low-poly cylinders, all in a single egui paint callback that draws
+//! instanced capsule meshes, all in a single egui paint callback that draws
 //! into egui's render pass against its depth buffer (enabled via
 //! `NativeOptions::depth_buffer` in `app.rs`). The shaders (`molecule.wgsl`)
 //! replicate the CPU [`Projector`] projection and the CPU "paper" shading so the
@@ -19,9 +19,8 @@ use super::camera::Projector;
 /// (32 bits → [`wgpu::TextureFormat::Depth32Float`]) configured in `app.rs`.
 pub(crate) const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
 
-/// Sides of the unit bond cylinder. Bonds are thin, so a coarse ring reads as
-/// round; ends are left open because the atom spheres cover them.
-const CYLINDER_SIDES: usize = 10;
+const CYLINDER_SIDES: usize = 16;
+const CAPSULE_CAP_RINGS: usize = 5;
 
 // ---------------------------------------------------------------------------
 // GPU data (std430/vertex-buffer layouts; kept in sync with `molecule.wgsl`).
@@ -91,7 +90,7 @@ struct CameraUniform {
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
 struct CylinderVertex {
-    /// rx, ry, y, cap (unused here; sides only).
+    /// Radial xy, axial length fraction, and radius-scaled axial offset/normal.
     local: [f32; 4],
 }
 
@@ -125,9 +124,29 @@ fn camera_uniform(projector: &Projector) -> CameraUniform {
     }
 }
 
-fn unit_cylinder_vertices() -> Vec<CylinderVertex> {
+fn capsule_ring_vertex(
+    side: usize,
+    latitude: f32,
+    axial_fraction: f32,
+    axial_sign: f32,
+) -> [f32; 4] {
     use std::f32::consts::TAU;
-    let mut vertices = Vec::with_capacity(CYLINDER_SIDES * 6);
+    let azimuth = TAU * side as f32 / CYLINDER_SIDES as f32;
+    let (azimuth_sin, azimuth_cos) = azimuth.sin_cos();
+    let (axial, radial) = latitude.sin_cos();
+    [
+        radial * azimuth_cos,
+        radial * azimuth_sin,
+        axial_fraction,
+        axial_sign * axial,
+    ]
+}
+
+fn unit_capsule_vertices() -> Vec<CylinderVertex> {
+    use std::f32::consts::{FRAC_PI_2, TAU};
+    let cap_vertices_per_side = (CAPSULE_CAP_RINGS - 1) * 6 + 3;
+    let mut vertices = Vec::with_capacity(CYLINDER_SIDES * (6 + cap_vertices_per_side * 2));
+
     for side in 0..CYLINDER_SIDES {
         let a0 = TAU * side as f32 / CYLINDER_SIDES as f32;
         let a1 = TAU * (side + 1) as f32 / CYLINDER_SIDES as f32;
@@ -141,6 +160,42 @@ fn unit_cylinder_vertices() -> Vec<CylinderVertex> {
             vertices.push(CylinderVertex { local });
         }
     }
+
+    for (axial_fraction, axial_sign) in [(0.0, -1.0), (1.0, 1.0)] {
+        for ring in 0..CAPSULE_CAP_RINGS {
+            let latitude0 = FRAC_PI_2 * ring as f32 / CAPSULE_CAP_RINGS as f32;
+            let latitude1 = FRAC_PI_2 * (ring + 1) as f32 / CAPSULE_CAP_RINGS as f32;
+            for side in 0..CYLINDER_SIDES {
+                let v00 = capsule_ring_vertex(side, latitude0, axial_fraction, axial_sign);
+                let v10 = capsule_ring_vertex(side + 1, latitude0, axial_fraction, axial_sign);
+
+                if ring + 1 == CAPSULE_CAP_RINGS {
+                    let pole = [0.0, 0.0, axial_fraction, axial_sign];
+                    let triangle = if axial_sign < 0.0 {
+                        [v00, pole, v10]
+                    } else {
+                        [v00, v10, pole]
+                    };
+                    for local in triangle {
+                        vertices.push(CylinderVertex { local });
+                    }
+                    continue;
+                }
+
+                let v11 = capsule_ring_vertex(side + 1, latitude1, axial_fraction, axial_sign);
+                let v01 = capsule_ring_vertex(side, latitude1, axial_fraction, axial_sign);
+                let triangles = if axial_sign < 0.0 {
+                    [v00, v11, v10, v00, v01, v11]
+                } else {
+                    [v00, v10, v11, v00, v11, v01]
+                };
+                for local in triangles {
+                    vertices.push(CylinderVertex { local });
+                }
+            }
+        }
+    }
+
     vertices
 }
 
@@ -373,12 +428,12 @@ impl MoleculeRenderer {
                 cache: None,
             });
 
-        let unit_cylinder = unit_cylinder_vertices();
+        let unit_capsule = unit_capsule_vertices();
         let cylinder_vertices = create_static_buffer(
             device,
-            "molecule_unit_cylinder",
+            "molecule_unit_capsule",
             wgpu::BufferUsages::VERTEX,
-            bytemuck::cast_slice(&unit_cylinder),
+            bytemuck::cast_slice(&unit_capsule),
         );
 
         let spheres = create_dynamic_buffer::<SphereInstance>(device, "molecule_spheres", 1);
@@ -394,7 +449,7 @@ impl MoleculeRenderer {
             camera_buffer,
             camera_bind_group,
             cylinder_vertices,
-            cylinder_vertex_count: unit_cylinder.len() as u32,
+            cylinder_vertex_count: unit_capsule.len() as u32,
             spheres,
             sphere_capacity: 1,
             sphere_count: 0,

--- a/src/frontend/viewport/gpu/tests.rs
+++ b/src/frontend/viewport/gpu/tests.rs
@@ -72,8 +72,27 @@ fn camera_uniform_projection_matches_cpu_projector() {
 }
 
 #[test]
-fn unit_cylinder_is_two_triangles_per_side() {
-    assert_eq!(unit_cylinder_vertices().len(), CYLINDER_SIDES * 6);
+fn unit_capsule_has_side_wall_and_hemisphere_caps() {
+    let vertices = unit_capsule_vertices();
+    let cap_vertices_per_side = (CAPSULE_CAP_RINGS - 1) * 6 + 3;
+    assert_eq!(
+        vertices.len(),
+        CYLINDER_SIDES * (6 + cap_vertices_per_side * 2)
+    );
+
+    let mut min_axial = f32::INFINITY;
+    let mut max_axial = f32::NEG_INFINITY;
+    for vertex in vertices {
+        let [x, y, fraction, axial_offset] = vertex.local;
+        let normal_length_squared = x * x + y * y + axial_offset * axial_offset;
+        assert!((normal_length_squared - 1.0).abs() < 1e-5);
+        assert!((0.0..=1.0).contains(&fraction));
+        min_axial = min_axial.min(fraction + axial_offset);
+        max_axial = max_axial.max(fraction + axial_offset);
+    }
+
+    assert!((min_axial + 1.0).abs() < 1e-6);
+    assert!((max_axial - 2.0).abs() < 1e-6);
 }
 
 fn benzene() -> Structure {

--- a/src/frontend/viewport/mod.rs
+++ b/src/frontend/viewport/mod.rs
@@ -125,9 +125,10 @@ impl GpuInstanceKey {
 }
 
 /// Hash the styling that changes the GPU scene: per-category and per-atom style
-/// overrides, ion visibility/color, cartoon ribbon geometry, surface settings,
-/// and chain colors. Only the lighting preset and background are excluded (they
-/// do not change geometry). Camera state is excluded by construction.
+/// overrides, explicit atom visibility, ion visibility/color, cartoon ribbon
+/// geometry, surface settings, and chain colors. Only the lighting preset and
+/// background are excluded (they do not change geometry). Camera state is
+/// excluded by construction.
 fn hash_visual_state(visual_state: &ViewportVisualState) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -138,6 +139,9 @@ fn hash_visual_state(visual_state: &ViewportVisualState) -> u64 {
     for (index, style) in &visual_state.atom_styles {
         index.hash(&mut hasher);
         style.hash(&mut hasher);
+    }
+    for index in &visual_state.atom_hidden {
+        index.hash(&mut hasher);
     }
     visual_state
         .ions

--- a/src/frontend/viewport/molecule.wgsl
+++ b/src/frontend/viewport/molecule.wgsl
@@ -1,7 +1,7 @@
 // GPU molecular rendering for the viewport.
 //
 // Atoms are drawn as camera-facing billboard impostors with a ray-sphere
-// intersection in the fragment shader; bonds as instanced low-poly cylinders.
+// intersection in the fragment shader; bonds as instanced capsule meshes.
 // Both replicate the CPU `Projector` projection exactly so they line up with the
 // CPU-drawn unit-cell box, atom labels, and picking, and both reproduce the CPU
 // "paper" shading (`ball_stick::shade_surface_color`) so the look is unchanged.
@@ -165,10 +165,10 @@ fn sphere_fs(in: SphereOut) -> FragOut {
 }
 
 // ---------------------------------------------------------------------------
-// Bond cylinders (instanced unit-cylinder mesh).
+// Bond capsules (instanced unit mesh).
 
 struct CylinderIn {
-    @location(0) local: vec4<f32>,       // unit mesh: rx, ry, y, cap (-1 bottom, 0 side, +1 top)
+    @location(0) local: vec4<f32>,       // radial xy, length fraction, radius-scaled axial offset/normal
     @location(1) start_len: vec4<f32>,   // instance: xyz start, w length
     @location(2) axis_radius: vec4<f32>, // instance: xyz unit axis, w radius
     @location(3) side_u: vec4<f32>,      // instance: xyz U basis
@@ -180,40 +180,33 @@ struct CylinderIn {
 struct CylinderOut {
     @builtin(position) clip: vec4<f32>,
     @location(0) normal_view: vec3<f32>,
-    @location(1) color: vec3<f32>,
+    @location(1) color_a: vec3<f32>,
+    @location(2) color_b: vec3<f32>,
+    @location(3) axial_fraction: f32,
 };
 
 @vertex
 fn cylinder_vs(in: CylinderIn) -> CylinderOut {
-    let radial = in.side_u.xyz * in.local.x + in.side_v.xyz * in.local.y;
-    let world = in.start_len.xyz + in.axis_radius.xyz * (in.start_len.w * in.local.z)
-        + radial * in.axis_radius.w;
+    let radial_normal = in.side_u.xyz * in.local.x + in.side_v.xyz * in.local.y;
+    let axial = in.start_len.w * in.local.z + in.axis_radius.w * in.local.w;
+    let world = in.start_len.xyz + in.axis_radius.xyz * axial
+        + radial_normal * in.axis_radius.w;
     let view = to_view(world);
-
-    var world_normal: vec3<f32>;
-    if abs(in.local.w) < 0.5 {
-        world_normal = normalize(radial);
-    } else {
-        world_normal = in.axis_radius.xyz * sign(in.local.w);
-    }
-
-    var color: vec3<f32>;
-    if in.local.z < 0.5 {
-        color = in.color_a.rgb;
-    } else {
-        color = in.color_b.rgb;
-    }
+    let world_normal = normalize(radial_normal + in.axis_radius.xyz * in.local.w);
 
     var out: CylinderOut;
     out.clip = vec4<f32>(view_to_ndc(view), depth_ndc(view.z), 1.0);
     out.normal_view = (camera.rotation * vec4<f32>(world_normal, 0.0)).xyz;
-    out.color = color;
+    out.color_a = in.color_a.rgb;
+    out.color_b = in.color_b.rgb;
+    out.axial_fraction = in.local.z;
     return out;
 }
 
 @fragment
 fn cylinder_fs(in: CylinderOut) -> @location(0) vec4<f32> {
-    return frame_color(shade(in.color, in.normal_view));
+    let color = select(in.color_a, in.color_b, in.axial_fraction >= 0.5);
+    return frame_color(shade(color, in.normal_view));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/frontend/viewport/render.rs
+++ b/src/frontend/viewport/render.rs
@@ -45,13 +45,20 @@ const SPHERE_LATITUDE_SEGMENTS: usize = 10;
 const SPHERE_LONGITUDE_SEGMENTS: usize = 18;
 const BOND_RADIAL_SEGMENTS: usize = 14;
 const SINGLE_BOND_RADIUS: f32 = 0.115;
+/// Clear spacing between adjacent rods in a multiple-bond bundle. The bundle's
+/// full envelope stays equal to the single-bond diameter.
+const STICK_MULTI_BOND_GAP: f32 = SINGLE_BOND_RADIUS * 0.12;
+const STICK_DOUBLE_BOND_RADIUS: f32 = SINGLE_BOND_RADIUS * 0.5 - STICK_MULTI_BOND_GAP * 0.25;
+const STICK_DOUBLE_BOND_OFFSET: f32 = SINGLE_BOND_RADIUS - STICK_DOUBLE_BOND_RADIUS;
+const STICK_TRIPLE_BOND_RADIUS: f32 = (SINGLE_BOND_RADIUS - STICK_MULTI_BOND_GAP) / 3.0;
+const STICK_TRIPLE_BOND_OFFSET: f32 = SINGLE_BOND_RADIUS - STICK_TRIPLE_BOND_RADIUS;
 const MULTI_BOND_RADIUS: f32 = 0.082;
+const MULTI_BOND_OFFSET: f32 = 0.18;
 /// Radius of the thin rod a Wireframe (line) bond becomes on the GPU path, which
 /// has no screen-space line primitive. Wireframe atoms draw no node, so the bond
 /// carries the whole representation; kept well under [`SINGLE_BOND_RADIUS`] so
 /// wireframe still reads as light lines next to solid sticks.
 const WIREFRAME_BOND_RADIUS: f32 = 0.05;
-const MULTI_BOND_OFFSET: f32 = 0.18;
 const AROMATIC_DASH_RADIUS: f32 = 0.052;
 const AROMATIC_DASH_OFFSET: f32 = 0.17;
 const AROMATIC_DASH_LENGTH: f32 = 0.26;
@@ -125,30 +132,21 @@ fn atom_ball_radius(element: &str) -> f32 {
     element_style(element).display_radius * BALL_RADIUS_SCALE
 }
 
-/// World-space radius of the solid sphere drawn at an atom of `style`, before any
-/// selection-highlight scaling, or `None` when the style draws no sphere at the
-/// atom center (the flat "dots" disc and bond-only Wireframe own their markers).
-///
-/// Stick is deliberately special: its node matches the *bond* radius, not the
-/// element, so a bonded chain reads as one smooth uniform tube with rounded
-/// elbows — and a lone, bond-less atom still shows as a small node — rather than
-/// the fat element-sized ball of ball-and-stick. Sphere and ball-and-stick scale
-/// the element's display radius (full van der Waals, and [`BALL_RADIUS_SCALE`] of
-/// it, respectively).
+/// World-space radius of the solid atom marker drawn for `style`, before any
+/// selection-highlight scaling. Stick joints are topology-dependent connectors,
+/// not atom markers, and are emitted separately by the molecule builders.
 fn atom_marker_radius(element: &str, style: AtomStyle) -> Option<f32> {
     match style {
         AtomStyle::Sphere => Some(atom_ball_radius(element) / BALL_RADIUS_SCALE),
         AtomStyle::BallAndStick => Some(atom_ball_radius(element)),
-        AtomStyle::Stick => Some(SINGLE_BOND_RADIUS),
         _ => None,
     }
 }
 
 /// How far to sink a bond cylinder into the atom at each end so the cylinder cap
 /// is hidden. For ball styles the cylinder disappears inside the element-sized
-/// ball; for Stick (and bond-only neighbours) the cylinder runs all the way to
-/// the atom center, where the bond-sized joint node caps it flush — trimming it
-/// back would expose the flat cap as a protruding disc around the small node.
+/// ball; bond-only styles run to the atom center so rounded terminal caps and
+/// topology-dependent joints meet at the actual bond vertex.
 fn bond_trim_radius(element: &str, style: AtomStyle) -> f32 {
     match style {
         AtomStyle::Sphere | AtomStyle::BallAndStick => atom_ball_radius(element),

--- a/src/frontend/viewport/render/ball_stick.rs
+++ b/src/frontend/viewport/render/ball_stick.rs
@@ -14,7 +14,8 @@ use super::scene::{RenderedAtom, RenderedBondSegment, ViewportGeometry};
 use super::{
     AROMATIC_DASH_LENGTH, AROMATIC_DASH_OFFSET, AROMATIC_DASH_RADIUS, AROMATIC_GAP_LENGTH,
     MULTI_BOND_OFFSET, MULTI_BOND_RADIUS, POINT_DISC_SEGMENTS, PrimitiveMeshVertex,
-    PrimitiveTriangle, SINGLE_BOND_RADIUS, ViewportVisualState, atom_marker_radius,
+    PrimitiveTriangle, SINGLE_BOND_RADIUS, STICK_DOUBLE_BOND_OFFSET, STICK_DOUBLE_BOND_RADIUS,
+    STICK_TRIPLE_BOND_OFFSET, STICK_TRIPLE_BOND_RADIUS, ViewportVisualState, atom_marker_radius,
     atom_render_color_with_settings, atom_visible, bond_trim_radius, darken, initial_cartoon_side,
     normalize_vector3,
 };
@@ -31,6 +32,17 @@ struct TrimmedBondSegment {
     axis: Vector3<f32>,
     length: f32,
 }
+
+#[derive(Clone, Copy)]
+struct BondCylinderStyle {
+    start_atom_radius: f32,
+    end_atom_radius: f32,
+    start_color: Color32,
+    end_color: Color32,
+    involves_stick: bool,
+}
+
+const BOND_CAP_BURY_EPSILON: f32 = 0.001;
 
 /// Per-atom drawing inputs resolved once per frame: whether the atom is drawn in
 /// the ball-and-stick scene, its effective [`AtomStyle`], and its render color.
@@ -60,6 +72,39 @@ pub(super) fn build_atom_draw_table(
         .collect()
 }
 
+pub(super) fn effective_stick_degrees(structure: &Structure, atom_draw: &[AtomDraw]) -> Vec<usize> {
+    let mut degrees = vec![0; structure.atoms.len()];
+    for bond in &structure.bonds {
+        if bond.a == bond.b {
+            continue;
+        }
+        let (Some(a), Some(b)) = (atom_draw.get(bond.a), atom_draw.get(bond.b)) else {
+            continue;
+        };
+        if !(a.visible && b.visible)
+            || !(a.style.draws_stick_bonds() || b.style.draws_stick_bonds())
+        {
+            continue;
+        }
+        let (Some(atom_a), Some(atom_b)) =
+            (structure.atoms.get(bond.a), structure.atoms.get(bond.b))
+        else {
+            continue;
+        };
+        let length_squared = (atom_b.position - atom_a.position).norm_squared();
+        if !length_squared.is_finite() || length_squared <= 1e-10 {
+            continue;
+        }
+        if a.style == AtomStyle::Stick {
+            degrees[bond.a] += 1;
+        }
+        if b.style == AtomStyle::Stick {
+            degrees[bond.b] += 1;
+        }
+    }
+    degrees
+}
+
 pub(crate) fn build_ball_and_stick_scene(
     structure: &Structure,
     geometry: &ViewportGeometry,
@@ -68,6 +113,7 @@ pub(crate) fn build_ball_and_stick_scene(
     visual_state: &ViewportVisualState,
 ) -> RenderScene {
     let atom_draw = build_atom_draw_table(structure, selection, visual_state);
+    let stick_degrees = effective_stick_degrees(structure, &atom_draw);
 
     // An atom is drawn when its resolved style places it in the ball-and-stick
     // scene (i.e. not Hidden and not drawn via the cartoon path).
@@ -83,7 +129,7 @@ pub(crate) fn build_ball_and_stick_scene(
     for bond in &geometry.bonds {
         let a = atom_draw[bond.a];
         let b = atom_draw[bond.b];
-        if !(a.visible || b.visible) {
+        if !(a.visible && b.visible) {
             continue;
         }
         if a.style.draws_stick_bonds() || b.style.draws_stick_bonds() {
@@ -91,10 +137,13 @@ pub(crate) fn build_ball_and_stick_scene(
                 &mut opaque_triangles,
                 bond,
                 viewport,
-                bond_trim_radius(&structure.atoms[bond.a].element, a.style),
-                bond_trim_radius(&structure.atoms[bond.b].element, b.style),
-                a.color,
-                b.color,
+                BondCylinderStyle {
+                    start_atom_radius: bond_trim_radius(&structure.atoms[bond.a].element, a.style),
+                    end_atom_radius: bond_trim_radius(&structure.atoms[bond.b].element, b.style),
+                    start_color: a.color,
+                    end_color: b.color,
+                    involves_stick: a.style == AtomStyle::Stick || b.style == AtomStyle::Stick,
+                },
             );
         } else if a.style.draws_line_bonds() || b.style.draws_line_bonds() {
             push_split_bond_line(&mut lines, viewport, bond, structure, a.color, b.color);
@@ -105,12 +154,19 @@ pub(crate) fn build_ball_and_stick_scene(
         let index = atom_projection.index;
         let draw = atom_draw[index];
         let atom = &structure.atoms[index];
-        match atom_marker_radius(&atom.element, draw.style) {
+        let marker_radius = if draw.style == AtomStyle::Stick {
+            (stick_degrees[index] >= 2).then_some(SINGLE_BOND_RADIUS)
+        } else {
+            atom_marker_radius(&atom.element, draw.style)
+        };
+        match marker_radius {
             Some(mut radius) => {
-                if selection.primary() == Some(index) {
-                    radius *= 1.18;
-                } else if selection.contains(index) {
-                    radius *= 1.10;
+                if draw.style != AtomStyle::Stick {
+                    if selection.primary() == Some(index) {
+                        radius *= 1.18;
+                    } else if selection.contains(index) {
+                        radius *= 1.10;
+                    }
                 }
                 append_sphere_triangles(
                     &mut opaque_triangles,
@@ -213,15 +269,58 @@ fn append_atom_point(
     }
 }
 
+fn double_bond_profile(involves_stick: bool) -> (f32, f32) {
+    if involves_stick {
+        (STICK_DOUBLE_BOND_RADIUS, STICK_DOUBLE_BOND_OFFSET)
+    } else {
+        (MULTI_BOND_RADIUS, MULTI_BOND_OFFSET * 0.5)
+    }
+}
+
+fn triple_bond_profile(involves_stick: bool) -> (f32, f32) {
+    if involves_stick {
+        (STICK_TRIPLE_BOND_RADIUS, STICK_TRIPLE_BOND_OFFSET)
+    } else {
+        (MULTI_BOND_RADIUS, MULTI_BOND_OFFSET)
+    }
+}
+
+fn bond_bundle_envelope(bond_type: BondType, involves_stick: bool) -> f32 {
+    match bond_type {
+        BondType::Single => SINGLE_BOND_RADIUS,
+        BondType::Double | BondType::Triple if involves_stick => SINGLE_BOND_RADIUS,
+        BondType::Double => MULTI_BOND_OFFSET * 0.5 + MULTI_BOND_RADIUS,
+        BondType::Triple => MULTI_BOND_OFFSET + MULTI_BOND_RADIUS,
+        BondType::Aromatic => SINGLE_BOND_RADIUS.max(AROMATIC_DASH_OFFSET + AROMATIC_DASH_RADIUS),
+    }
+}
+
+fn embedded_axial_trim(atom_radius: f32, bundle_envelope: f32) -> f32 {
+    let tangent = (atom_radius * atom_radius - bundle_envelope * bundle_envelope)
+        .max(0.0)
+        .sqrt();
+    (tangent - BOND_CAP_BURY_EPSILON).max(0.0)
+}
+
+fn aromatic_dash_centerline(cursor: f32, length: f32) -> Option<(f32, f32)> {
+    let visible_end = (cursor + AROMATIC_DASH_LENGTH).min(length);
+    let centerline_start = cursor + AROMATIC_DASH_RADIUS;
+    let centerline_end = visible_end - AROMATIC_DASH_RADIUS;
+    if centerline_end - centerline_start <= 0.0001 {
+        return None;
+    }
+    Some((centerline_start, centerline_end))
+}
+
 fn append_bond_triangles(
     triangles: &mut Vec<PrimitiveTriangle>,
     bond: &RenderedBondSegment,
     viewport: &Projector,
-    start_trim: f32,
-    end_trim: f32,
-    start_color: Color32,
-    end_color: Color32,
+    style: BondCylinderStyle,
 ) {
+    let bundle_envelope = bond_bundle_envelope(bond.bond_type, style.involves_stick);
+    let start_trim = embedded_axial_trim(style.start_atom_radius, bundle_envelope);
+    let end_trim = embedded_axial_trim(style.end_atom_radius, bundle_envelope);
     let Some(trimmed) = trimmed_bond_segment(bond.start, bond.end, start_trim, end_trim) else {
         return;
     };
@@ -242,15 +341,16 @@ fn append_bond_triangles(
             },
             SplitCylinderStyle {
                 radius: SINGLE_BOND_RADIUS,
-                start_color,
-                end_color,
+                start_color: style.start_color,
+                end_color: style.end_color,
                 orientation_hint: offset_direction,
             },
             split_caps,
         ),
         BondType::Double => {
+            let (radius, offset_distance) = double_bond_profile(style.involves_stick);
             for offset_sign in [-1.0_f32, 1.0] {
-                let offset = offset_direction * (MULTI_BOND_OFFSET * offset_sign * 0.5);
+                let offset = offset_direction * (offset_distance * offset_sign);
                 append_split_cylinder(
                     triangles,
                     viewport,
@@ -259,9 +359,9 @@ fn append_bond_triangles(
                         end: trimmed.end + offset,
                     },
                     SplitCylinderStyle {
-                        radius: MULTI_BOND_RADIUS,
-                        start_color,
-                        end_color,
+                        radius,
+                        start_color: style.start_color,
+                        end_color: style.end_color,
                         orientation_hint: offset_direction,
                     },
                     split_caps,
@@ -269,6 +369,7 @@ fn append_bond_triangles(
             }
         }
         BondType::Triple => {
+            let (radius, offset_distance) = triple_bond_profile(style.involves_stick);
             append_split_cylinder(
                 triangles,
                 viewport,
@@ -277,15 +378,15 @@ fn append_bond_triangles(
                     end: trimmed.end,
                 },
                 SplitCylinderStyle {
-                    radius: MULTI_BOND_RADIUS,
-                    start_color,
-                    end_color,
+                    radius,
+                    start_color: style.start_color,
+                    end_color: style.end_color,
                     orientation_hint: offset_direction,
                 },
                 split_caps,
             );
             for offset_sign in [-1.0_f32, 1.0] {
-                let offset = offset_direction * (MULTI_BOND_OFFSET * offset_sign);
+                let offset = offset_direction * (offset_distance * offset_sign);
                 append_split_cylinder(
                     triangles,
                     viewport,
@@ -294,9 +395,9 @@ fn append_bond_triangles(
                         end: trimmed.end + offset,
                     },
                     SplitCylinderStyle {
-                        radius: MULTI_BOND_RADIUS,
-                        start_color,
-                        end_color,
+                        radius,
+                        start_color: style.start_color,
+                        end_color: style.end_color,
                         orientation_hint: offset_direction,
                     },
                     split_caps,
@@ -313,33 +414,36 @@ fn append_bond_triangles(
                 },
                 SplitCylinderStyle {
                     radius: SINGLE_BOND_RADIUS,
-                    start_color,
-                    end_color,
+                    start_color: style.start_color,
+                    end_color: style.end_color,
                     orientation_hint: offset_direction,
                 },
                 split_caps,
             );
 
-            let dashed_start = trimmed.start + offset_direction * AROMATIC_DASH_OFFSET;
+            let dash_origin = trimmed.start + offset_direction * AROMATIC_DASH_OFFSET;
             let dash_axis = trimmed.axis;
             let mut cursor = 0.0;
             while cursor < trimmed.length {
-                let dash_end = (cursor + AROMATIC_DASH_LENGTH).min(trimmed.length);
-                append_split_cylinder(
-                    triangles,
-                    viewport,
-                    CylinderSpan {
-                        start: dashed_start + dash_axis * cursor,
-                        end: dashed_start + dash_axis * dash_end,
-                    },
-                    SplitCylinderStyle {
-                        radius: AROMATIC_DASH_RADIUS,
-                        start_color,
-                        end_color,
-                        orientation_hint: offset_direction,
-                    },
-                    split_caps,
-                );
+                if let Some((dash_start, dash_end)) =
+                    aromatic_dash_centerline(cursor, trimmed.length)
+                {
+                    append_split_cylinder(
+                        triangles,
+                        viewport,
+                        CylinderSpan {
+                            start: dash_origin + dash_axis * dash_start,
+                            end: dash_origin + dash_axis * dash_end,
+                        },
+                        SplitCylinderStyle {
+                            radius: AROMATIC_DASH_RADIUS,
+                            start_color: style.start_color,
+                            end_color: style.end_color,
+                            orientation_hint: offset_direction,
+                        },
+                        split_caps,
+                    );
+                }
                 cursor += AROMATIC_DASH_LENGTH + AROMATIC_GAP_LENGTH;
             }
         }
@@ -402,7 +506,7 @@ fn bond_offset_direction(
 mod tests {
     use super::super::scene::build_viewport_geometry;
     use super::*;
-    use crate::domain::{Atom, Structure};
+    use crate::domain::{Atom, Bond, Structure};
     use crate::frontend::{AtomSelection, state::AtomStyle};
     use eframe::egui::{Pos2, Rect, Vec2};
     use nalgebra::Point3;
@@ -469,6 +573,42 @@ mod tests {
         visual
     }
 
+    fn assert_close(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() < 1e-6,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    fn stick_bond_triangle_count(bond_type: BondType) -> usize {
+        let structure = Structure::with_bonds(
+            "stick bond",
+            vec![
+                Atom {
+                    element: "C".to_string(),
+                    position: Point3::new(-0.5, 0.0, 0.0),
+                    charge: 0.0,
+                },
+                Atom {
+                    element: "C".to_string(),
+                    position: Point3::new(0.5, 0.0, 0.0),
+                    charge: 0.0,
+                },
+            ],
+            vec![Bond::with_type(0, 1, bond_type)],
+        );
+        let viewport = test_projector();
+        let geometry = build_viewport_geometry(&structure, &viewport);
+        build_ball_and_stick_scene(
+            &structure,
+            &geometry,
+            &viewport,
+            &AtomSelection::default(),
+            &all_atoms_styled(2, AtomStyle::Stick),
+        )
+        .triangle_count()
+    }
+
     #[test]
     fn small_systems_use_full_sphere_meshes() {
         // Spheres are hundreds of triangles each, far above the dots LOD.
@@ -499,6 +639,56 @@ mod tests {
     }
 
     #[test]
+    fn stick_bond_orders_keep_independent_rounded_rods() {
+        let single = stick_bond_triangle_count(BondType::Single);
+        assert!(single > 0);
+        assert_eq!(stick_bond_triangle_count(BondType::Double), single * 2);
+        assert_eq!(stick_bond_triangle_count(BondType::Triple), single * 3);
+        assert_eq!(stick_bond_triangle_count(BondType::Aromatic), single * 4);
+    }
+
+    #[test]
+    fn ball_bond_trims_bury_the_full_bundle_envelope() {
+        let atom_radius = 0.6;
+        for (bond_type, involves_stick) in [
+            (BondType::Single, false),
+            (BondType::Double, true),
+            (BondType::Triple, true),
+            (BondType::Double, false),
+            (BondType::Triple, false),
+            (BondType::Aromatic, false),
+        ] {
+            let envelope = bond_bundle_envelope(bond_type, involves_stick);
+            let trim = embedded_axial_trim(atom_radius, envelope);
+            assert!(trim * trim + envelope * envelope < atom_radius * atom_radius);
+            let tangent = (atom_radius * atom_radius - envelope * envelope)
+                .max(0.0)
+                .sqrt();
+            assert_close(trim, tangent - BOND_CAP_BURY_EPSILON);
+        }
+
+        assert_eq!(
+            embedded_axial_trim(AROMATIC_DASH_RADIUS, SINGLE_BOND_RADIUS),
+            0.0
+        );
+    }
+
+    #[test]
+    fn aromatic_dash_centerlines_preserve_visible_length_and_gap() {
+        let first = aromatic_dash_centerline(0.0, 1.0).expect("first dash");
+        let pitch = AROMATIC_DASH_LENGTH + AROMATIC_GAP_LENGTH;
+        let second = aromatic_dash_centerline(pitch, 1.0).expect("second dash");
+
+        assert_close(first.0 - AROMATIC_DASH_RADIUS, 0.0);
+        assert_close(first.1 + AROMATIC_DASH_RADIUS, AROMATIC_DASH_LENGTH);
+        assert_close(
+            second.0 - AROMATIC_DASH_RADIUS - (first.1 + AROMATIC_DASH_RADIUS),
+            AROMATIC_GAP_LENGTH,
+        );
+        assert!(aromatic_dash_centerline(0.8, 0.8 + AROMATIC_DASH_RADIUS * 2.0).is_none());
+    }
+
+    #[test]
     fn apply_atom_styles_stays_sparse_against_category_default() {
         // Grid atoms have no residue → category Other → software default
         // BallAndStick.
@@ -514,7 +704,6 @@ mod tests {
 
     #[test]
     fn wireframe_bond_splits_into_two_atom_colors() {
-        use crate::domain::{Bond, BondType};
         // An O–H bond drawn as wireframe must split into two half-segments — one
         // O-colored, one H-colored — so H–O–H reads as a colored V, not a single
         // line that looks like O–O–O.

--- a/src/frontend/viewport/render/ball_stick/solids.rs
+++ b/src/frontend/viewport/render/ball_stick/solids.rs
@@ -169,8 +169,98 @@ fn append_cylinder_triangles(
         ));
     }
 
-    for index in 0..BOND_RADIAL_SEGMENTS {
-        let next_index = (index + 1) % BOND_RADIAL_SEGMENTS;
+    append_ring_strip(triangles, &start_ring, &end_ring);
+
+    if caps.start {
+        append_hemisphere_cap(
+            triangles,
+            viewport,
+            span.start,
+            -axis,
+            side,
+            normal,
+            style.radius,
+            &start_ring,
+            style.color,
+        );
+    }
+    if caps.end {
+        append_hemisphere_cap(
+            triangles,
+            viewport,
+            span.end,
+            axis,
+            side,
+            normal,
+            style.radius,
+            &end_ring,
+            style.color,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_hemisphere_cap(
+    triangles: &mut Vec<PrimitiveTriangle>,
+    viewport: &Projector,
+    center: Point3<f32>,
+    outward_axis: Vector3<f32>,
+    side: Vector3<f32>,
+    cylinder_normal: Vector3<f32>,
+    radius: f32,
+    equator_ring: &[PrimitiveMeshVertex],
+    color: Color32,
+) {
+    let shade = surface_shade(color);
+    let latitude_segments = SPHERE_LATITUDE_SEGMENTS.div_ceil(2);
+    let mut previous_ring = equator_ring.to_vec();
+
+    for latitude in 1..latitude_segments {
+        let polar = std::f32::consts::FRAC_PI_2 * latitude as f32 / latitude_segments as f32;
+        let (axial, radial_scale) = polar.sin_cos();
+        let mut ring = Vec::with_capacity(BOND_RADIAL_SEGMENTS);
+
+        for index in 0..BOND_RADIAL_SEGMENTS {
+            let angle = TAU * index as f32 / BOND_RADIAL_SEGMENTS as f32;
+            let (sin_angle, cos_angle) = angle.sin_cos();
+            let radial = side * cos_angle + cylinder_normal * sin_angle;
+            let surface_normal = radial * radial_scale + outward_axis * axial;
+            ring.push(primitive_vertex(
+                viewport,
+                center + surface_normal * radius,
+                surface_normal,
+                shade,
+            ));
+        }
+
+        append_ring_strip(triangles, &previous_ring, &ring);
+        previous_ring = ring;
+    }
+
+    let pole = primitive_vertex(
+        viewport,
+        center + outward_axis * radius,
+        outward_axis,
+        shade,
+    );
+    for index in 0..previous_ring.len() {
+        let next_index = (index + 1) % previous_ring.len();
+        triangles.push(primitive_triangle(
+            previous_ring[index],
+            pole,
+            previous_ring[next_index],
+        ));
+    }
+}
+
+fn append_ring_strip(
+    triangles: &mut Vec<PrimitiveTriangle>,
+    start_ring: &[PrimitiveMeshVertex],
+    end_ring: &[PrimitiveMeshVertex],
+) {
+    debug_assert_eq!(start_ring.len(), end_ring.len());
+    for index in 0..start_ring.len() {
+        let next_index = (index + 1) % start_ring.len();
         triangles.push(primitive_triangle(
             start_ring[index],
             end_ring[index],
@@ -180,40 +270,6 @@ fn append_cylinder_triangles(
             start_ring[index],
             end_ring[next_index],
             start_ring[next_index],
-        ));
-    }
-
-    if caps.start {
-        append_cylinder_cap(
-            triangles,
-            viewport,
-            span.start,
-            -axis,
-            &start_ring,
-            style.color,
-        );
-    }
-    if caps.end {
-        append_cylinder_cap(triangles, viewport, span.end, axis, &end_ring, style.color);
-    }
-}
-
-fn append_cylinder_cap(
-    triangles: &mut Vec<PrimitiveTriangle>,
-    viewport: &Projector,
-    center: Point3<f32>,
-    normal: Vector3<f32>,
-    ring: &[PrimitiveMeshVertex],
-    color: Color32,
-) {
-    let center_vertex =
-        primitive_vertex(viewport, center, normal, surface_shade(darken(color, 0.06)));
-    for index in 0..ring.len() {
-        let next_index = (index + 1) % ring.len();
-        triangles.push(primitive_triangle(
-            center_vertex,
-            ring[next_index],
-            ring[index],
         ));
     }
 }
@@ -288,4 +344,89 @@ fn shade_surface_color(
     };
 
     mix_color(shaded, PAPER_TINT, soft_highlight)
+}
+
+#[cfg(test)]
+mod tests {
+    use eframe::egui::{Pos2, Rect, Vec2};
+
+    use super::*;
+
+    fn projector() -> Projector {
+        Projector::new(
+            Rect::from_min_size(Pos2::ZERO, Vec2::splat(400.0)),
+            Point3::origin(),
+            100.0,
+            1_000.0,
+            0.0,
+            0.0,
+            Vec2::ZERO,
+        )
+    }
+
+    fn cylinder(caps: CylinderCaps) -> Vec<PrimitiveTriangle> {
+        let mut triangles = Vec::new();
+        append_cylinder_triangles(
+            &mut triangles,
+            &projector(),
+            CylinderSpan {
+                start: Point3::new(-1.0, 0.0, 0.0),
+                end: Point3::new(1.0, 0.0, 0.0),
+            },
+            CylinderStyle {
+                radius: 0.25,
+                color: Color32::WHITE,
+                orientation_hint: Vector3::y(),
+            },
+            caps,
+        );
+        triangles
+    }
+
+    fn x_extent(triangles: &[PrimitiveTriangle]) -> (f32, f32) {
+        triangles
+            .iter()
+            .flat_map(|triangle| triangle.vertices.iter())
+            .map(|vertex| vertex.pos.x)
+            .fold((f32::INFINITY, f32::NEG_INFINITY), |(min, max), x| {
+                (min.min(x), max.max(x))
+            })
+    }
+
+    #[test]
+    fn cylinder_caps_add_hemispheres_independently() {
+        let open = cylinder(CylinderCaps {
+            start: false,
+            end: false,
+        });
+        let start = cylinder(CylinderCaps {
+            start: true,
+            end: false,
+        });
+        let end = cylinder(CylinderCaps {
+            start: false,
+            end: true,
+        });
+
+        let latitude_segments = SPHERE_LATITUDE_SEGMENTS.div_ceil(2);
+        let hemisphere_triangles = ((latitude_segments - 1) * 2 + 1) * BOND_RADIAL_SEGMENTS;
+        assert_eq!(
+            start.len() - open.len(),
+            hemisphere_triangles,
+            "the start cap must be a tessellated hemisphere"
+        );
+        assert_eq!(
+            end.len() - open.len(),
+            hemisphere_triangles,
+            "the end cap must be a tessellated hemisphere"
+        );
+
+        let (open_min, open_max) = x_extent(&open);
+        let (start_min, start_max) = x_extent(&start);
+        let (end_min, end_max) = x_extent(&end);
+        assert!(start_min < open_min - 24.0);
+        assert!((start_max - open_max).abs() < 0.1);
+        assert!((end_min - open_min).abs() < 0.1);
+        assert!(end_max > open_max + 24.0);
+    }
 }

--- a/src/frontend/viewport/render/instances.rs
+++ b/src/frontend/viewport/render/instances.rs
@@ -16,15 +16,18 @@ use crate::{
 };
 
 use super::super::gpu::{CylinderInstance, MeshVertex, MoleculeInstances, SphereInstance};
-use super::ball_stick::build_atom_draw_table;
+#[cfg(test)]
+use super::STICK_MULTI_BOND_GAP;
+use super::ball_stick::{build_atom_draw_table, effective_stick_degrees};
 #[cfg(test)]
 use super::cartoon::build_biopolymer_cartoon_world_mesh;
 use super::cartoon::build_cached_biopolymer_cartoon_world_mesh;
 use super::scene::{BondWorldSegment, bond_world_segments};
 use super::{
     AROMATIC_DASH_LENGTH, AROMATIC_DASH_OFFSET, AROMATIC_DASH_RADIUS, AROMATIC_GAP_LENGTH,
-    MULTI_BOND_OFFSET, MULTI_BOND_RADIUS, SINGLE_BOND_RADIUS, WIREFRAME_BOND_RADIUS,
-    atom_ball_radius, atom_marker_radius,
+    MULTI_BOND_OFFSET, MULTI_BOND_RADIUS, SINGLE_BOND_RADIUS, STICK_DOUBLE_BOND_OFFSET,
+    STICK_DOUBLE_BOND_RADIUS, STICK_TRIPLE_BOND_OFFSET, STICK_TRIPLE_BOND_RADIUS,
+    WIREFRAME_BOND_RADIUS, atom_ball_radius, atom_marker_radius,
 };
 
 /// World radius (relative to the full ball-and-stick radius) used to draw atoms
@@ -65,13 +68,19 @@ fn build_molecule_instances_with_cartoon(
     cartoon: Vec<MeshVertex>,
 ) -> MoleculeInstances {
     let atom_draw = build_atom_draw_table(structure, selection, visual_state);
+    let stick_degrees = effective_stick_degrees(structure, &atom_draw);
 
     let mut spheres = Vec::new();
     for (index, draw) in atom_draw.iter().enumerate() {
         if !draw.visible {
             continue;
         }
-        if let Some(radius) = sphere_radius(structure, index, draw.style, selection) {
+        let radius = if draw.style == AtomStyle::Stick {
+            (stick_degrees[index] >= 2).then_some(SINGLE_BOND_RADIUS)
+        } else {
+            sphere_radius(structure, index, draw.style, selection)
+        };
+        if let Some(radius) = radius {
             let position = structure.atoms[index].position;
             spheres.push(SphereInstance {
                 pos_radius: [position.x, position.y, position.z, radius],
@@ -85,7 +94,7 @@ fn build_molecule_instances_with_cartoon(
     for segment in bond_world_segments(structure) {
         let start = atom_draw[segment.start_atom];
         let end = atom_draw[segment.end_atom];
-        if !(start.visible || end.visible) {
+        if !(start.visible && end.visible) {
             continue;
         }
         if start.style.draws_stick_bonds() || end.style.draws_stick_bonds() {
@@ -96,6 +105,7 @@ fn build_molecule_instances_with_cartoon(
                 &segment,
                 start.color,
                 end.color,
+                start.style == AtomStyle::Stick || end.style == AtomStyle::Stick,
             );
         } else if start.style.draws_line_bonds() || end.style.draws_line_bonds() {
             append_wireframe_bond(&mut cylinders, &segment, start.color, end.color);
@@ -153,6 +163,7 @@ fn append_bond_cylinders(
     segment: &BondWorldSegment,
     color_a: Color32,
     color_b: Color32,
+    involves_stick: bool,
 ) {
     let (start, end) = (segment.start, segment.end);
     let mut push = |s: Point3<f32>, e: Point3<f32>, radius: f32, ca: Color32, cb: Color32| {
@@ -170,29 +181,27 @@ fn append_bond_cylinders(
         BondType::Single => push(start, end, SINGLE_BOND_RADIUS, color_a, color_b),
         BondType::Double => {
             let offset = bond_offset_direction(structure, adjacency, segment);
+            let (radius, bond_offset) = if involves_stick {
+                (STICK_DOUBLE_BOND_RADIUS, STICK_DOUBLE_BOND_OFFSET)
+            } else {
+                (MULTI_BOND_RADIUS, MULTI_BOND_OFFSET * 0.5)
+            };
             for sign in [-1.0_f32, 1.0] {
-                let shift = offset * (MULTI_BOND_OFFSET * 0.5 * sign);
-                push(
-                    start + shift,
-                    end + shift,
-                    MULTI_BOND_RADIUS,
-                    color_a,
-                    color_b,
-                );
+                let shift = offset * (bond_offset * sign);
+                push(start + shift, end + shift, radius, color_a, color_b);
             }
         }
         BondType::Triple => {
-            push(start, end, MULTI_BOND_RADIUS, color_a, color_b);
+            let (radius, bond_offset) = if involves_stick {
+                (STICK_TRIPLE_BOND_RADIUS, STICK_TRIPLE_BOND_OFFSET)
+            } else {
+                (MULTI_BOND_RADIUS, MULTI_BOND_OFFSET)
+            };
+            push(start, end, radius, color_a, color_b);
             let offset = bond_offset_direction(structure, adjacency, segment);
             for sign in [-1.0_f32, 1.0] {
-                let shift = offset * (MULTI_BOND_OFFSET * sign);
-                push(
-                    start + shift,
-                    end + shift,
-                    MULTI_BOND_RADIUS,
-                    color_a,
-                    color_b,
-                );
+                let shift = offset * (bond_offset * sign);
+                push(start + shift, end + shift, radius, color_a, color_b);
             }
         }
         BondType::Aromatic => {
@@ -221,19 +230,21 @@ fn append_aromatic_dashes(
     let mut cursor = 0.0;
     while cursor < length {
         let dash_end = (cursor + AROMATIC_DASH_LENGTH).min(length);
-        let color = if (cursor + dash_end) * 0.5 < length * 0.5 {
-            color_a
-        } else {
-            color_b
-        };
-        if let Some(cylinder) = cylinder_instance(
-            dash_origin + axis * cursor,
-            dash_origin + axis * dash_end,
-            AROMATIC_DASH_RADIUS,
-            color,
-            color,
-        ) {
-            cylinders.push(cylinder);
+        if dash_end - cursor > AROMATIC_DASH_RADIUS * 2.0 {
+            let color = if (cursor + dash_end) * 0.5 < length * 0.5 {
+                color_a
+            } else {
+                color_b
+            };
+            if let Some(cylinder) = cylinder_instance(
+                dash_origin + axis * (cursor + AROMATIC_DASH_RADIUS),
+                dash_origin + axis * (dash_end - AROMATIC_DASH_RADIUS),
+                AROMATIC_DASH_RADIUS,
+                color,
+                color,
+            ) {
+                cylinders.push(cylinder);
+            }
         }
         cursor += AROMATIC_DASH_LENGTH + AROMATIC_GAP_LENGTH;
     }
@@ -338,8 +349,14 @@ mod tests {
     use crate::domain::{Atom, Bond, BondType, Structure};
     use nalgebra::Point3;
 
-    /// Two carbons bonded along x, both forced to `style`.
     fn bonded_pair(style: AtomStyle) -> (Structure, ViewportVisualState) {
+        bonded_pair_with_type(style, BondType::Single)
+    }
+
+    fn bonded_pair_with_type(
+        style: AtomStyle,
+        bond_type: BondType,
+    ) -> (Structure, ViewportVisualState) {
         let structure = Structure::with_bonds(
             "pair",
             vec![
@@ -354,12 +371,69 @@ mod tests {
                     charge: 0.0,
                 },
             ],
-            vec![Bond::with_type(0, 1, BondType::Single)],
+            vec![Bond::with_type(0, 1, bond_type)],
         );
         let mut visual = ViewportVisualState::default();
         visual.atom_styles.insert(0, style);
         visual.atom_styles.insert(1, style);
         (structure, visual)
+    }
+
+    fn stick_chain(bond_type: BondType) -> (Structure, ViewportVisualState) {
+        let structure = Structure::with_bonds(
+            "chain",
+            vec![
+                Atom {
+                    element: "C".to_string(),
+                    position: Point3::new(0.0, 0.0, 0.0),
+                    charge: 0.0,
+                },
+                Atom {
+                    element: "C".to_string(),
+                    position: Point3::new(1.5, 0.0, 0.0),
+                    charge: 0.0,
+                },
+                Atom {
+                    element: "C".to_string(),
+                    position: Point3::new(3.0, 0.0, 0.0),
+                    charge: 0.0,
+                },
+            ],
+            vec![
+                Bond::with_type(0, 1, bond_type),
+                Bond::with_type(1, 2, bond_type),
+            ],
+        );
+        let mut visual = ViewportVisualState::default();
+        for index in 0..structure.atoms.len() {
+            visual.atom_styles.insert(index, AtomStyle::Stick);
+        }
+        (structure, visual)
+    }
+
+    fn cylinder_start_distance(a: &CylinderInstance, b: &CylinderInstance) -> f32 {
+        let delta = Vector3::new(
+            a.start_len[0] - b.start_len[0],
+            a.start_len[1] - b.start_len[1],
+            a.start_len[2] - b.start_len[2],
+        );
+        delta.norm()
+    }
+
+    fn cylinder_start_offset(cylinder: &CylinderInstance) -> f32 {
+        Vector3::new(
+            cylinder.start_len[0],
+            cylinder.start_len[1],
+            cylinder.start_len[2],
+        )
+        .norm()
+    }
+
+    fn assert_close(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() < 1e-6,
+            "expected {expected}, got {actual}"
+        );
     }
 
     #[test]
@@ -375,17 +449,173 @@ mod tests {
     }
 
     #[test]
-    fn stick_joint_matches_its_bond_radius() {
-        // The joint node must be exactly as thick as the bond so a stick chain
-        // reads as one smooth tube, not a string of beads at every atom.
+    fn stick_pair_uses_terminal_caps_without_atom_spheres() {
         let (structure, visual) = bonded_pair(AtomStyle::Stick);
         let instances = build_molecule_instances(&structure, &AtomSelection::default(), &visual);
-        assert_eq!(instances.spheres.len(), 2, "each atom caps its bond");
-        for sphere in &instances.spheres {
-            assert_eq!(sphere.pos_radius[3], SINGLE_BOND_RADIUS);
-        }
+        assert!(instances.spheres.is_empty());
         assert_eq!(instances.cylinders.len(), 1);
         assert_eq!(instances.cylinders[0].axis_radius[3], SINGLE_BOND_RADIUS);
+    }
+
+    #[test]
+    fn stick_chain_emits_only_one_internal_joint() {
+        let (structure, visual) = stick_chain(BondType::Single);
+        let instances = build_molecule_instances(&structure, &AtomSelection::default(), &visual);
+        assert_eq!(instances.spheres.len(), 1);
+        assert_eq!(
+            instances.spheres[0].pos_radius,
+            [1.5, 0.0, 0.0, SINGLE_BOND_RADIUS]
+        );
+        assert_eq!(instances.cylinders.len(), 2);
+    }
+
+    #[test]
+    fn selecting_stick_joint_does_not_change_its_radius() {
+        let (structure, visual) = stick_chain(BondType::Single);
+        let mut selection = AtomSelection::default();
+        selection.select_only(1);
+        let instances = build_molecule_instances(&structure, &selection, &visual);
+        assert_eq!(instances.spheres.len(), 1);
+        assert_eq!(instances.spheres[0].pos_radius[3], SINGLE_BOND_RADIUS);
+    }
+
+    #[test]
+    fn stick_double_bond_emits_two_parallel_rods() {
+        let (structure, visual) = bonded_pair_with_type(AtomStyle::Stick, BondType::Double);
+        let instances = build_molecule_instances(&structure, &AtomSelection::default(), &visual);
+        assert!(instances.spheres.is_empty());
+        assert_eq!(instances.cylinders.len(), 2);
+        assert_ne!(
+            instances.cylinders[0].start_len,
+            instances.cylinders[1].start_len
+        );
+        for cylinder in &instances.cylinders {
+            assert_eq!(
+                cylinder.axis_radius,
+                [1.0, 0.0, 0.0, STICK_DOUBLE_BOND_RADIUS]
+            );
+            let offset = cylinder_start_offset(cylinder);
+            assert_close(offset + STICK_DOUBLE_BOND_RADIUS, SINGLE_BOND_RADIUS);
+        }
+        let center_distance =
+            cylinder_start_distance(&instances.cylinders[0], &instances.cylinders[1]);
+        assert_close(
+            center_distance - 2.0 * STICK_DOUBLE_BOND_RADIUS,
+            STICK_MULTI_BOND_GAP,
+        );
+    }
+
+    #[test]
+    fn stick_triple_bond_emits_center_and_two_parallel_side_rods() {
+        let (structure, visual) = bonded_pair_with_type(AtomStyle::Stick, BondType::Triple);
+        let instances = build_molecule_instances(&structure, &AtomSelection::default(), &visual);
+        assert!(instances.spheres.is_empty());
+        assert_eq!(instances.cylinders.len(), 3);
+        assert_eq!(instances.cylinders[0].start_len, [0.0, 0.0, 0.0, 1.5]);
+        for cylinder in &instances.cylinders {
+            assert_eq!(
+                cylinder.axis_radius,
+                [1.0, 0.0, 0.0, STICK_TRIPLE_BOND_RADIUS]
+            );
+        }
+        for side in &instances.cylinders[1..] {
+            let center_distance = cylinder_start_distance(&instances.cylinders[0], side);
+            assert_close(
+                center_distance + STICK_TRIPLE_BOND_RADIUS,
+                SINGLE_BOND_RADIUS,
+            );
+            assert_close(
+                center_distance - 2.0 * STICK_TRIPLE_BOND_RADIUS,
+                STICK_MULTI_BOND_GAP,
+            );
+        }
+    }
+
+    #[test]
+    fn stick_aromatic_bond_emits_full_rod_and_parallel_dashes() {
+        let (structure, visual) = bonded_pair_with_type(AtomStyle::Stick, BondType::Aromatic);
+        let instances = build_molecule_instances(&structure, &AtomSelection::default(), &visual);
+        assert!(instances.spheres.is_empty());
+        assert_eq!(instances.cylinders.len(), 5);
+        assert_eq!(
+            instances.cylinders[0].axis_radius,
+            [1.0, 0.0, 0.0, SINGLE_BOND_RADIUS]
+        );
+        let dashes = &instances.cylinders[1..];
+        for dash in dashes {
+            assert_eq!(dash.axis_radius, [1.0, 0.0, 0.0, AROMATIC_DASH_RADIUS]);
+        }
+        let surface_intervals = dashes
+            .iter()
+            .map(|dash| {
+                (
+                    dash.start_len[0] - AROMATIC_DASH_RADIUS,
+                    dash.start_len[0] + dash.start_len[3] + AROMATIC_DASH_RADIUS,
+                )
+            })
+            .collect::<Vec<_>>();
+        for intervals in surface_intervals.windows(2) {
+            assert_close(intervals[1].0 - intervals[0].1, AROMATIC_GAP_LENGTH);
+        }
+        assert!(surface_intervals[0].0 >= -1e-6);
+        assert!(surface_intervals.last().unwrap().1 <= 1.5 + 1e-6);
+
+        let (mut short_structure, short_visual) =
+            bonded_pair_with_type(AtomStyle::Stick, BondType::Aromatic);
+        short_structure.atoms[1].position.x = 1.3;
+        let short_instances =
+            build_molecule_instances(&short_structure, &AtomSelection::default(), &short_visual);
+        assert_eq!(short_instances.cylinders.len(), 4);
+    }
+
+    #[test]
+    fn mixed_stick_double_bond_also_emits_two_parallel_rods() {
+        let (structure, mut visual) = bonded_pair_with_type(AtomStyle::Stick, BondType::Double);
+        visual.atom_styles.insert(1, AtomStyle::BallAndStick);
+        let instances = build_molecule_instances(&structure, &AtomSelection::default(), &visual);
+        assert_eq!(instances.spheres.len(), 1);
+        assert_eq!(instances.cylinders.len(), 2);
+        for cylinder in &instances.cylinders {
+            assert_eq!(cylinder.axis_radius[3], STICK_DOUBLE_BOND_RADIUS);
+            assert_close(cylinder_start_offset(cylinder), STICK_DOUBLE_BOND_OFFSET);
+        }
+    }
+
+    #[test]
+    fn ball_and_stick_preserves_legacy_multiple_bond_profile() {
+        let (double_structure, double_visual) =
+            bonded_pair_with_type(AtomStyle::BallAndStick, BondType::Double);
+        let double_instances =
+            build_molecule_instances(&double_structure, &AtomSelection::default(), &double_visual);
+        assert_eq!(double_instances.cylinders.len(), 2);
+        for cylinder in &double_instances.cylinders {
+            assert_eq!(cylinder.axis_radius[3], MULTI_BOND_RADIUS);
+            assert_close(cylinder_start_offset(cylinder), MULTI_BOND_OFFSET * 0.5);
+        }
+
+        let (triple_structure, triple_visual) =
+            bonded_pair_with_type(AtomStyle::BallAndStick, BondType::Triple);
+        let triple_instances =
+            build_molecule_instances(&triple_structure, &AtomSelection::default(), &triple_visual);
+        assert_eq!(triple_instances.cylinders.len(), 3);
+        assert_eq!(
+            triple_instances.cylinders[0].axis_radius[3],
+            MULTI_BOND_RADIUS
+        );
+        assert_close(cylinder_start_offset(&triple_instances.cylinders[0]), 0.0);
+        for side in &triple_instances.cylinders[1..] {
+            assert_eq!(side.axis_radius[3], MULTI_BOND_RADIUS);
+            assert_close(cylinder_start_offset(side), MULTI_BOND_OFFSET);
+        }
+    }
+
+    #[test]
+    fn hidden_endpoint_removes_the_entire_stick_bond() {
+        let (structure, mut visual) = bonded_pair(AtomStyle::Stick);
+        visual.set_atoms_hidden([1], true);
+        let instances = build_molecule_instances(&structure, &AtomSelection::default(), &visual);
+        assert!(instances.spheres.is_empty());
+        assert!(instances.cylinders.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace open or flat bond cylinders with rounded capsule geometry in both viewport paths
- remove terminal Stick atom spheres and emit fixed-radius joints only at connected internal atoms
- render Stick double and triple bonds as independent parallel rods within a single-bond-width
envelope
- preserve the existing Ball-and-Stick multiple-bond profile
- bury rounded bond caps inside ball-style atoms and preserve aromatic dash length and spacing
- remove bonds whose endpoints are hidden and include atom visibility in GPU instance caching

## Implementation

- tessellate hemisphere caps with continuous normals for CPU and GPU rendering
- increase GPU capsule radial resolution and split hetero-atom colors at the bond midpoint
- derive Stick joints from effective visible bond topology
- keep selection highlighting from changing Stick joint geometry
- add regression coverage for capsule geometry, topology joints, multiple-bond envelopes, aromatic
gaps, hidden endpoints, and legacy profiles

## Validation

- `cargo pr-check`
- manual GUI verification confirmed rounded terminals, continuous joints, and compact double and
triple bond bundles