### PR TITLE
docs: repair and validate repository documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,15 +77,24 @@ jobs:
   static-checks:
     name: Static checks
     needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
         with:
           components: rustfmt
+          linux-deps: ${{ needs.changes.outputs.code }}
+          cache: 'true'
+      - name: Validate repository documentation
+        run: cargo xtask check-docs
       - name: Format
         run: cargo fmt --all --check
+
+      - name: Build public Rust API documentation
+        if: needs.changes.outputs.code == 'true'
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --workspace --no-deps --all-features
 
       # Scope to the musl target (drops host-only pure-Rust bindings) and to the
       # worker's own subgraph. cc is the canonical native-build signal.

--- a/.rules
+++ b/.rules
@@ -15,19 +15,19 @@ Keep these rules short, practical, and focused on the invariants that are expens
 
 * Before adding a new command, action, engine setting, or persistence path, search for the existing pattern and extend it instead of creating a parallel path. `docs/adding-a-feature.md` maps each feature archetype to the module to mirror and the sites to touch.
 * A new structure IO format touches four sites: `io/structure_format.rs`, `io/structure_codec.rs`, `io/formats/mod.rs`, and `io/structure_paths.rs::READABLE_EXTENSIONS` — the last is a plain array, so the compiler will NOT flag it if you forget it.
-* The GUI and CLI share the same `.sls` command definitions in `src/frontend/console.rs`. Add or change a script command once there; do not create separate GUI-only and CLI-only implementations.
-* Higher layers may depend on lower layers only; lower layers must not import or call higher layers. The compute stack lives in the `compute-core` crate; the GUI app (`silicolab`) and the headless worker both depend on it. Layer order, lowest to highest:
+* The GUI and CLI share the `.sls` grammar in `src/frontend/console/grammar.rs`. Add or change a script command once there; do not create separate GUI-only and CLI-only implementations.
+* The compute stack lives in the `compute-core` crate; the GUI app (`silicolab`) and the headless worker both depend on it. Within `compute-core`, higher layers may depend on lower layers only. Layer order, lowest to highest:
 
   ```text
   compute-core:  domain/ <- io/ <- md/ <- engines/ <- workflows/
-  silicolab:     backend/ <- frontend/   (the app crate; depends on compute-core)
+  silicolab:     backend/ + frontend/    (the app crate; depends on compute-core)
   ```
 
   `md/` is the engine-neutral molecular-dynamics model (system building, topology, solvation, force fields, the stage/parameter model, recommendations) that both the MD engines and the MD workflow build on — so it sits below `engines/`. The engine-coupling step (translating that model into an engine stage chain) is the one MD piece that stays in `workflows/molecular_dynamics/protocol.rs`. Do not import `workflows/` from `engines/`; reach for `md/` instead.
 
   `compute-core` also holds the remote-host descriptor (`hosts`), the serializable `payload` bridge, and the engine-job `wire` contract, and carries no GUI dependencies so the headless worker can link it alone.
 
-* Put code in the lowest layer that can own it. Lower layers should not depend on higher layers; `domain/` should stay free of UI and IO.
+* Put code in the lowest layer that can own it. `domain/` must stay free of UI and IO. The app's persistence code currently serializes a small set of frontend-owned view DTOs; do not expand that seam, and put new shared DTOs below both users when practical.
 * Projects are directories of SQLite databases. Do not introduce a separate single-file project format without an ADR, issue, or documented design note.
 * Keep generated project data backward-compatible unless there is an explicit migration path.
 * Prefer structured parsing and serialization for project files and command definitions. Avoid ad hoc string parsing when an existing parser or data model owns the format.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,7 +5,7 @@ materials modeling. It is split into three crates:
 
 - **`silicolab`** (repository root, `src/`) — the desktop application: an
   egui/wgpu GUI and a headless CLI, both driven by the same `.sls` scripting
-  language defined in `src/frontend/console.rs`.
+  language defined in `src/frontend/console/grammar.rs`.
 - **`compute-core`** (`compute-core/`) — the compute stack (domain model, IO,
   engines, workflows) plus the remote-host descriptor, the serializable payload
   bridge, and the engine-job wire contract. It carries **no GUI dependencies**.
@@ -13,7 +13,7 @@ materials modeling. It is split into three crates:
   self-contained static musl binary deployed to a remote host on first use. It
   links `compute-core` alone.
 
-A script command is defined **once** in `console.rs` and is then available in
+A script command is defined **once** in `console/grammar.rs` and is then available in
 both the GUI console and the CLI. When you add or change a command, you do not
 wire it up twice — keep that single definition the source of truth so the two
 front-ends can never drift apart.
@@ -33,9 +33,9 @@ which is what makes the dual-front-end guarantee above hold.
 
 ## Module layers
 
-Code is organized as a one-directional stack; a lower layer never depends on a
-higher one. The stack spans two crates — the GUI app depends on `compute-core`,
-never the reverse:
+The compute stack is organized as a one-directional stack; a lower compute
+layer never depends on a higher one. The GUI app and worker depend on
+`compute-core`, never the reverse:
 
 ```
 compute-core crate (no GUI deps):
@@ -50,29 +50,37 @@ compute-core crate (no GUI deps):
      wire         engine-job request/outcome contract)
 
 silicolab crate (depends on compute-core):
-    → backend/   persistence (SQLite projects, config, secrets)
-    → frontend/  egui / wgpu, the .sls console, the dispatcher
+  backend/    persistence (SQLite projects, config, secrets)
+  frontend/   egui / wgpu, the .sls console, the dispatcher
 
 silicolab-compute crate (depends on compute-core):
     the headless worker that runs wire requests on a remote host
 ```
 
-**Why:** keeping `domain/` free of UI and IO — and `compute-core` free of GUI
+**Why:** keeping `domain/` free of UI and IO - and `compute-core` free of GUI
 deps entirely — makes the core data model testable, reusable by both front-ends,
 and linkable by the headless worker alone. The strict direction prevents
 dependency cycles and keeps compute and persistence independent of rendering.
 When adding code, put it in the lowest layer (and lowest crate) that can own it,
 and don't reach upward.
 
-## GUI data flow: single direction, single mutator
+The app crate is not a strict `backend <- frontend` stack today. Persistence
+serializes a small set of frontend-owned view DTOs such as `AtomSelection` and
+`ViewportVisualState`. Treat that as an explicit compatibility seam, not a
+general permission for backend code to call UI behavior. New shared persisted
+DTOs should live below both users when practical; do not expand the seam merely
+for convenience.
+
+## GUI data flow: persisted changes through actions
 
 The GUI is an Elm-style loop:
 
-- UI code under `frontend/ui/` is **pure rendering**. It reads `AppState` and
-  emits `AppAction`s (`frontend/actions.rs`). It never mutates application state.
-- **Only `dispatcher.rs::dispatch` mutates `AppState`.**
+- UI code under `frontend/ui/` reads `AppState` and emits `AppAction`s
+  (`frontend/actions.rs`) for persisted or undoable workspace changes.
+- `frontend/dispatcher/mod.rs::dispatch` is the entry point for those semantic
+  state transitions.
 - A new GUI operation = add an `AppAction` variant → handle it in
-  `dispatcher.rs` → emit it from the widget.
+  `dispatcher/mod.rs` → emit it from the widget.
 
 **Why:** funneling every state change through one function gives a single,
 auditable place where state transitions happen. That is what makes undo/replay,
@@ -82,23 +90,25 @@ code and impossible to track.
 
 ### Exception: transient render state
 
-There is one deliberate, narrow exception for **transient/derived render
-state** — fields that are:
+Direct UI mutation is reserved for **transient/derived render state** - fields
+that are:
 
 1. recomputed every frame from other state or from system queries,
 2. never persisted, and
 3. never subject to undo or replay.
 
-Such fields may be written directly in the app loop (`app.rs`) or in the
-rendering pass itself, bypassing `AppAction → dispatch`.
+Such fields may be written directly in the app loop (`app.rs`) or rendering
+pass, bypassing `AppAction → dispatch`. Local widget state, modal drafts, focus
+flags, selection gestures, and background-job handles follow the same rule when
+they are neither persisted workspace data nor undoable semantic changes.
 
 Current example: `UiState::glass_active`, derived each frame from `config.glass`
 plus an OS accessibility check.
 
-Everything else is **persisted application state** and must go through
+Persisted or undoable workspace state must go through
 `AppAction → dispatch`. Before adding a field to this exception, confirm all
-three criteria hold: pure derivation, frame-scoped, no semantic history. When in
-doubt, route it through dispatch.
+three criteria hold, or that it is an explicitly transient UI/job handle with no
+semantic history. When in doubt, route it through dispatch.
 
 **Why this distinction is first-class:** the line between "derived render state"
 and "persisted application state" is the most load-bearing decision in the GUI,
@@ -125,9 +135,10 @@ dispatcher.
 
 ## Engine discovery is performance-sensitive
 
-`registry.rs::probe()` is cheap: it only checks `PATH` and configured overrides
-and spawns no subprocess. `detect_versions()` and `probe_with_versions()` are
-**slow** — they run each engine's `--version`, which cold-starts WSL.
+`EngineRegistry::probe()` is cheap: it only checks `PATH` and configured
+overrides and spawns no subprocess. `verify_launch()` and `probe_local()` are
+**slow** - they run each candidate engine's version command, which can
+cold-start WSL.
 
 Run the slow paths only when the user explicitly asks to detect or refresh
 engine versions. Never trigger them on routine events such as opening the
@@ -139,14 +150,16 @@ user-initiated action.
 
 ## Subprocess execution
 
-The subprocess layer (`engines/process.rs`) is **async-runtime-free** and runs
-only on `JobManager` worker threads — never on the UI thread. Cancellation is via
-an `AtomicBool`, and runaway processes are bounded by a wall-clock timeout.
+The subprocess layer (`engines/process.rs`) is **async-runtime-free** and must
+run on caller-owned worker threads - never on the UI thread. Cancellation is via
+an `AtomicBool`. A `ProcessConfig` may carry a wall-clock timeout; GROMACS stages
+and engine verification do, while deliberately unbounded engine calls such as
+ORCA currently rely on cancellation and the external program's own termination.
 
 **Why:** external compute engines can run for minutes and must never block
 rendering. Keeping this layer free of an async runtime keeps it simple and
-portable, and confining it to worker threads guarantees the UI stays responsive
-and cancellable.
+portable. Callers must provide worker-thread isolation and choose a timeout when
+the operation has a meaningful upper bound.
 
 ## Launching engines: WSL vs native
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 How to build, test, and land changes in SilicoLab. Before you start, read
-[ARCHITECTURE.md](ARCHITECTURE.md) â€” it describes the design invariants you are
+[ARCHITECTURE.md](ARCHITECTURE.md) - it describes the design invariants you are
 expected to respect while making changes. When you are adding a new feature,
 [docs/adding-a-feature.md](docs/adding-a-feature.md) maps each kind of feature to
 the module to mirror and the exact sites to touch.
@@ -11,24 +11,37 @@ the module to mirror and the exact sites to touch.
 Debug builds of the wgpu renderer are slow, so **default to `--release`** for
 anything you actually intend to run or look at.
 
+Install the repository toolchain with `rustup`. On Debian or Ubuntu, the GUI
+also needs the same system libraries CI installs:
+
+```sh
+sudo apt-get update
+sudo apt-get install -y libgtk-3-dev libxkbcommon-dev libwayland-dev \
+  libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+```
+
+Windows and macOS need no additional build packages. Common commands are:
+
 ```powershell
 cargo build --release
 cargo run --release                                 # launch the GUI
 cargo run --release -- <script.sls> --name value    # run a script headless
-cargo test --release [<name substring>]
-cargo test --release -- --ignored wsl_gromacs       # needs WSL + GROMACS
+cargo test --release --workspace --all-features [<name substring>]
+cargo test --release -p compute-core -- --ignored wsl_gromacs --test-threads=1
 ```
 
-(See the README for installing external runtime dependencies such as GROMACS.)
+The last command needs WSL and GROMACS. See
+[Testing external engines](docs/testing-external-engines.md) for GROMACS, ORCA,
+GPU, and SSH acceptance-test prerequisites and environment variables.
 
 Most tests are inline `#[cfg(test)] mod tests` blocks next to the code they cover.
 A top-level `tests/` directory holds the few true integration tests that drive the
 compiled binary end-to-end (e.g. `tests/engine_exec.rs`); prefer inline unit tests
 and reach for `tests/` only when a test must exercise the built artifact itself.
 
-Machine-specific acceptance tests â€” those that need an external tool installed â€”
+Machine-specific acceptance tests - those that need an external tool installed -
 are gated with `#[ignore]` so the default `cargo test` run stays hermetic. Run
-them explicitly, as shown above.
+them explicitly using the commands in the external-engine testing guide.
 
 ## Remote execution development
 
@@ -48,12 +61,15 @@ opt-in SSH integration tests.
 
 ## Commit discipline
 
-Everything syncs straight to `main`. As a result:
+All changes land through a pull request targeting `main`; there is no long-lived
+development branch. As a result:
 
 - **Every commit must compile and stand on its own.**
 - Each commit should be **one coherent capability**, not a grab-bag of unrelated
   changes.
 - Note any known limitations in the commit body.
+- Use a [Conventional Commits](https://www.conventionalcommits.org/) subject,
+  matching the existing history.
 
 Two classes of code are gated differently:
 
@@ -62,7 +78,7 @@ Two classes of code are gated differently:
 - **Engine-specific integration** (e.g. GROMACS input generation, grompp/mdrun
   orchestration, output parsing): **must not land until a test exercises the
   real external tool end-to-end.** A `--version` detection test is not
-  sufficient â€” integration code that has only been checked against mocks does
+  sufficient - integration code that has only been checked against mocks does
   not ship.
 
 When a single change mixes the two, **split the commit**: land the generic layer
@@ -80,6 +96,9 @@ The command mirrors CI's local Rust gates, including warning-as-error builds. It
 does not replace CI's cross-OS matrix or the ignored machine-specific acceptance
 tests.
 
+Documentation-only changes must also pass this command. It validates repository
+documentation and builds public Rust API documentation with warnings denied.
+
 ## Licensing
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in SilicoLab is submitted under GPL-3.0-or-later and also grants the SilicoLab copyright holders the right to offer that contribution under separate commercial licenses.
@@ -87,6 +106,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 By contributing, you confirm that you have the right to make that grant.
 
 ## Code conventions
+
 - **Single-responsibility files.** Split into modules rather than letting a file
   accumulate; see [`.rules`](.rules) for the current size budget. This is a
   modular Cargo workspace; lean on the module system.

--- a/LICENSE
+++ b/LICENSE
@@ -9,4 +9,6 @@ SilicoLab is available under either:
 
 If you have not entered into a commercial license agreement, you may use, copy, modify, and distribute SilicoLab only under the GPL-3.0-or-later terms. See LICENSES/GPL-3.0-or-later.txt for the GPL text and LICENSES/LicenseRef-SilicoLab-Commercial.txt for the commercial licensing notice.
 
+Cargo package metadata describes the license available to recipients of the public crate distribution and therefore lists GPL-3.0-or-later. It does not represent or grant a separate commercial agreement.
+
 Third-party components and bundled assets remain governed by their own licenses. See THIRD-PARTY-NOTICES.md.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,16 @@ Download prebuilt executables from
 
 ### Build from source
 
-Install the [Rust toolchain](https://rustup.rs), then build the release
+Install the [Rust toolchain](https://rustup.rs). On Debian or Ubuntu, install
+the GUI development libraries used by eframe/wgpu first:
+
+```sh
+sudo apt-get update
+sudo apt-get install -y libgtk-3-dev libxkbcommon-dev libwayland-dev \
+  libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+```
+
+Windows and macOS need no additional build packages. Then build the release
 executable:
 
 ```sh
@@ -85,7 +94,10 @@ engine when the user configures its executable path. See the manual for setup de
 
 - [Contributing guide](CONTRIBUTING.md)
 - [Architecture notes](ARCHITECTURE.md)
+- [Documentation map](docs/README.md)
 - [Feature wiring guide](docs/adding-a-feature.md)
+- [Release process](RELEASING.md)
+- [Security policy](SECURITY.md)
 
 ## License
 
@@ -95,6 +107,10 @@ SilicoLab is available under either:
 - a separate commercial license granted in writing by the SilicoLab copyright holders.
 
 If you do not have a signed commercial license agreement, your rights are under GPL-3.0-or-later. The repository records this dual-license structure with REUSE/SPDX metadata in [REUSE.toml](REUSE.toml): GPL-3.0-or-later OR LicenseRef-SilicoLab-Commercial.
+
+The public Cargo packages list `GPL-3.0-or-later` because downloading a crate
+does not grant the separate commercial license; that license exists only under
+a written agreement with the copyright holders.
 
 Third-party components remain under their own licenses; see [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,80 @@
+# Releasing SilicoLab
+
+This document owns the release contract consumed by automatic application
+updates and remote-worker deployment. Do not publish a non-draft GitHub Release
+until every required asset is present and verified.
+
+## 1. Prepare the version
+
+1. Update `workspace.package.version` in `Cargo.toml`; every crate inherits it.
+2. Update `Cargo.lock` and any user-facing release notes.
+3. If an on-disk format changed incompatibly, add a migration before changing
+   its format constant. Never reuse a format version for a different shape.
+4. Run `cargo pr-check` from a clean checkout and let the cross-OS PR matrix pass.
+5. Merge the release preparation PR to `main`.
+
+The Git tag must be exactly `v<workspace package version>`, for example
+`v0.2.0`. The application update check and production worker resolver both
+reject a different tag scheme.
+
+## 2. Build application archives
+
+Build release binaries from the tagged commit for every target the release
+claims to support. Each GitHub asset filename must contain its Rust target
+triple because the `self_update` client selects an asset by that substring.
+
+Use `.zip` or `.tar.gz`; both formats are supported by the current updater.
+Inside an archive:
+
+- Windows contains `silicolab.exe` at the archive root.
+- Linux contains `silicolab` at the archive root.
+- macOS contains
+  `silicolab.app/Contents/MacOS/silicolab` exactly, with no leading `./`.
+
+Include `LICENSE`, `LICENSES/`, and `THIRD-PARTY-NOTICES.md` in every binary
+distribution. Use an unambiguous naming scheme such as
+`silicolab-<version>-<target>.zip` or `.tar.gz`; do not publish two application
+archives containing the same target substring.
+
+## 3. Build the remote worker
+
+Build the worker from the same tagged commit:
+
+```text
+cargo xtask build-dev-worker
+```
+
+Publish the raw ELF executable under this exact asset name:
+
+```text
+silicolab-compute-x86_64-unknown-linux-musl
+```
+
+Publish its SHA-256 as a second asset with the exact name:
+
+```text
+silicolab-compute-x86_64-unknown-linux-musl.sha256
+```
+
+The checksum file's first whitespace-delimited token must be the 64-character
+hex digest of the uploaded worker bytes. Production deployment fails closed if
+either asset is missing or the digest differs.
+
+## 4. Publish and verify
+
+1. Create a draft GitHub Release for the exact tag.
+2. Upload every application archive, the worker, its checksum, and release notes.
+3. Verify the worker reports the release version with
+   `silicolab-compute --version`.
+4. Download each archive, inspect its internal executable path, and start the
+   application on its target OS.
+5. Verify the worker checksum from the downloaded assets, not the build tree.
+6. Publish the release only after all checks pass.
+7. From the previous released application, confirm update detection and one
+   in-place update on a writable installation.
+8. From the new application, submit one production remote job and confirm that
+   the exact-version worker is downloaded, verified, deployed, and executed.
+
+The repository does not currently claim code signing or package-manager
+publication. Add those requirements here before presenting them as part of the
+release process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are made on `main` and included in the next release. Only the
+latest published release is supported; older releases do not receive separate
+patches unless the maintainers announce otherwise.
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability. Email
+[jiekangtian@gmail.com](mailto:jiekangtian@gmail.com) with a concise description
+and enough information to reproduce or assess the issue.
+
+Useful reports include:
+
+- the affected version, commit, and operating system;
+- the feature and trust boundary involved;
+- reproduction steps or a minimal proof of concept;
+- the expected and observed behavior;
+- the potential impact and any known mitigations.
+
+Do not send live API keys, SSH private keys, access tokens, proprietary project
+files, or other credentials. Replace secrets with test values and state what
+kind of credential was used.
+
+The maintainers will acknowledge the report, validate its scope, and coordinate
+a fix and disclosure with the reporter. Please allow time for a release to be
+prepared before publishing details that would put users at risk.
+
+## Security-sensitive areas
+
+Reports are especially useful for issues involving:
+
+- automatic update downloads and executable replacement;
+- remote-worker download, checksum verification, SSH deployment, or execution;
+- host-key verification and remote command construction;
+- assistant API-key storage or unintended credential disclosure;
+- project-file parsing, path traversal, or unsafe external-engine arguments.
+
+Ordinary bugs and non-sensitive feature requests belong in the public issue
+tracker.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,12 +1,19 @@
 # Third-party notices
 
-SilicoLab is available under GPL-3.0-or-later, with commercial licenses available under separate written agreement from the SilicoLab copyright holders. The repository records file-level licensing metadata using REUSE/SPDX in REUSE.toml and LICENSES/.
+SilicoLab is available under GPL-3.0-or-later, with commercial licenses
+available under separate written agreement from the SilicoLab copyright
+holders. The repository records file-level licensing metadata using REUSE/SPDX
+in `REUSE.toml` and `LICENSES/`.
 
-Most Rust dependencies are permissively licensed (MIT / Apache-2.0 / BSD / Zlib / ISC / Unicode-style licenses) and impose no notice obligation beyond what their own published packages already carry.
+Most Rust dependencies are permissively licensed (MIT / Apache-2.0 / BSD / Zlib
+/ ISC / Unicode-style licenses) and impose no notice obligation beyond what
+their own published packages already carry.
 
-This file records third-party components whose notices must travel with a binary redistribution of SilicoLab because the license is weak-copyleft, font-specific, or because the component is vendored into this repository and embedded into the binary.
-
-A complete, machine-generated inventory of every dependency's license can be produced with cargo about or cargo license from the workspace root.
+This file records third-party components whose notices must travel with a
+binary redistribution of SilicoLab because the license is weak-copyleft,
+font-specific, or because the component is vendored into this repository and
+embedded into the binary. `Cargo.lock` is the exact dependency inventory for a
+checkout; regenerate and review dependency-license reports when it changes.
 
 ---
 
@@ -14,32 +21,60 @@ A complete, machine-generated inventory of every dependency's license can be pro
 
 ### xcx - exchange-correlation functionals for DFT
 
-Copyright (c) 2026 Jiekang Tian and the xcx authors. Portions are derived from libxc (<https://libxc.gitlab.io/>), Copyright (C) the libxc authors, including M. A. L. Marques, X. Andrade, S. Lehtola, and M. Oliveira.
+Copyright (c) 2026 Jiekang Tian and the xcx authors. Portions are derived from
+libxc (<https://libxc.gitlab.io/>), Copyright (C) the libxc authors, including
+M. A. L. Marques, X. Andrade, S. Lehtola, and M. Oliveira.
 
-Pulled in transitively via hartree. SPDX: (MIT OR Apache-2.0) AND MPL-2.0. xcx is licensed per file: its original code is MIT OR Apache-2.0, while files derived from libxc remain under the Mozilla Public License, Version 2.0.
+Pulled in transitively via hartree. SPDX: (MIT OR Apache-2.0) AND MPL-2.0. xcx is
+licensed per file: its original code is MIT OR Apache-2.0, while files derived
+from libxc remain under the Mozilla Public License, Version 2.0.
 
-MPL-2.0 is file-level weak copyleft. It places no restriction on SilicoLab as a whole, nor on your use of it; only modifications to the MPL-licensed source files themselves must be released under MPL-2.0. SilicoLab links this code unmodified. The corresponding source, including the MPL-licensed files and the full license text, is published with the crate at <https://crates.io/crates/xcx>.
+MPL-2.0 is file-level weak copyleft. It places no restriction on SilicoLab as a
+whole, nor on your use of it; only modifications to the MPL-licensed source
+files themselves must be released under MPL-2.0. SilicoLab links this code
+unmodified. The corresponding source, including the MPL-licensed files and the
+full license text, is published with the crate at <https://crates.io/crates/xcx>.
 
-If you redistribute SilicoLab in binary form, keep this notice available and ensure recipients can obtain that source, as required by MPL-2.0 section 3.2. The full MPL-2.0 text is available at <https://www.mozilla.org/MPL/2.0/>.
+If you redistribute SilicoLab in binary form, keep this notice available and
+ensure recipients can obtain that source, as required by MPL-2.0 section 3.2.
+The full MPL-2.0 text is available at <https://www.mozilla.org/MPL/2.0/>.
 
 ---
 
 ## Bundled data assets
 
-These third-party data files are vendored into this repository and embedded into the binary, so the copyright and permission notices below must accompany binary redistributions.
+These third-party data files are vendored into this repository and embedded
+into the binary, so the copyright and permission notices below must accompany
+binary redistributions.
 
 ### CHARMM36 force field
 
-Copyright (c) 2025 mackerell-lab. Licensed under the MIT License. A pruned subset is bundled under ssets/forcefields/charmm36.ff/; the in-tree license file is ssets/forcefields/charmm36.ff/LICENSE. REUSE metadata records this subtree as MIT.
+Copyright (c) 2025 mackerell-lab. Licensed under the MIT License. A pruned
+subset is bundled under `assets/forcefields/charmm36.ff/`; its upstream release
+and retained scope are recorded in `assets/forcefields/charmm36.ff/VERSION`, and
+the in-tree license is `assets/forcefields/charmm36.ff/LICENSE`. REUSE metadata
+records this subtree as MIT.
 
 ### Liberation Sans embedded font
 
-ssets/fonts/LiberationSans-Regular.ttf (Liberation Fonts 2.1.5, <https://github.com/liberationfonts/liberation-fonts>) is compiled into the binary and embedded in exported charts. It is licensed under the SIL Open Font License, Version 1.1; the full license text is vendored at ssets/fonts/LiberationSans-LICENSE. REUSE metadata records these files as OFL-1.1.
+`assets/fonts/LiberationSans-Regular.ttf` (Liberation Fonts 2.1.5,
+<https://github.com/liberationfonts/liberation-fonts>) is compiled into the
+binary and embedded in exported charts. It is licensed under the SIL Open Font
+License, Version 1.1; the full license text is vendored at
+`assets/fonts/LiberationSans-LICENSE`. REUSE metadata records these files as
+OFL-1.1.
 
 ### Default egui fonts
 
-Some GUI font assets are provided by transitive egui/epaint packages and are licensed under their published font licenses, including OFL-1.1 and Ubuntu Font License terms. These licenses continue to apply to those font assets under both the GPL and commercial licensing paths.
+Some GUI font assets are provided by transitive egui/epaint packages and are
+licensed under their published font licenses, including OFL-1.1 and Ubuntu Font
+License terms. These licenses continue to apply to those font assets under both
+the GPL and commercial licensing paths.
 
 ### RCSB Protein Data Bank templates
 
-The bundled ubiquitin-like PDB templates under compute-core/assets/ubl/ are cleaned derivatives of RCSB Protein Data Bank coordinate files identified in compute-core/assets/ubl/README.md. RCSB PDB data are released into the public domain; REUSE metadata records the PDB coordinate files as LicenseRef-Public-Domain.
+The bundled ubiquitin-like PDB templates under `compute-core/assets/ubl/` are
+cleaned derivatives of RCSB Protein Data Bank coordinate files identified in
+`compute-core/assets/ubl/README.md`. RCSB PDB data are released into the public
+domain; REUSE metadata records the PDB coordinate files as
+LicenseRef-Public-Domain.

--- a/assets/forcefields/charmm36.ff/forcefield.itp
+++ b/assets/forcefields/charmm36.ff/forcefield.itp
@@ -10,7 +10,7 @@
 ; Charmm2GMX written by András Wacha and Justin Lemkul, based on the original
 ; port by E. Prabhu Raman, Justin A. Lemkul, Robert Best and Alexander D. 
 ; MacKerell, Jr.
-; please see forcefield.doc for a list of source files and references
+; see VERSION for the upstream release, retained subset, and generator metadata
 
 #define _FF_CHARMM
 

--- a/compute-core/src/domain/sketch/mod.rs
+++ b/compute-core/src/domain/sketch/mod.rs
@@ -7,7 +7,7 @@
 //! [`crate::domain::Structure`].
 //!
 //! Implicit hydrogens are *not* stored; they are derived on demand from the
-//! valence model in [`valence`] so the depiction stays a clean heavy-atom
+//! valence model in the private `valence` module so the depiction stays a clean heavy-atom
 //! skeleton. The same model decides when an atom is over-bonded so the canvas
 //! can flag it.
 

--- a/compute-core/src/engines/methods/mod.rs
+++ b/compute-core/src/engines/methods/mod.rs
@@ -20,7 +20,7 @@
 //! future on-disk overlay; the consistency tests below are the correctness gate
 //! that both the embedded core and any overlay must pass — in particular every
 //! pinned `--method`/`--basis` is checked against the curated
-//! [`VETTED_FUNCTIONALS`]/[`VETTED_BASES`] allowlists, so a rule can never name a
+//! `VETTED_FUNCTIONALS`/`VETTED_BASES` allowlists, so a rule can never name a
 //! molecular method or basis this build can't run.
 
 use std::sync::OnceLock;

--- a/compute-core/src/engines/process.rs
+++ b/compute-core/src/engines/process.rs
@@ -4,7 +4,7 @@
 //! (such as GROMACS) with streamed stdout/stderr, a
 //! cooperative cancellation flag, and a wall-clock timeout. It deliberately
 //! avoids any async runtime so that engine jobs can be spawned from worker
-//! threads spawned by [`crate::frontend::jobs::JobManager`].
+//! threads owned by the calling application rather than an async runtime.
 
 use std::{
     collections::HashMap,

--- a/compute-core/src/engines/qm/build.rs
+++ b/compute-core/src/engines/qm/build.rs
@@ -432,11 +432,11 @@ fn resolve_hartree_method(
 }
 
 /// Whether hartree carries a dispersion parametrization for `method` + `disp` —
-/// i.e. whether [`resolve_dispersion`] would resolve it rather than bail. The
+/// i.e. whether `resolve_dispersion` would resolve it rather than bail. The
 /// panel uses this to offer only the dispersion variants the chosen functional
 /// supports (D3(BJ) covers a small set; D4 additionally covers the double
 /// hybrids). Composites carry their own and post-HF has none, so both return
-/// false. Mirrors [`resolve_dispersion`]'s key derivation exactly.
+/// false. Mirrors `resolve_dispersion`'s key derivation exactly.
 pub fn supports_dispersion(method: &QmMethod, disp: QmDispersion) -> bool {
     if method.is_post_hf() {
         return false;

--- a/compute-core/src/io/formats/cif.rs
+++ b/compute-core/src/io/formats/cif.rs
@@ -41,7 +41,7 @@ pub fn parse_cif(input: &str) -> Result<Structure> {
 
 /// Serialize a structure as a minimal mmCIF document with Cartesian
 /// coordinates. This is the canonical on-disk form produced on save and read
-/// back by [`parse_mmcif`].
+/// back by the private `parse_mmcif` parser.
 pub fn to_cif(structure: &Structure) -> Result<String> {
     let mut output = String::new();
     output.push_str(&format!("data_{}\n", sanitize_identifier(&structure.title)));

--- a/compute-core/src/io/formats/pdbqt/mod.rs
+++ b/compute-core/src/io/formats/pdbqt/mod.rs
@@ -3,7 +3,7 @@
 //! PDBQT is the input/output format of AutoDock Vina (and the `docking` crate).
 //! Compared to PDB it adds a partial-charge column and an AutoDock atom-type
 //! column, and ligands carry a `ROOT`/`BRANCH`/`TORSDOF` torsion tree. silicolab
-//! reads PDBQT (e.g. docking result poses) into [`Structure`]s and prepares
+//! reads PDBQT (e.g. docking result poses) into [`crate::domain::Structure`]s and prepares
 //! receptor/ligand PDBQT from structures for the docking engine.
 //!
 //! Preparation is best-effort: it derives AutoDock types from the element and bond

--- a/compute-core/src/io/self_update.rs
+++ b/compute-core/src/io/self_update.rs
@@ -28,9 +28,8 @@ const ARCHIVE_BIN_NAME: &str = "silicolab";
 
 /// On macOS the release archive ships a `.app` bundle, so the executable is
 /// nested rather than at the archive root. `self_update` locates the binary by
-/// an *exact* path match against the archive entries (see `release.yml`, which
-/// packages the bundle without a leading `./`), so this must match the layout
-/// the workflow produces.
+/// an *exact* path match against the archive entries. The release contract in
+/// the repository's `RELEASING.md` requires this layout without a leading `./`.
 #[cfg(target_os = "macos")]
 const MACOS_BIN_PATH_IN_ARCHIVE: &str = "silicolab.app/Contents/MacOS/silicolab";
 

--- a/compute-core/src/wire.rs
+++ b/compute-core/src/wire.rs
@@ -63,7 +63,7 @@ impl EngineRequest {
 
     /// A request for a built-in engine, which runs in-process and needs no
     /// external program. Misuse (passing an engine that does need one) is caught
-    /// by [`validate_request`] and by the executor, so this cannot smuggle an
+    /// by the private `validate_request` guard and by the executor, so this cannot smuggle an
     /// unlaunchable job past them — it only skips an impossible error path.
     pub fn builtin(engine: Engine, cores: Option<usize>) -> Self {
         debug_assert!(
@@ -679,7 +679,7 @@ fn run_request(
 
 /// Process a staged `request.json` and write `outcome.json`. This is the engine
 /// entry a subprocess (and a remote worker) runs; malformed input fails the parse
-/// or [`validate_request`] and returns an error, so the process exits non-zero.
+/// or the private `validate_request` guard and returns an error, so the process exits non-zero.
 pub fn exec(request_path: &Path, outcome_path: &Path) -> Result<()> {
     let bytes =
         std::fs::read(request_path).with_context(|| format!("read {}", request_path.display()))?;

--- a/compute-core/src/workflows/molecular_dynamics/protocol.rs
+++ b/compute-core/src/workflows/molecular_dynamics/protocol.rs
@@ -34,7 +34,7 @@ const TRAJECTORY_MAX_INTERVAL: u64 = 5_000;
 ///
 /// MD output is saved by default so each dynamics step of a run is playable;
 /// passing `save_trajectory = false` disables it (only final structures are
-/// kept). The interval targets [`TRAJECTORY_TARGET_FRAMES`] frames for the
+/// kept). The interval targets `TRAJECTORY_TARGET_FRAMES` frames for the
 /// stage's length, so a short equilibration step still yields a usable track
 /// instead of two or three frames.
 ///

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,0 +1,33 @@
+# SilicoLab documentation site
+
+This directory is the Astro/Starlight application for the public, localized
+end-user manual. Contributor and maintainer documentation belongs in
+[`../docs/`](../docs/README.md), not in the site content tree.
+
+## Development
+
+Use Node.js 22, matching the documentation workflow:
+
+```sh
+npm ci
+npm run dev
+```
+
+Run `npm run build` before submitting changes. The build validates Starlight
+content and internal links. Cloudflare builds and deploys the site from this
+directory after changes reach `main`; `.github/workflows/docs.yml` performs the
+pull-request validation build.
+
+## Content and assets
+
+- Put English user documentation under `src/content/docs/` and Simplified
+  Chinese counterparts under `src/content/docs/zh/`.
+- Update both maintained locales when behavior or instructions change.
+- Link to canonical repository policies instead of copying them into the site.
+- Do not edit generated files under `src/assets/` or `public/`. The
+  `predev`/`prebuild` hooks run `scripts/sync-assets.mjs`, which copies canonical
+  branding, screenshot, and icon assets from the repository root.
+
+If a new document is primarily for people modifying or releasing SilicoLab,
+put it in `../docs/` or a named root policy file. If it helps users install,
+configure, operate, or troubleshoot the product, put it in this site.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# Repository documentation
+
+This directory contains documentation for contributors and maintainers working
+on the SilicoLab repository. The public end-user manual and its website live in
+[`docs-site/`](../docs-site/README.md).
+
+## Where documentation belongs
+
+| Content | Location |
+| --- | --- |
+| Project overview and primary entry points | Root `README.md` |
+| Contribution, architecture, release, and security policy | Named root documents |
+| Detailed implementation and maintainer guides | `docs/` |
+| Public installation, configuration, workflows, and troubleshooting | `docs-site/src/content/docs/` |
+| Rust API contracts | Rust doc comments next to the API |
+| Shared screenshots used by root documents and the site | `docs/images/` |
+
+Keep a fact in one canonical place and link to it elsewhere. Do not copy a
+maintainer guide into the public manual or duplicate user instructions in this
+directory. English and translated site pages are intentional counterparts;
+changes to user-visible behavior should update every maintained locale in the
+same pull request.
+
+Repository documentation is validated by `cargo xtask check-docs`, which is
+also part of `cargo pr-check`. The site has a separate Node build because its
+MDX, localization, navigation, and generated assets require Astro/Starlight.
+
+## Current guides
+
+- [Adding a feature](adding-a-feature.md)
+- [Developing remote execution](developing-remote-execution.md)
+- [Testing external engines](testing-external-engines.md)

--- a/docs/adding-a-feature.md
+++ b/docs/adding-a-feature.md
@@ -12,14 +12,11 @@ See [ARCHITECTURE.md](../ARCHITECTURE.md) for *why* the layers and the
 build/test/land. Changes to a remote-capable engine or the `wire`/`payload`
 contract must also follow
 [Developing remote execution](developing-remote-execution.md) so the current
-worker is rebuilt and exercised instead of a released worker. Layer order
-(lowest owns it) spans two crates: **compute-core**
-`domain → io → md → engines → workflows` (no GUI deps; also holds `hosts`/
-`payload`/`wire`; `md` is the engine-neutral molecular-dynamics model), then
-**silicolab** `backend → frontend` (depends on compute-core); the headless
-worker crate `silicolab-compute` links compute-core alone. The module paths
-below are relative to a crate: `md/`, `engines/`, `io/`, `workflows/` live under
-`compute-core/src/`; `backend/`, `frontend/` under `src/`.
+worker is rebuilt and exercised instead of a released worker. The architecture
+document owns the layer order and dependency exceptions; do not duplicate them
+here. Module paths below are relative to a crate: `md/`, `engines/`, `io/`, and
+`workflows/` live under `compute-core/src/`; `backend/` and `frontend/` live
+under `src/`.
 
 ## Pick the template
 
@@ -31,10 +28,10 @@ below are relative to a crate: `md/`, `engines/`, `io/`, `workflows/` live under
 | Background compute **task** (panel + result entries) | the `qm-energy` task, end-to-end — see the checklist | For a CPU loop that streams intermediate structures, also study `build-disordered-system`. |
 | Multi-entry picker panel | `disorder` | `SetDisorderComponentEntry`, `with_disorder_prompt`, and the `ensure_panel_form` seeding. |
 | Inline edit task (no panel, acts on the active structure) | `add-hydrogens` / `recompute-bonds` | Executor runs the op and marks the task complete; no prompt state. |
-| New `.sls` command group | `frontend/qm_commands.rs` | Sub-dispatch + a `--flag` scanner; register the verb in `console.rs`. Defining it once makes it a CLI command too. |
+| New `.sls` command group | `frontend/qm_commands.rs` | Put the top-level verb in `console/grammar.rs::Command`, classify it in `Command::risk`, dispatch it there, and add it to `command_catalog()`. Defining it once makes it a CLI command too. |
 | New molecular file format | `io/formats/cif.rs` (single) / `mol2.rs`, `pdb.rs` (multi-record) | Plus 3 registry edits — see Traps. Declare whether records concatenate in `StructureFormat::multi_structure_file`. |
 | New GUI interaction (no task) | an `AppAction` variant + arm in `dispatcher/mod.rs` + a handler in a `dispatcher/*.rs` | Widgets only emit actions; only `dispatch` mutates state. |
-| Expose a capability to the in-app assistant | — | Automatic via the `run_command` tool once a `.sls` verb exists. Only gate the verb in `agent/tools.rs::command_needs_confirmation`, and heavy-classify it in `agent/loop_driver/heavy.rs` if it is CPU-bound. |
+| Expose a capability to the in-app assistant | — | Automatic via the `run_command` tool once a `.sls` verb exists. `Command::risk` controls approval; heavy-classify it in `agent/loop_driver/heavy.rs` if it is CPU-bound. |
 
 ## Background compute task — the full checklist
 
@@ -66,9 +63,10 @@ arms won't build); ⚠ marks the steps it does **not** catch.
    `dispatcher/mod.rs`.
 9. **`frontend/ui/secondary_sidebar/task_panels.rs`** — `render_x_task_panel`
    (`pub(crate)`), dispatched from `frontend/ui/dock.rs::render_task_body`.
-10. **`frontend/<x>_commands.rs`** — the `.sls` command; `mod` in
-    `frontend/mod.rs`; an arm in `console.rs` plus the `command_catalog()` /
-    `help_text()` strings.
+10. **`frontend/<x>_commands.rs`** — the `.sls` implementation; `mod` in
+    `frontend/mod.rs`; a `Command` variant, dispatch arm, and exhaustive risk arm
+    in `console/grammar.rs`; plus an entry in `console.rs::command_catalog()`.
+    Clap generates `help`; do not add a second hand-written help list.
 11. **Assistant** — gate the verb in `agent/tools.rs`; if CPU-bound, add
     `HeavyKind` + `AgentHeavyJob` arms in `agent/loop_driver/heavy.rs`.
 
@@ -96,7 +94,7 @@ new `EntryOrigin` variant.
   `cancel` is best-effort: honored before the call starts; in-flight work runs to
   completion and the result is discarded. Don't promise mid-run cancellation.
 - **Console commands are shared GUI+CLI.** Define the command once in
-  `console.rs`; never add a GUI-only path.
+  `console/grammar.rs`; never add a GUI-only path.
 
 ---
 

--- a/docs/developing-remote-execution.md
+++ b/docs/developing-remote-execution.md
@@ -210,6 +210,10 @@ installed Rust debugger extension.
 These tests deploy the current local worker themselves. Do not pre-place a
 worker or forge the host's `_worker` cache value.
 
+This section covers the remote suite. The canonical inventory of all
+machine-specific engine tests and environment variables is
+[Testing external engines](testing-external-engines.md).
+
 First build and validate the artifact:
 
 ```text
@@ -262,6 +266,17 @@ The GROMACS test requires `gmx` on the host. If a non-interactive SSH shell must
 source an environment first, set `SILICOLAB_TEST_GMX_PRELUDE` to that one shell
 line. `SILICOLAB_DEV_WORKER` is optional for all of these tests and selects a
 non-default local artifact when set.
+
+Three additional frontend tests cover configured and auto-detected GROMACS
+launches. To exercise a non-standard executable, set
+`SILICOLAB_TEST_GMX_PROGRAM` to an absolute remote path that is neither on
+`PATH` nor in the built-in candidate list, then run:
+
+```text
+cargo test -p silicolab --features dev-worker --lib -- --ignored remote_gromacs_honors --nocapture
+cargo test -p silicolab --features dev-worker --lib -- --ignored verify_confirms_a_remote_gmx --nocapture
+cargo test -p silicolab --features dev-worker --lib -- --ignored verify_with_no_program --nocapture
+```
 
 The tests are ignored by default because they mutate the configured host's
 SilicoLab work directory and require real SSH access. They leave production

--- a/docs/testing-external-engines.md
+++ b/docs/testing-external-engines.md
@@ -1,0 +1,77 @@
+# Testing external engines
+
+Machine-specific acceptance tests are ignored by default. Run them when a
+change touches engine discovery, launch configuration, input generation,
+execution, or output parsing. Unit tests and mocks do not replace these tests
+for engine-specific integration code.
+
+Run ordinary hermetic tests first:
+
+```text
+cargo test --release --workspace --all-features
+```
+
+## Local GROMACS through WSL
+
+These tests require Windows, WSL, and a working `gmx` inside WSL. They share
+working paths, so run them serially:
+
+```text
+cargo test --release -p compute-core -- --ignored wsl_gromacs --test-threads=1 --nocapture
+```
+
+To test a GROMACS executable outside the normal candidate paths, set
+`SILICOLAB_TEST_WSL_GMX` to its absolute Linux path before running the same
+command.
+
+The frontend command-path acceptance test is separate:
+
+```text
+cargo test --release -p silicolab --lib -- --ignored agent_md_simulate --nocapture
+```
+
+## Local ORCA
+
+Set `SILICOLAB_TEST_ORCA_PROGRAM` to the ORCA executable. If it must be launched
+through a wrapper, set `SILICOLAB_TEST_ORCA_PREFIX` to the prefix tokens. Then
+run both the core adapter and compiled-binary integration tests:
+
+```text
+cargo test --release -p compute-core --lib -- --ignored configured_orca --nocapture
+cargo test --release -p silicolab --test engine_exec -- --ignored exec_subcommand_runs_configured_orca --nocapture
+```
+
+## Remote direct and Slurm execution
+
+Remote tests mutate the configured host's SilicoLab work directory. Use a
+disposable fixture or dedicated test directory, and build the current worker
+before running them:
+
+```text
+cargo xtask build-dev-worker
+```
+
+Required environment:
+
+| Variable | Meaning |
+|---|---|
+| `SILICOLAB_TEST_SSH_HOST` | Reachable x86_64 Linux SSH host. |
+| `SILICOLAB_TEST_SSH_USER` | SSH user; defaults to `root` in the tests. |
+| `SILICOLAB_DEV_WORKER` | Optional non-default local worker artifact. |
+| `SILICOLAB_TEST_GMX_PRELUDE` | Optional shell line run before remote `gmx`. |
+| `SILICOLAB_TEST_GMX_PROGRAM` | Optional non-standard absolute remote `gmx` path. |
+
+The complete commands and Slurm fixture assumptions live in
+[Developing remote execution](developing-remote-execution.md#opt-in-ssh-integration-tests).
+
+## GPU-dependent renderer tests
+
+GPU adapter tests are ignored on headless machines. Run them on a machine with
+a supported graphics adapter and driver:
+
+```text
+cargo test --release -p silicolab --lib -- --ignored gpu_ --nocapture
+```
+
+Treat a test that prints `skip:` because a required environment variable is
+missing as not executed, not as acceptance evidence.

--- a/src/backend/config.rs
+++ b/src/backend/config.rs
@@ -197,19 +197,19 @@ pub struct AppConfig {
     #[serde(default)]
     pub theme: ThemeMode,
     /// Accent + neutral color scheme, applied on top of light/dark. Defaults to
-    /// `Graphite`. See [`crate::frontend::theme::Palette::for_scheme`].
+    /// `Graphite`. The frontend maps it through `Palette::for_scheme`.
     #[serde(default)]
     pub color_scheme: ColorScheme,
     /// Apple-style frosted-glass (vibrancy) material on the window chrome.
     /// Defaults off: the effect costs continuous backdrop-blur compositing while
     /// revealed, so it is opt-in (performance first). Only takes effect where the
     /// platform supports it (macOS for now) and is auto-suppressed when the OS
-    /// "Reduce Transparency" setting is on. See [`crate::frontend::glass`].
+    /// "Reduce Transparency" setting is on. See the frontend `glass` module.
     #[serde(default = "default_glass")]
     pub glass: bool,
     /// Liquid Glass tint intensity, 0.0 (ultra-clear) ..= 1.0 (fully tinted).
     /// Maps linearly onto the chrome-fill alpha range (see
-    /// [`crate::frontend::theme::glass_alpha`]); macOS 27-style user control over
+    /// `theme::glass_alpha`); macOS 27-style user control over
     /// how see-through the frosted chrome reads.
     #[serde(default = "default_glass_intensity")]
     pub glass_intensity: f32,
@@ -241,7 +241,7 @@ pub struct AppConfig {
     /// project data. `#[serde(default)]` so an older `settings.json` still parses
     /// and falls back to the default layout. Only the fixed views persist here;
     /// per-task panels are session state and are never written. See
-    /// [`crate::frontend::state::DockModel`].
+    /// the frontend `DockModel`.
     #[serde(default)]
     pub dock_layout: DockLayoutConfig,
     /// Default number of CPU cores a new job starts with — the seed every task
@@ -270,7 +270,7 @@ pub struct AppConfig {
 
 /// Persisted state of one dock area (the bottom panel or the right sidebar). The
 /// `tabs`/`active` strings are fixed-view tokens (see
-/// [`crate::frontend::state::StaticView::token`]); unknown tokens are skipped on
+/// `StaticView::token`); unknown tokens are skipped on
 /// load, so the schema tolerates reordering or removing a view.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DockAreaLayout {
@@ -280,7 +280,7 @@ pub struct DockAreaLayout {
     pub collapsed: bool,
 }
 
-/// Persisted workbench layout mirror of [`crate::frontend::state::DockModel`].
+/// Persisted workbench layout mirror of the frontend `DockModel`.
 /// Lives in the backend layer (no dependency on `frontend`), so the default
 /// placement is spelled out here with literal view tokens and sizes; a test in
 /// `state.rs` asserts it stays in lock-step with `DockModel::default()`.

--- a/src/backend/config/persist.rs
+++ b/src/backend/config/persist.rs
@@ -24,7 +24,7 @@ pub fn recent_projects_path() -> PathBuf {
 }
 
 /// Load the app config. A missing file is a normal first run (silent default). A
-/// file that exists but fails to parse is preserved (see [`back_up_corrupt_file`])
+/// file that exists but fails to parse is preserved (see `back_up_corrupt_file`)
 /// and a warning is returned, rather than silently resetting every setting — the
 /// silent reset is what made an interrupted write look like the app randomly
 /// forgetting the assistant model.

--- a/src/backend/representation.rs
+++ b/src/backend/representation.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 /// Default representation for atoms that use base atom/bond geometry. The four
 /// styles the renderer can draw as a *base* geometry; each maps 1:1 onto an
-/// [`crate::frontend::state::AtomStyle`] frontend-side. (Protein chains keep
+/// frontend `AtomStyle`. (Protein chains keep
 /// their Cartoon default and follow [`CartoonPrefs`] instead.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum BaseStyle {

--- a/src/backend/structure_codec.rs
+++ b/src/backend/structure_codec.rs
@@ -25,7 +25,7 @@ use crate::frontend::AtomSelection;
 use compute_core::payload::{StructurePayload, payload_to_structure, structure_to_payload};
 
 /// Payload format tag stored next to each blob. Bump when the on-disk shape of
-/// [`StructurePayload`]/[`SnapshotPayload`] changes incompatibly.
+/// [`StructurePayload`]/`SnapshotPayload` changes incompatibly.
 pub const PAYLOAD_FORMAT: i64 = 1;
 
 /// A compressed structure blob plus the length of its uncompressed JSON.

--- a/src/frontend/console.rs
+++ b/src/frontend/console.rs
@@ -27,7 +27,7 @@ mod tests;
 /// The Console tab's full session state: the command input, the recall history,
 /// and the transient view state (wrap, auto-follow, and the clear-view / unread
 /// cursors over the command transcript). The transcript itself is owned by the
-/// [`SessionLogStore`](crate::frontend::state::SessionLogStore); this holds only
+/// the private `SessionLogStore`; this holds only
 /// what the view needs.
 #[derive(Debug, Clone)]
 pub struct CommandConsoleState {

--- a/src/frontend/viewport/visual_state.rs
+++ b/src/frontend/viewport/visual_state.rs
@@ -187,7 +187,7 @@ impl OverlayScope {
 pub struct ViewportVisualState {
     pub background_color: Color32,
     /// Project-level style override for each chemical category, overriding the
-    /// [`software_default_style`]. Empty categories fall back to the software
+    /// `software_default_style`. Empty categories fall back to the software
     /// default. This is the "project display style" the user sets in View.
     pub category_styles: BTreeMap<AtomCategory, AtomStyle>,
     /// Per-atom style overrides, keyed by atom index. Sparse — only atoms the

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,6 +24,13 @@ fn run() -> Result<(), String> {
             }
             pr_check()
         }
+        Some("check-docs") => {
+            if args.next().is_some() {
+                return Err("usage: cargo xtask check-docs".to_owned());
+            }
+            let repo_root = repo_root()?;
+            assert_documentation(&repo_root, 1, 1)
+        }
         Some("build-dev-worker") => {
             if args.next().is_some() {
                 return Err("usage: cargo xtask build-dev-worker".to_owned());
@@ -54,7 +61,7 @@ fn pr_check() -> Result<(), String> {
     run_cargo_step(
         &repo_root,
         1,
-        8,
+        10,
         "fmt",
         &["fmt", "--all", "--check", "--quiet"],
         Warnings::Allow,
@@ -62,7 +69,7 @@ fn pr_check() -> Result<(), String> {
     run_cargo_step(
         &repo_root,
         2,
-        8,
+        10,
         "clippy",
         &[
             "clippy",
@@ -76,26 +83,28 @@ fn pr_check() -> Result<(), String> {
     run_cargo_step(
         &repo_root,
         3,
-        8,
+        10,
         "default-feature clippy",
         &["clippy", "--workspace", "--all-targets", "--quiet"],
         Warnings::Deny,
     )?;
-    assert_worker_pure_rust(&repo_root, 4, 8)?;
-    build_dev_worker_step(5, 8)?;
-    assert_rust_file_sizes(&repo_root, 6, 8)?;
+    assert_documentation(&repo_root, 4, 10)?;
+    run_rustdoc_step(&repo_root, 5, 10)?;
+    assert_worker_pure_rust(&repo_root, 6, 10)?;
+    build_dev_worker_step(7, 10)?;
+    assert_rust_file_sizes(&repo_root, 8, 10)?;
     run_cargo_step(
         &repo_root,
-        7,
-        8,
+        9,
+        10,
         "test",
         &["test", "--workspace", "--all-features", "--quiet"],
         Warnings::Allow,
     )?;
     run_cargo_step(
         &repo_root,
-        8,
-        8,
+        10,
+        10,
         "production worker deploy tests",
         &[
             "test",
@@ -166,6 +175,149 @@ fn run_cargo_step(
 
 fn print_step(index: usize, total: usize, name: &str) {
     print!("[{index}/{total}] {name} ... ");
+}
+
+fn assert_documentation(repo_root: &Path, index: usize, total: usize) -> Result<(), String> {
+    let started_at = Instant::now();
+    print_step(index, total, "documentation files");
+
+    let output = Command::new("git")
+        .args(["ls-files", "--cached", "--others", "--exclude-standard"])
+        .current_dir(repo_root)
+        .output()
+        .map_err(|error| format!("failed to list tracked files: {error}"))?;
+    if !output.status.success() {
+        print_command_failure(
+            "git",
+            &["ls-files", "--cached", "--others", "--exclude-standard"],
+            &output,
+        );
+        return Err(format!(
+            "failed to list tracked files with {}.",
+            output.status
+        ));
+    }
+    let tracked = String::from_utf8(output.stdout)
+        .map_err(|error| format!("git produced non-UTF-8 file output: {error}"))?;
+    let files: Vec<_> = tracked
+        .lines()
+        .filter(|path| is_repository_document(path))
+        .collect();
+    let mut errors = Vec::new();
+
+    for relative in &files {
+        let path = repo_root.join(relative);
+        let bytes = fs::read(&path)
+            .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+        let text = match String::from_utf8(bytes) {
+            Ok(text) => text,
+            Err(error) => {
+                errors.push(format!("{relative}: not valid UTF-8 ({error})"));
+                continue;
+            }
+        };
+        for (offset, ch) in text.char_indices() {
+            if ch.is_control() && !matches!(ch, '\n' | '\r' | '\t') {
+                errors.push(format!(
+                    "{relative}: disallowed control character U+{:04X} at byte {offset}",
+                    ch as u32
+                ));
+            }
+        }
+        if relative.ends_with(".md") {
+            check_local_markdown_links(repo_root, relative, &text, &mut errors);
+        }
+    }
+
+    if errors.is_empty() {
+        println!(
+            "ok ({} files, {})",
+            files.len(),
+            format_duration(started_at.elapsed())
+        );
+        Ok(())
+    } else {
+        println!("failed");
+        for error in errors {
+            eprintln!("{error}");
+        }
+        Err("repository documentation validation failed".to_owned())
+    }
+}
+
+fn is_repository_document(path: &str) -> bool {
+    if path.starts_with("docs-site/") {
+        return false;
+    }
+    path.ends_with(".md") || path == ".rules" || path == "LICENSE" || path.ends_with("/VERSION")
+}
+
+fn check_local_markdown_links(
+    repo_root: &Path,
+    relative: &str,
+    text: &str,
+    errors: &mut Vec<String>,
+) {
+    let source = Path::new(relative);
+    let parent = source.parent().unwrap_or_else(|| Path::new(""));
+    let mut rest = text;
+    while let Some(marker) = rest.find("](") {
+        let tail = &rest[marker + 2..];
+        let Some(end) = tail.find(')') else {
+            break;
+        };
+        let raw = tail[..end].trim();
+        let target = raw
+            .split_whitespace()
+            .next()
+            .unwrap_or_default()
+            .trim_matches(['<', '>']);
+        rest = &tail[end + 1..];
+
+        if target.is_empty()
+            || target.starts_with('#')
+            || target.starts_with('/')
+            || target.contains("://")
+            || target.starts_with("mailto:")
+            || target.starts_with("app://")
+        {
+            continue;
+        }
+        let file_part = target.split('#').next().unwrap_or_default();
+        if file_part.is_empty() {
+            continue;
+        }
+        let resolved = repo_root.join(parent).join(file_part);
+        if !resolved.exists() {
+            errors.push(format!(
+                "{relative}: local link target does not exist: {target}"
+            ));
+        }
+    }
+}
+
+fn run_rustdoc_step(repo_root: &Path, index: usize, total: usize) -> Result<(), String> {
+    let started_at = Instant::now();
+    print_step(index, total, "rustdoc");
+    let args = [
+        "doc",
+        "--workspace",
+        "--no-deps",
+        "--all-features",
+        "--quiet",
+    ];
+    let output = Command::new("cargo")
+        .args(args)
+        .current_dir(repo_root)
+        .env("RUSTDOCFLAGS", "-D warnings")
+        .output()
+        .map_err(|error| format!("failed to run cargo {}: {error}", args.join(" ")))?;
+    if !output.status.success() {
+        print_command_failure("cargo", &args, &output);
+        return Err(format!("rustdoc failed with {}.", output.status));
+    }
+    println!("ok ({})", format_duration(started_at.elapsed()));
+    Ok(())
 }
 
 fn assert_worker_pure_rust(repo_root: &Path, index: usize, total: usize) -> Result<(), String> {


### PR DESCRIPTION
## Summary

- correct outdated paths, commands, architecture descriptions, licensing notes, and broken rustdoc links
- add release, security, external-engine testing, and documentation ownership guides
- add `cargo xtask check-docs` and strict workspace rustdoc validation to `cargo pr-check`
- merge repository documentation validation into `static-checks` while keeping the Astro/Starlight site build separate

## Verification

- `cargo pr-check` (10/10 steps passed)
- `cargo xtask check-docs` (16 files passed)
- `cargo test -p xtask` (3 tests passed)
- `npm run build` in `docs-site` (11 pages; internal links valid)
- `git diff --check`