### PR TITLE
feat: redesign assistant conversations and composer

### DIFF
--- a/design-qa.md
+++ b/design-qa.md
@@ -1,0 +1,50 @@
+# Assistant Composer Design QA
+
+- Source visual truth: user-provided Cursor composer screenshots, originally attached from `C:\Users\jtian\Desktop\ScreenShot_2026-07-13_211845_574.png`, `...211829_517.png`, and `...211839_373.png`.
+- Implementation screenshot: `C:\tmp\silicolab-assistant-composer-final.png`.
+- Viewport: 1001 × 699 desktop window; Assistant right sidebar at its persisted narrow layout.
+- State: first-run, API not configured, Assistant idle.
+
+## Full-view comparison evidence
+
+The final window capture shows the same two-tier composition as the reference: a full-width text area above a fixed bottom control row. The permission picker and model picker remain left-aligned; Send remains independently anchored to the right edge. The surrounding SilicoLab visual tokens are intentionally retained instead of cloning Cursor's colors.
+
+## Focused composer comparison evidence
+
+- Permission, model, and Send controls use the same 28px control height.
+- The model label is reduced to `Sonnet 4.6`; permission is reduced to `Safe`.
+- The model picker is capped at 132px and cannot consume the Send rectangle.
+- The controls rectangle clips independently from the fixed Send/Stop rectangles.
+- The user visually inspected the running final build and confirmed that it meets the requirement.
+
+## Findings and comparison history
+
+1. Earlier P1: the model picker could overlap Send because both depended on adaptive row allocation.
+   - Fix: replaced shared-flow allocation with explicit right-anchored action rectangles and a separately clipped controls rectangle.
+   - Post-fix evidence: `C:\tmp\silicolab-assistant-composer-final.png`; no overlap at the narrow sidebar width.
+2. Earlier P2: model names remained verbose and permission icons rendered as question marks.
+   - Fix: removed font-dependent permission icons, shortened permission labels, removed model qualifiers, and capped the collapsed model label.
+   - Post-fix evidence: final capture shows `Safe` and `Sonnet 4.6` without missing glyphs.
+3. Earlier P2: dropdowns and Send had visibly different heights.
+   - Fix: set the bottom controls' interaction height to the same 28px used by Send/Stop.
+   - Post-fix evidence: final capture shows a common baseline and height.
+
+## Required fidelity surfaces
+
+- Fonts and typography: existing SilicoLab UI font retained; no missing permission glyphs; labels remain readable and truncate safely.
+- Spacing and layout rhythm: 4px picker gap, 6px action gap, 28px controls, and a fixed two-row 92px composer.
+- Colors and visual tokens: SilicoLab semantic input, hairline, text, disabled, and accent colors retained.
+- Image quality and asset fidelity: no raster assets are required; existing Phosphor Send/Stop icons remain crisp.
+- Copy and content: compact permission/model labels in the collapsed row; complete permission descriptions remain available in the menu and tooltips.
+
+## Implementation checklist
+
+- [x] Text input cannot displace persistent actions.
+- [x] Permission picker is available at point of action.
+- [x] Per-conversation model picker is available at point of action.
+- [x] Long model labels are shortened and capped.
+- [x] Missing icon glyphs removed.
+- [x] Control heights aligned.
+- [x] Final running build visually accepted by the user.
+
+final result: passed

--- a/src/backend/assistant_config.rs
+++ b/src/backend/assistant_config.rs
@@ -1,7 +1,22 @@
-//! Persisted settings for the in-app LLM assistant: provider/model selection and
-//! the command-approval policy. Re-exported from [`super::config`].
+//! Persisted settings for the in-app LLM assistant: new-conversation defaults,
+//! provider options, and the command-approval policy.
 
 use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssistantModelSelection {
+    pub provider: String,
+    pub model: String,
+}
+
+impl Default for AssistantModelSelection {
+    fn default() -> Self {
+        Self {
+            provider: "anthropic".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+        }
+    }
+}
 
 /// How aggressively assistant-issued commands auto-run. Combined with each
 /// command's `RiskLevel` (declared in the console grammar) to decide whether a
@@ -53,9 +68,9 @@ impl ApprovalMode {
     }
 }
 
-/// Settings for the in-app LLM assistant. Holds only non-secret selection: the
-/// provider id, model, effort, an optional `base_url` override for
-/// OpenAI-compatible providers, and the command-approval policy. **The API key is
+/// Settings for the in-app LLM assistant. Holds only non-secret defaults: the
+/// selection copied into new conversations, effort, per-provider URL overrides,
+/// model capabilities, and the command-approval policy. **The API key is
 /// never stored here** — it is read from the provider's environment variable at
 /// call time (see `frontend::agent::registry`), preserving the
 /// no-secrets-in-config invariant SSH already follows.
@@ -64,24 +79,17 @@ pub struct AssistantConfig {
     /// Whether the assistant is usable (the Assistant tab still renders a hint when a
     /// key is missing). On by default.
     pub enabled: bool,
-    /// Active provider id, keyed into `frontend::agent::registry::PROVIDERS`.
-    pub provider: String,
-    /// Active model id within the selected provider.
-    pub model: String,
+    /// Provider and model copied into each newly-created conversation.
+    pub default_selection: AssistantModelSelection,
     /// Reasoning effort; adapters map or drop it per model capability.
     pub effort: crate::io::llm::types::Effort,
-    /// Base-URL override for OpenAI-compatible providers. `None` uses
-    /// the provider's registry default. Non-secret.
+    /// Base-URL overrides keyed by provider id. Missing uses the registry default.
     #[serde(default)]
-    pub base_url: Option<String>,
-    /// Per-model override for whether the active OpenAI-compatible model accepts
-    /// a reasoning-effort knob. `None` uses the registry heuristic (known model
-    /// → its declared capability; unknown / free-typed id → assume yes); `Some`
-    /// pins it. Lets users point a custom endpoint at a reasoning model the
-    /// built-in table can't know about — or silence the picker for one that
-    /// rejects the knob. Reset when the model or provider changes. Non-secret.
+    pub base_urls: std::collections::BTreeMap<String, String>,
+    /// Capability overrides keyed by provider, then model id.
     #[serde(default)]
-    pub effort_override: Option<bool>,
+    pub model_effort_overrides:
+        std::collections::BTreeMap<String, std::collections::BTreeMap<String, bool>>,
     /// How much of what the assistant proposes auto-runs. `#[serde(default)]` so
     /// an older `settings.json` parses to the default (AutoSafe).
     #[serde(default)]
@@ -92,13 +100,10 @@ impl Default for AssistantConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            provider: "anthropic".to_string(),
-            // Sonnet 4.6: cheaper/faster than Opus, very strong tool use — the
-            // recommended default driver (Opus 4.8 remains selectable).
-            model: "claude-sonnet-4-6".to_string(),
+            default_selection: AssistantModelSelection::default(),
             effort: crate::io::llm::types::Effort::High,
-            base_url: None,
-            effort_override: None,
+            base_urls: Default::default(),
+            model_effort_overrides: Default::default(),
             approval_mode: ApprovalMode::default(),
         }
     }

--- a/src/backend/config.rs
+++ b/src/backend/config.rs
@@ -21,7 +21,9 @@ pub use persist::{
     remember_recent_project, save_config, save_config_to, save_recent_projects, settings_path,
 };
 
-pub use crate::backend::assistant_config::{ApprovalMode, AssistantConfig};
+pub use crate::backend::assistant_config::{
+    ApprovalMode, AssistantConfig, AssistantModelSelection,
+};
 
 /// How the interface picks its light/dark appearance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -231,7 +233,7 @@ pub struct AppConfig {
     /// the whole parse and resetting every other setting.
     #[serde(default)]
     pub representation: RepresentationPrefs,
-    /// In-app LLM assistant selection (provider/model/effort). Never stores the
+    /// In-app LLM assistant defaults and provider options. Never stores the
     /// API key. `#[serde(default)]` so an older `settings.json` still parses.
     #[serde(default)]
     pub assistant: AssistantConfig,
@@ -503,8 +505,9 @@ mod tests {
             "default_project_dir": "/tmp/p",
             "last_project_path": null,
             "closed_to_scratch": false,
-            "assistant": { "enabled": true, "provider": "openai",
-                           "model": "gpt-5.1", "effort": "high", "base_url": null }
+            "assistant": { "enabled": true,
+                           "default_selection": { "provider": "openai", "model": "gpt-5.1" },
+                           "effort": "high", "base_urls": {} }
         }"#;
         let dir = std::env::temp_dir().join("silicolab-cfg-norepr");
         let _ = std::fs::remove_dir_all(&dir);
@@ -513,7 +516,7 @@ mod tests {
         std::fs::write(&path, json).expect("write");
 
         let config = load_config_from(&path).expect("parse despite missing representation");
-        assert_eq!(config.assistant.model, "gpt-5.1");
+        assert_eq!(config.assistant.default_selection.model, "gpt-5.1");
         assert_eq!(config.representation, super::RepresentationPrefs::default());
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -535,8 +538,9 @@ mod tests {
             "default_project_dir": "/tmp/p",
             "last_project_path": null,
             "closed_to_scratch": false,
-            "assistant": { "enabled": true, "provider": "openai",
-                           "model": "gpt-5.1", "effort": "high", "base_url": null }
+            "assistant": { "enabled": true,
+                           "default_selection": { "provider": "openai", "model": "gpt-5.1" },
+                           "effort": "high", "base_urls": {} }
         }"#;
         let parsed: AppConfig = serde_json::from_str(json).expect("legacy config should parse");
         assert_eq!(
@@ -579,8 +583,9 @@ mod tests {
             "default_project_dir": "/tmp/p",
             "last_project_path": null,
             "closed_to_scratch": false,
-            "assistant": { "enabled": true, "provider": "openai",
-                           "model": "gpt-5.1", "effort": "high", "base_url": null }
+            "assistant": { "enabled": true,
+                           "default_selection": { "provider": "openai", "model": "gpt-5.1" },
+                           "effort": "high", "base_urls": {} }
         }"#;
         let parsed: AppConfig = serde_json::from_str(json).expect("legacy config should parse");
         assert!(!parsed.show_utilization_bars);

--- a/src/backend/config/persist.rs
+++ b/src/backend/config/persist.rs
@@ -201,8 +201,10 @@ mod tests {
 
         let config = AppConfig {
             assistant: AssistantConfig {
-                provider: "openai".to_string(),
-                model: "gpt-5.1".to_string(),
+                default_selection: crate::backend::config::AssistantModelSelection {
+                    provider: "openai".to_string(),
+                    model: "gpt-5.1".to_string(),
+                },
                 ..AssistantConfig::default()
             },
             ..AppConfig::default()
@@ -212,8 +214,8 @@ mod tests {
         // No temp file left behind after the rename.
         assert!(!path.with_extension("tmp").exists());
         let back = load_config_from(&path).expect("load back");
-        assert_eq!(back.assistant.provider, "openai");
-        assert_eq!(back.assistant.model, "gpt-5.1");
+        assert_eq!(back.assistant.default_selection.provider, "openai");
+        assert_eq!(back.assistant.default_selection.model, "gpt-5.1");
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src/backend/storage/assistant.rs
+++ b/src/backend/storage/assistant.rs
@@ -50,6 +50,8 @@ impl ProjectAssistantSnapshot {
 pub struct PersistedAssistantConversation {
     pub id: u64,
     pub title: String,
+    pub provider: String,
+    pub model: String,
     #[serde(default)]
     pub history: Vec<PersistedChatMessage>,
     #[serde(default)]

--- a/src/backend/storage/tests.rs
+++ b/src/backend/storage/tests.rs
@@ -521,6 +521,8 @@ fn assistant_history_survives_save_and_load() {
         conversations: vec![PersistedAssistantConversation {
             id: 2,
             title: "Protein setup".to_string(),
+            provider: "openai".to_string(),
+            model: "gpt-5.5".to_string(),
             history: vec![
                 PersistedChatMessage {
                     role: PersistedRole::User,
@@ -622,6 +624,8 @@ fn corrupt_assistant_state_warns_but_project_loads() {
                 conversations: vec![PersistedAssistantConversation {
                     id: 1,
                     title: "Chat".to_string(),
+                    provider: "anthropic".to_string(),
+                    model: "claude-sonnet-4-6".to_string(),
                     history: Vec::new(),
                     transcript: Vec::new(),
                     input: String::new(),

--- a/src/frontend/actions.rs
+++ b/src/frontend/actions.rs
@@ -341,6 +341,11 @@ pub enum AppAction {
     },
     /// Delete one in-memory assistant conversation.
     DeleteAssistantConversation(crate::frontend::agent::AssistantConversationId),
+    /// Change the provider/model used by the active assistant conversation.
+    SwitchAssistantConversationModel {
+        provider: String,
+        model: String,
+    },
     /// Cancel the in-flight assistant turn and any pending tool batch.
     CancelAgent,
     /// Approve the gated (compute/destructive) tool call with this id.
@@ -355,7 +360,7 @@ pub enum AppAction {
     SetApprovalMode(crate::backend::config::ApprovalMode),
     /// Drop the queued (type-ahead) assistant follow-up message at this index.
     RemoveQueuedAgentInput(usize),
-    /// Switch the active assistant provider + model and persist.
+    /// Change the provider/model defaults copied into new conversations.
     SwitchProviderModel {
         provider: String,
         model: String,

--- a/src/frontend/agent/loop_driver/settings.rs
+++ b/src/frontend/agent/loop_driver/settings.rs
@@ -10,7 +10,9 @@ use crate::frontend::state::{AppState, SystemSubsystem};
 use crate::io::llm::types::Effort;
 
 pub fn new_assistant_conversation(state: &mut AppState) {
-    state.ui.agent.start_new_conversation();
+    let selection = state.config.assistant.default_selection.clone();
+    state.ui.agent.start_new_conversation(selection);
+    refresh_key_status(state);
 }
 
 pub fn switch_assistant_conversation(
@@ -19,6 +21,7 @@ pub fn switch_assistant_conversation(
     ctx: &egui::Context,
 ) {
     state.ui.agent.switch_conversation(id);
+    refresh_key_status(state);
     // A background job may have finished while this conversation was inactive; its
     // queued follow-up now dispatches against the freshly-active conversation.
     pump_queue(state, ctx);
@@ -40,24 +43,42 @@ pub fn delete_assistant_conversation(state: &mut AppState, id: AssistantConversa
         cancel_conversation_jobs(state, id);
     }
     state.ui.agent.delete_conversation(id);
+    refresh_key_status(state);
 }
 
-/// Switch the active provider + model and persist. Strips prior-provider
-/// reasoning blobs from the replayed history (ignored-but-billed, or
-/// shape-incompatible, on a different provider/model) and clears a stale base-URL
-/// override when the provider changes.
-pub fn switch_provider_model(state: &mut AppState, provider: &str, model: &str) {
-    if state.config.assistant.provider != provider {
-        // The base-URL override is provider-specific; drop it on a provider change.
-        state.config.assistant.base_url = None;
+pub fn switch_assistant_conversation_model(state: &mut AppState, provider: &str, model: &str) {
+    let Some(spec) = registry::provider_spec(provider) else {
+        return;
+    };
+    // Providers without a curated model list (currently Local) may be selected
+    // before discovery/manual entry. The composer treats that blank selection
+    // as incomplete and disables Send until a real model id is chosen.
+    let incomplete_dynamic_provider = model.trim().is_empty() && spec.models.is_empty();
+    if !state.ui.agent.can_manage_conversations()
+        || (model.trim().is_empty() && !incomplete_dynamic_provider)
+    {
+        return;
     }
-    // The effort override is per-model; drop it so the new model falls back to
-    // the registry heuristic until the user pins it again.
-    state.config.assistant.effort_override = None;
-    state.config.assistant.provider = provider.to_string();
-    state.config.assistant.model = model.to_string();
-    for conversation in &mut state.ui.agent.conversations {
-        strip_reasoning(&mut conversation.history);
+    let conversation = state.ui.agent.active_mut();
+    if conversation.selection.provider == provider && conversation.selection.model == model {
+        return;
+    }
+    strip_reasoning(&mut conversation.history);
+    conversation.selection = crate::backend::config::AssistantModelSelection {
+        provider: provider.to_string(),
+        model: model.to_string(),
+    };
+    refresh_key_status(state);
+}
+
+/// Change the provider/model defaults copied into new conversations.
+pub fn switch_provider_model(state: &mut AppState, provider: &str, model: &str) {
+    state.config.assistant.default_selection = crate::backend::config::AssistantModelSelection {
+        provider: provider.to_string(),
+        model: model.to_string(),
+    };
+    if !state.ui.agent.has_activity() {
+        switch_assistant_conversation_model(state, provider, model);
     }
     // The fetch status is global; clear it so a prior provider's spinner or
     // error note doesn't bleed onto the newly selected one. The fetched model
@@ -85,30 +106,40 @@ pub fn set_approval_mode(state: &mut AppState, mode: ApprovalMode) {
     persist(state);
 }
 
-/// Pin whether the active OpenAI-compatible model accepts a reasoning-effort
-/// knob, overriding the registry heuristic, and persist. Cleared automatically
-/// when the model or provider changes.
+/// Pin whether the default OpenAI-compatible model accepts a reasoning-effort
+/// knob, overriding the registry heuristic, and persist it per provider/model.
 pub fn set_assistant_effort_supported(state: &mut AppState, supported: bool) {
-    state.config.assistant.effort_override = Some(supported);
+    let selection = &state.config.assistant.default_selection;
+    state
+        .config
+        .assistant
+        .model_effort_overrides
+        .entry(selection.provider.clone())
+        .or_default()
+        .insert(selection.model.clone(), supported);
     persist(state);
 }
 
-/// Set (or clear, when blank) the base-URL override for an OpenAI-compatible
-/// provider and persist.
+/// Set (or clear, when blank) the default provider's base-URL override.
 pub fn set_assistant_base_url(state: &mut AppState, base_url: &str) {
     let trimmed = base_url.trim();
-    state.config.assistant.base_url = if trimmed.is_empty() {
-        None
+    let provider = state.config.assistant.default_selection.provider.clone();
+    if trimmed.is_empty() {
+        state.config.assistant.base_urls.remove(&provider);
     } else {
-        Some(trimmed.to_string())
-    };
+        state
+            .config
+            .assistant
+            .base_urls
+            .insert(provider, trimmed.to_string());
+    }
     state.ui.agent.model_fetch = ModelFetchStatus::Idle;
     persist(state);
 }
 
-/// Store the active provider's API key in the app key store (never in config).
+/// Store the default provider's API key in the app key store (never in config).
 pub fn set_assistant_api_key(state: &mut AppState, key: &str) {
-    let provider = registry::active_provider(&state.config.assistant);
+    let provider = registry::default_provider(&state.config.assistant);
     match crate::backend::secrets::set_stored_key(provider.id, key.trim()) {
         Ok(()) => state.status_success(format!("Saved the API key for {}.", provider.label)),
         Err(error) => state.report_system_error(
@@ -140,12 +171,12 @@ pub fn clear_stored_key(state: &mut AppState, provider_id: &str) {
 /// key store) and cache it on the session, so the render path never hits the
 /// key store. Called on provider/key changes and once at startup.
 pub fn refresh_key_status(state: &mut AppState) {
-    let available =
-        registry::api_key_for(registry::active_provider(&state.config.assistant)).is_some();
+    let provider = registry::provider_spec(&state.ui.agent.selection.provider);
+    let available = provider.and_then(registry::api_key_for).is_some();
     state.ui.agent.key_available = Some(available);
 }
 
-/// Kick off a live `/models` fetch for the active provider. Resolves the key the
+/// Kick off a live `/models` fetch for the default provider. Resolves the key the
 /// same way a turn does (env → key store); with no key it records an error
 /// instead of spawning. The result is drained in [`poll_model_fetch`]. A fetch
 /// already in flight is left to finish.
@@ -153,7 +184,7 @@ pub fn fetch_models(state: &mut AppState, ctx: &egui::Context) {
     if state.jobs.model_fetch.is_some() {
         return;
     }
-    let spec = registry::active_provider(&state.config.assistant);
+    let spec = registry::default_provider(&state.config.assistant);
     let Some(key) = registry::api_key_for(spec) else {
         state.ui.agent.model_fetch = ModelFetchStatus::Error(format!(
             "Add a key for {} first to list its models.",

--- a/src/frontend/agent/loop_driver/tests/jobs.rs
+++ b/src/frontend/agent/loop_driver/tests/jobs.rs
@@ -160,7 +160,7 @@ fn deleting_a_conversation_cancels_its_background_jobs() {
     let mut state = enabled_state();
     let ctx = egui::Context::default();
     let first = state.ui.agent.active_conversation;
-    state.ui.agent.start_new_conversation(); // a 2nd chat, so delete removes `first`
+    state.ui.agent.start_new_conversation(Default::default()); // a 2nd chat, so delete removes `first`
     let (_tx, rx) = std::sync::mpsc::channel();
     state.jobs.agent_jobs.push(fake_qm_job(1, first, rx));
 
@@ -192,7 +192,7 @@ fn job_finishing_in_inactive_conversation_routes_to_its_origin() {
     drop(tx);
     state.jobs.agent_jobs.push(fake_qm_job(5, origin, rx));
     // Make a different conversation active before the job completes.
-    state.ui.agent.start_new_conversation();
+    state.ui.agent.start_new_conversation(Default::default());
     let active = state.ui.agent.active_conversation;
     assert_ne!(origin, active);
 
@@ -217,7 +217,7 @@ fn switching_back_pumps_a_pending_jobdone() {
     let mut state = enabled_state();
     let ctx = egui::Context::default();
     let origin = state.ui.agent.active_conversation;
-    state.ui.agent.start_new_conversation(); // switch away from `origin`
+    state.ui.agent.start_new_conversation(Default::default()); // switch away from `origin`
     state
         .ui
         .agent
@@ -238,7 +238,7 @@ fn switching_back_pumps_a_pending_jobdone() {
 }
 
 #[test]
-fn switching_provider_strips_reasoning() {
+fn switching_conversation_model_strips_reasoning() {
     let mut state = AppState::scratch(Default::default(), Vec::new());
     state.ui.agent.history.push(ChatMessage {
         role: Role::Assistant,
@@ -247,7 +247,7 @@ fn switching_provider_strips_reasoning() {
             ContentBlock::Text("hi".to_string()),
         ],
     });
-    switch_provider_model(&mut state, "anthropic", "claude-opus-4-8");
+    switch_assistant_conversation_model(&mut state, "anthropic", "claude-opus-4-8");
     let still_has_reasoning = state.ui.agent.history.iter().any(|message| {
         message
             .content
@@ -255,7 +255,50 @@ fn switching_provider_strips_reasoning() {
             .any(|block| matches!(block, ContentBlock::OpaqueReasoning(_)))
     });
     assert!(!still_has_reasoning);
-    assert_eq!(state.config.assistant.model, "claude-opus-4-8");
+    assert_eq!(state.ui.agent.selection.model, "claude-opus-4-8");
+}
+
+#[test]
+fn model_defaults_seed_new_conversations_without_changing_existing_ones() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+    let first = state.ui.agent.active_conversation;
+    let first_selection = state.ui.agent.selection.clone();
+    state
+        .ui
+        .agent
+        .history
+        .push(ChatMessage::user_text("keep this model"));
+
+    switch_provider_model(&mut state, "openai", "gpt-5.5");
+
+    assert_eq!(state.ui.agent.selection, first_selection);
+    new_assistant_conversation(&mut state);
+    assert_eq!(state.ui.agent.selection.provider, "openai");
+    assert_eq!(state.ui.agent.selection.model, "gpt-5.5");
+    state.ui.agent.switch_conversation(first);
+    assert_eq!(state.ui.agent.selection, first_selection);
+}
+
+#[test]
+fn changing_defaults_updates_an_empty_first_conversation_for_onboarding() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+
+    switch_provider_model(&mut state, "openai", "gpt-5.5");
+
+    assert_eq!(state.ui.agent.selection.provider, "openai");
+    assert_eq!(state.ui.agent.selection.model, "gpt-5.5");
+}
+
+#[test]
+fn choosing_local_keeps_model_blank_until_discovery_or_manual_entry() {
+    let mut state = AppState::scratch(Default::default(), Vec::new());
+
+    switch_provider_model(&mut state, "local", "");
+
+    assert_eq!(state.config.assistant.default_selection.provider, "local");
+    assert!(state.config.assistant.default_selection.model.is_empty());
+    assert_eq!(state.ui.agent.selection.provider, "local");
+    assert!(state.ui.agent.selection.model.is_empty());
 }
 
 #[test]
@@ -266,7 +309,12 @@ fn changing_base_url_clears_stale_model_fetch_error() {
     set_assistant_base_url(&mut state, "https://api.example.com/v1");
 
     assert_eq!(
-        state.config.assistant.base_url.as_deref(),
+        state
+            .config
+            .assistant
+            .base_urls
+            .get("anthropic")
+            .map(String::as_str),
         Some("https://api.example.com/v1")
     );
     assert_eq!(state.ui.agent.model_fetch, ModelFetchStatus::Idle);

--- a/src/frontend/agent/loop_driver/turn.rs
+++ b/src/frontend/agent/loop_driver/turn.rs
@@ -48,7 +48,9 @@ pub fn send_agent_message(state: &mut AppState, text: &str, ctx: &egui::Context)
 /// key / bad provider without mutating history.
 fn begin_user_turn(state: &mut AppState, text: &str, ctx: &egui::Context) {
     // Surface a missing key / bad provider up front, before recording the turn.
-    if let Err(reason) = registry::build_provider(&state.config.assistant) {
+    if let Err(reason) =
+        registry::build_provider(&state.config.assistant, &state.ui.agent.selection)
+    {
         notice(state, &reason);
         return;
     }
@@ -78,7 +80,8 @@ pub fn spawn_next_turn(state: &mut AppState, ctx: &egui::Context) {
         return;
     }
 
-    let provider = match registry::build_provider(&state.config.assistant) {
+    let selection = state.ui.agent.selection.clone();
+    let provider = match registry::build_provider(&state.config.assistant, &selection) {
         Ok(provider) => provider,
         Err(reason) => {
             notice(state, &reason);
@@ -92,8 +95,9 @@ pub fn spawn_next_turn(state: &mut AppState, ctx: &egui::Context) {
         notice(state, "Trimmed older conversation to stay within context.");
     }
 
-    let stream = registry::active_provider(&state.config.assistant)
-        .caps_for(&state.config.assistant.model)
+    let stream = registry::provider_spec(&selection.provider)
+        .unwrap_or(&registry::PROVIDERS[0])
+        .caps_for(&selection.model)
         .supports_streaming;
     let project_root = state
         .workspace
@@ -101,7 +105,7 @@ pub fn spawn_next_turn(state: &mut AppState, ctx: &egui::Context) {
         .map(|project| project.root.clone());
     state.ui.agent.ensure_skills_loaded(project_root);
     let cfg = LlmConfig {
-        model: state.config.assistant.model.clone(),
+        model: selection.model,
         effort: state.config.assistant.effort,
         max_output_tokens: MAX_OUTPUT_TOKENS,
         stream,
@@ -215,10 +219,11 @@ pub fn handle_turn_result(
 
     // Record the assistant turn for replay via the provider's encoder (with a
     // provider-agnostic fallback when one can't be built, e.g. in tests).
-    let assistant_message = match registry::build_provider(&state.config.assistant) {
-        Ok(provider) => provider.encode_assistant_for_replay(&turn),
-        Err(_) => fallback_encode(&turn),
-    };
+    let assistant_message =
+        match registry::build_provider(&state.config.assistant, &state.ui.agent.selection) {
+            Ok(provider) => provider.encode_assistant_for_replay(&turn),
+            Err(_) => fallback_encode(&turn),
+        };
     state.ui.agent.history.push(assistant_message);
 
     if turn.stop == StopReason::ToolUse && !turn.tool_calls.is_empty() {
@@ -293,7 +298,9 @@ fn begin_job_followup(
     is_error: bool,
     ctx: &egui::Context,
 ) {
-    if let Err(reason) = registry::build_provider(&state.config.assistant) {
+    if let Err(reason) =
+        registry::build_provider(&state.config.assistant, &state.ui.agent.selection)
+    {
         notice(state, &reason);
         return;
     }

--- a/src/frontend/agent/mod.rs
+++ b/src/frontend/agent/mod.rs
@@ -19,6 +19,6 @@ pub use loop_driver::{
     refresh_key_status, reject_tool_call, remove_queued_agent_input, rename_assistant_conversation,
     send_agent_message, set_approval_mode, set_assistant_api_key, set_assistant_base_url,
     set_assistant_effort, set_assistant_effort_supported, set_assistant_enabled,
-    switch_assistant_conversation, switch_provider_model,
+    switch_assistant_conversation, switch_assistant_conversation_model, switch_provider_model,
 };
 pub use session::{AgentSession, AssistantConversationId, ModelFetchStatus, TranscriptEntry};

--- a/src/frontend/agent/registry.rs
+++ b/src/frontend/agent/registry.rs
@@ -2,7 +2,7 @@
 //! OpenRouter, a local model) is a row here plus reuse of the OpenAI-compatible
 //! adapter — not new loop code.
 
-use crate::backend::config::AssistantConfig;
+use crate::backend::config::{AssistantConfig, AssistantModelSelection};
 use crate::io::llm::anthropic::{AnthropicProvider, caps_for_model};
 use crate::io::llm::openai_compat::OpenAiCompatProvider;
 use crate::io::llm::provider::{LlmProvider, ProviderCaps};
@@ -92,22 +92,22 @@ pub const PROVIDERS: &[ProviderSpec] = &[
         models: &[
             ModelSpec {
                 id: "claude-sonnet-4-6",
-                label: "Claude Sonnet 4.6 (recommended)",
+                label: "Claude Sonnet 4.6",
                 supports_effort: true,
             },
             ModelSpec {
                 id: "claude-opus-4-8",
-                label: "Claude Opus 4.8 (most capable)",
+                label: "Claude Opus 4.8",
                 supports_effort: true,
             },
             ModelSpec {
                 id: "claude-fable-5",
-                label: "Claude Fable 5 (frontier)",
+                label: "Claude Fable 5",
                 supports_effort: true,
             },
             ModelSpec {
                 id: "claude-haiku-4-5",
-                label: "Claude Haiku 4.5 (fastest)",
+                label: "Claude Haiku 4.5",
                 supports_effort: false,
             },
         ],
@@ -155,7 +155,7 @@ pub const PROVIDERS: &[ProviderSpec] = &[
             },
             ModelSpec {
                 id: "gemini-3.1-pro-preview",
-                label: "Gemini 3.1 Pro (preview)",
+                label: "Gemini 3.1 Pro",
                 supports_effort: false,
             },
             ModelSpec {
@@ -220,12 +220,12 @@ pub const PROVIDERS: &[ProviderSpec] = &[
         models: &[
             ModelSpec {
                 id: "anthropic/claude-opus-4.8",
-                label: "Claude Opus 4.8 (via OpenRouter)",
+                label: "Claude Opus 4.8",
                 supports_effort: false,
             },
             ModelSpec {
                 id: "z-ai/glm-5.2",
-                label: "GLM-5.2 (via OpenRouter)",
+                label: "GLM-5.2",
                 supports_effort: false,
             },
         ],
@@ -239,7 +239,7 @@ pub const PROVIDERS: &[ProviderSpec] = &[
         reasoning_replay: false,
         models: &[ModelSpec {
             id: "gpt-5.5",
-            label: "gpt-5.5 (edit to your model)",
+            label: "gpt-5.5",
             // Default-on like any free-typed OpenAI-compatible id; the Effort
             // toggle in settings overrides this per model.
             supports_effort: true,
@@ -253,11 +253,9 @@ pub const PROVIDERS: &[ProviderSpec] = &[
         // Keyless: a local server ignores the bearer token.
         key_env: "",
         reasoning_replay: false,
-        models: &[ModelSpec {
-            id: "llama3.1",
-            label: "llama3.1 (edit to your model)",
-            supports_effort: false,
-        }],
+        // A local server can expose any model. Never pretend a particular one
+        // is installed; populate this provider from `/models` or free text.
+        models: &[],
     },
 ];
 
@@ -268,15 +266,16 @@ pub fn provider_spec(id: &str) -> Option<&'static ProviderSpec> {
 
 /// The provider a config points at, falling back to the first row if its id is
 /// unknown (e.g. a hand-edited or future-version `settings.json`).
-pub fn active_provider(config: &AssistantConfig) -> &'static ProviderSpec {
-    provider_spec(&config.provider).unwrap_or(&PROVIDERS[0])
+pub fn default_provider(config: &AssistantConfig) -> &'static ProviderSpec {
+    provider_spec(&config.default_selection.provider).unwrap_or(&PROVIDERS[0])
 }
 
 /// The effective base URL for a config: its override, else the provider default.
 pub fn effective_base_url(config: &AssistantConfig, spec: &ProviderSpec) -> String {
     config
-        .base_url
-        .as_deref()
+        .base_urls
+        .get(spec.id)
+        .map(String::as_str)
         .map(str::trim)
         .filter(|url| !url.is_empty())
         .unwrap_or(spec.base_url)
@@ -374,35 +373,54 @@ pub fn merged_model_ids(spec: &ProviderSpec, fetched: &[String]) -> Vec<(String,
 /// override applied. The override only exists for OpenAI-compatible providers
 /// (native Anthropic derives caps reliably from the model id); for those it
 /// pins `supports_effort`/`supports_thinking` on top of [`ProviderSpec::caps_for`].
-pub fn effective_caps(config: &AssistantConfig, spec: &ProviderSpec) -> ProviderCaps {
-    let mut caps = spec.caps_for(&config.model);
+pub fn effective_caps(
+    config: &AssistantConfig,
+    selection: &AssistantModelSelection,
+    spec: &ProviderSpec,
+) -> ProviderCaps {
+    let mut caps = spec.caps_for(&selection.model);
     if spec.kind == ProviderKind::OpenAiCompat
-        && let Some(supported) = config.effort_override
+        && let Some(supported) = config
+            .model_effort_overrides
+            .get(&selection.provider)
+            .and_then(|models| models.get(&selection.model))
     {
-        caps.supports_effort = supported;
-        caps.supports_thinking = supported;
+        caps.supports_effort = *supported;
+        caps.supports_thinking = *supported;
     }
     caps
 }
 
 /// Build a provider trait object from the assistant config + its env key, or a
 /// user-facing reason it can't be built (unknown provider or missing key).
-pub fn build_provider(config: &AssistantConfig) -> Result<Box<dyn LlmProvider>, String> {
-    let spec = provider_spec(&config.provider)
-        .ok_or_else(|| format!("Unknown assistant provider `{}`.", config.provider))?;
+pub fn build_provider(
+    config: &AssistantConfig,
+    selection: &AssistantModelSelection,
+) -> Result<Box<dyn LlmProvider>, String> {
+    let spec = provider_spec(&selection.provider)
+        .ok_or_else(|| format!("Unknown assistant provider `{}`.", selection.provider))?;
+    if selection.model.trim().is_empty() {
+        return Err(format!(
+            "Choose a model for {} before sending a message.",
+            spec.label
+        ));
+    }
     let key = api_key_for(spec).ok_or_else(|| {
         format!(
             "Set the {} environment variable to use {}.",
             spec.key_env, spec.label
         )
     })?;
-    let caps = effective_caps(config, spec);
+    let caps = effective_caps(config, selection, spec);
     match spec.kind {
-        ProviderKind::Native => Ok(Box::new(AnthropicProvider::new(key, config.model.clone()))),
+        ProviderKind::Native => Ok(Box::new(AnthropicProvider::new(
+            key,
+            selection.model.clone(),
+        ))),
         ProviderKind::OpenAiCompat => Ok(Box::new(OpenAiCompatProvider::new(
             key,
             effective_base_url(config, spec),
-            config.model.clone(),
+            selection.model.clone(),
             caps,
             spec.reasoning_replay,
             spec.id,
@@ -418,21 +436,36 @@ mod tests {
     fn local_provider_is_keyless() {
         let local = provider_spec("local").unwrap();
         assert_eq!(api_key_for(local), Some(String::new()));
+        assert!(local.models.is_empty());
+    }
+
+    #[test]
+    fn local_provider_requires_an_explicit_model() {
+        let config = AssistantConfig::default();
+        let selection = AssistantModelSelection {
+            provider: "local".to_string(),
+            model: String::new(),
+        };
+        let error = build_provider(&config, &selection)
+            .err()
+            .expect("blank local model should be rejected");
+        assert!(error.contains("Choose a model"));
     }
 
     #[test]
     fn base_url_override_wins() {
         let spec = provider_spec("deepseek").unwrap();
         let mut config = AssistantConfig {
-            provider: "deepseek".into(),
-            base_url: Some("https://proxy.internal/v1".into()),
             ..AssistantConfig::default()
         };
+        config
+            .base_urls
+            .insert("deepseek".into(), "https://proxy.internal/v1".into());
         assert_eq!(
             effective_base_url(&config, spec),
             "https://proxy.internal/v1"
         );
-        config.base_url = Some("   ".into());
+        config.base_urls.insert("deepseek".into(), "   ".into());
         assert_eq!(effective_base_url(&config, spec), spec.base_url);
     }
 
@@ -462,20 +495,28 @@ mod tests {
     #[test]
     fn effort_override_pins_caps_for_openai_compat() {
         let custom = provider_spec("custom_openai").expect("custom provider exists");
-        let mut config = AssistantConfig {
+        let selection = AssistantModelSelection {
             provider: "custom_openai".into(),
             model: "my-local-model".into(),
-            ..AssistantConfig::default()
         };
+        let mut config = AssistantConfig::default();
         // Default heuristic: unknown id → effort-on.
-        assert!(effective_caps(&config, custom).supports_effort);
+        assert!(effective_caps(&config, &selection, custom).supports_effort);
         // Override forces it off…
-        config.effort_override = Some(false);
-        assert!(!effective_caps(&config, custom).supports_effort);
-        assert!(!effective_caps(&config, custom).supports_thinking);
+        config
+            .model_effort_overrides
+            .entry(selection.provider.clone())
+            .or_default()
+            .insert(selection.model.clone(), false);
+        assert!(!effective_caps(&config, &selection, custom).supports_effort);
+        assert!(!effective_caps(&config, &selection, custom).supports_thinking);
         // …and back on.
-        config.effort_override = Some(true);
-        assert!(effective_caps(&config, custom).supports_effort);
+        config
+            .model_effort_overrides
+            .entry(selection.provider.clone())
+            .or_default()
+            .insert(selection.model.clone(), true);
+        assert!(effective_caps(&config, &selection, custom).supports_effort);
     }
 
     #[test]

--- a/src/frontend/agent/session.rs
+++ b/src/frontend/agent/session.rs
@@ -6,6 +6,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::ops::{Deref, DerefMut};
 
+use crate::backend::config::AssistantModelSelection;
 use crate::frontend::console::RiskLevel;
 use crate::io::llm::types::{ChatMessage, ContentBlock, ToolCall, Usage};
 
@@ -107,6 +108,7 @@ impl AssistantConversationId {
 pub struct AssistantConversation {
     pub id: AssistantConversationId,
     pub title: String,
+    pub selection: AssistantModelSelection,
     /// Neutral conversation history replayed to the provider each turn (includes
     /// prior assistant turns with their opaque reasoning blobs). The system
     /// prompt is *not* stored here — it is rebuilt per turn into `LlmConfig`.
@@ -157,10 +159,11 @@ pub struct AssistantConversation {
 }
 
 impl AssistantConversation {
-    fn new(id: AssistantConversationId, title: String) -> Self {
+    fn new(id: AssistantConversationId, title: String, selection: AssistantModelSelection) -> Self {
         Self {
             id,
             title,
+            selection,
             history: Vec::new(),
             transcript: Vec::new(),
             input: String::new(),
@@ -281,11 +284,18 @@ pub struct AgentSession {
 
 impl Default for AgentSession {
     fn default() -> Self {
+        Self::with_selection(AssistantModelSelection::default())
+    }
+}
+
+impl AgentSession {
+    pub fn with_selection(selection: AssistantModelSelection) -> Self {
         let active_conversation = AssistantConversationId::new(1);
         Self {
             conversations: vec![AssistantConversation::new(
                 active_conversation,
                 "Chat 1".to_string(),
+                selection,
             )],
             active_conversation,
             skills: Vec::new(),
@@ -382,7 +392,7 @@ impl AgentSession {
         !active.is_busy() && active.phase != AgentPhase::AwaitingApproval
     }
 
-    pub fn start_new_conversation(&mut self) {
+    pub fn start_new_conversation(&mut self, selection: AssistantModelSelection) {
         if !self.can_manage_conversations() {
             return;
         }
@@ -393,7 +403,7 @@ impl AgentSession {
         let title = format!("Chat {}", self.next_conversation_number);
         self.next_conversation_number += 1;
         self.conversations
-            .push(AssistantConversation::new(id, title));
+            .push(AssistantConversation::new(id, title, selection));
         self.active_conversation = id;
     }
 
@@ -437,7 +447,8 @@ impl AgentSession {
                 let conversation = self.active_mut();
                 let id = conversation.id;
                 let title = conversation.title.clone();
-                *conversation = AssistantConversation::new(id, title);
+                let selection = conversation.selection.clone();
+                *conversation = AssistantConversation::new(id, title, selection);
             }
             self.renaming_conversation = None;
             self.rename_buffer.clear();
@@ -504,6 +515,10 @@ mod tests {
         }
     }
 
+    fn selection() -> AssistantModelSelection {
+        AssistantModelSelection::default()
+    }
+
     #[test]
     fn new_conversation_switches_to_empty_state_and_preserves_old_content() {
         let mut session = AgentSession::default();
@@ -514,7 +529,7 @@ mod tests {
             .push(TranscriptEntry::User("old".to_string()));
         session.input = "draft".to_string();
 
-        session.start_new_conversation();
+        session.start_new_conversation(selection());
 
         assert_ne!(session.active_conversation, first);
         assert!(session.history.is_empty());
@@ -556,7 +571,7 @@ mod tests {
             ..Usage::default()
         });
 
-        session.start_new_conversation();
+        session.start_new_conversation(selection());
         let second = session.active_conversation;
         session.history.push(ChatMessage::user_text("second"));
         session.input = "second draft".to_string();
@@ -579,7 +594,11 @@ mod tests {
     fn project_snapshot_restores_conversations_without_runtime_state() {
         let mut session = AgentSession::default();
         let first = session.active_conversation;
-        session.start_new_conversation();
+        let second_selection = AssistantModelSelection {
+            provider: "openai".to_string(),
+            model: "gpt-5.5".to_string(),
+        };
+        session.start_new_conversation(second_selection.clone());
         session
             .transcript
             .push(TranscriptEntry::Assistant("second".to_string()));
@@ -600,10 +619,11 @@ mod tests {
         session.active_conversation = active;
 
         let snapshot = session.project_snapshot();
-        let restored = AgentSession::from_project_snapshot(snapshot);
+        let restored = AgentSession::from_project_snapshot(snapshot, selection());
 
         assert_eq!(restored.active_conversation, active);
         assert_eq!(restored.conversations.len(), 2);
+        assert_eq!(restored.active().selection, second_selection);
         let first_restored = restored
             .conversations
             .iter()
@@ -619,12 +639,27 @@ mod tests {
     }
 
     #[test]
+    fn empty_project_snapshot_uses_configured_default_selection() {
+        let default_selection = AssistantModelSelection {
+            provider: "openai".to_string(),
+            model: "gpt-5.5".to_string(),
+        };
+
+        let restored = AgentSession::from_project_snapshot(
+            crate::backend::storage::ProjectAssistantSnapshot::default(),
+            default_selection.clone(),
+        );
+
+        assert_eq!(restored.selection, default_selection);
+    }
+
+    #[test]
     fn deleting_active_conversation_selects_neighbor() {
         let mut session = AgentSession::default();
         let first = session.active_conversation;
-        session.start_new_conversation();
+        session.start_new_conversation(selection());
         let second = session.active_conversation;
-        session.start_new_conversation();
+        session.start_new_conversation(selection());
         let third = session.active_conversation;
 
         session.switch_conversation(second);
@@ -666,7 +701,7 @@ mod tests {
         let mut session = AgentSession::default();
         let original = session.active_conversation;
         session.phase = AgentPhase::AwaitingModel;
-        session.start_new_conversation();
+        session.start_new_conversation(selection());
         assert_eq!(session.active_conversation, original);
         assert_eq!(session.conversations.len(), 1);
 
@@ -690,7 +725,8 @@ mod tests {
 
     #[test]
     fn flush_current_backlog_clears_backlog() {
-        let mut conv = AssistantConversation::new(AssistantConversationId::new(1), "c".into());
+        let mut conv =
+            AssistantConversation::new(AssistantConversationId::new(1), "c".into(), selection());
         conv.note_backlog_start("compare methods".into(), 0);
         conv.flush_current_backlog();
         assert!(conv.current_backlog.is_none());
@@ -698,14 +734,16 @@ mod tests {
 
     #[test]
     fn flush_without_backlog_is_noop() {
-        let mut conv = AssistantConversation::new(AssistantConversationId::new(1), "c".into());
+        let mut conv =
+            AssistantConversation::new(AssistantConversationId::new(1), "c".into(), selection());
         conv.flush_current_backlog();
         assert!(conv.current_backlog.is_none());
     }
 
     #[test]
     fn resolve_drops_backlog_that_spawned_a_job() {
-        let mut conv = AssistantConversation::new(AssistantConversationId::new(1), "c".into());
+        let mut conv =
+            AssistantConversation::new(AssistantConversationId::new(1), "c".into(), selection());
         conv.note_backlog_start("optimize this".into(), 0);
         conv.resolve_current_backlog(1);
         assert!(conv.current_backlog.is_none());
@@ -713,7 +751,8 @@ mod tests {
 
     #[test]
     fn resolve_clears_backlog_when_no_new_job() {
-        let mut conv = AssistantConversation::new(AssistantConversationId::new(1), "c".into());
+        let mut conv =
+            AssistantConversation::new(AssistantConversationId::new(1), "c".into(), selection());
         conv.note_backlog_start("just answer".into(), 2);
         conv.resolve_current_backlog(2);
         assert!(conv.current_backlog.is_none());

--- a/src/frontend/agent/session/persistence.rs
+++ b/src/frontend/agent/session/persistence.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::backend::config::AssistantModelSelection;
 use crate::backend::storage::{
     PersistedAssistantConversation, PersistedChatMessage, PersistedContentBlock,
     PersistedReasoningBlob, PersistedRole, PersistedTranscriptEntry, PersistedUsage,
@@ -28,9 +29,12 @@ impl AgentSession {
         }
     }
 
-    pub fn from_project_snapshot(snapshot: ProjectAssistantSnapshot) -> Self {
+    pub fn from_project_snapshot(
+        snapshot: ProjectAssistantSnapshot,
+        default_selection: AssistantModelSelection,
+    ) -> Self {
         if snapshot.conversations.is_empty() {
-            return Self::default();
+            return Self::with_selection(default_selection);
         }
         let mut conversations: Vec<AssistantConversation> = snapshot
             .conversations
@@ -39,7 +43,7 @@ impl AgentSession {
             .map(restore_conversation)
             .collect();
         if conversations.is_empty() {
-            return Self::default();
+            return Self::with_selection(default_selection);
         }
         conversations.sort_by_key(|conversation| conversation.id.raw());
         let active_conversation = conversations
@@ -94,6 +98,8 @@ fn persist_conversation(conversation: &AssistantConversation) -> PersistedAssist
     PersistedAssistantConversation {
         id: conversation.id.raw(),
         title: conversation.title.clone(),
+        provider: conversation.selection.provider.clone(),
+        model: conversation.selection.model.clone(),
         history: resumable.history.iter().map(persist_message).collect(),
         transcript,
         input: conversation.input.clone(),
@@ -105,7 +111,11 @@ fn persist_conversation(conversation: &AssistantConversation) -> PersistedAssist
 fn restore_conversation(payload: PersistedAssistantConversation) -> AssistantConversation {
     let id = AssistantConversationId::new(payload.id);
     let title = normalize_title(&payload.title);
-    let mut conversation = AssistantConversation::new(id, title);
+    let selection = AssistantModelSelection {
+        provider: payload.provider,
+        model: payload.model,
+    };
+    let mut conversation = AssistantConversation::new(id, title, selection);
     conversation.history = payload.history.into_iter().map(restore_message).collect();
     conversation.transcript = payload
         .transcript

--- a/src/frontend/dispatcher/mod.rs
+++ b/src/frontend/dispatcher/mod.rs
@@ -371,6 +371,9 @@ pub fn dispatch(state: &mut AppState, action: AppAction, ctx: &egui::Context) {
         AppAction::DeleteAssistantConversation(id) => {
             crate::frontend::agent::delete_assistant_conversation(state, id)
         }
+        AppAction::SwitchAssistantConversationModel { provider, model } => {
+            crate::frontend::agent::switch_assistant_conversation_model(state, &provider, &model)
+        }
         AppAction::CancelAgent => crate::frontend::agent::cancel_agent(state, ctx),
         AppAction::ApproveToolCall(id) => {
             crate::frontend::agent::approve_tool_call(state, &id, ctx)

--- a/src/frontend/dispatcher/project.rs
+++ b/src/frontend/dispatcher/project.rs
@@ -266,7 +266,10 @@ pub(crate) fn replace_workspace_from_project(
     state.ui.project_viewport = snapshot.view.viewport;
     state.ui.viewport = state.ui.project_viewport.clone();
     state.ui.entry_viewports = snapshot.view.entry_viewports;
-    state.ui.agent = crate::frontend::agent::AgentSession::from_project_snapshot(assistant);
+    state.ui.agent = crate::frontend::agent::AgentSession::from_project_snapshot(
+        assistant,
+        state.config.assistant.default_selection.clone(),
+    );
     state.ui.entry_list.selected_entry_ids.clear();
     if let Some(id) = state.entries.active_entry_id() {
         state.ui.entry_list.selected_entry_ids.insert(id);
@@ -399,7 +402,9 @@ fn close_project_without_persist(state: &mut AppState, run_maintenance: bool) {
     state.ui.project_viewport = Default::default();
     state.ui.viewport = Default::default();
     state.ui.entry_viewports.clear();
-    state.ui.agent = crate::frontend::agent::AgentSession::default();
+    state.ui.agent = crate::frontend::agent::AgentSession::with_selection(
+        state.config.assistant.default_selection.clone(),
+    );
     state.config.closed_to_scratch = true;
     state.config.last_project_path = None;
     if let Err(error) = save_config(&state.config) {

--- a/src/frontend/state/app.rs
+++ b/src/frontend/state/app.rs
@@ -160,6 +160,11 @@ impl AppState {
                 .set_active_entry(state.entries.active_entry_id());
             state.ui.agent = crate::frontend::agent::AgentSession::from_project_snapshot(
                 snapshot.assistant.clone(),
+                state.config.assistant.default_selection.clone(),
+            );
+        } else {
+            state.ui.agent = crate::frontend::agent::AgentSession::with_selection(
+                state.config.assistant.default_selection.clone(),
             );
         }
         state.load_viewport_for_active_entry();

--- a/src/frontend/ui/panel_bodies/assistant.rs
+++ b/src/frontend/ui/panel_bodies/assistant.rs
@@ -10,7 +10,10 @@ use crate::frontend::{actions::AppAction, agent::AssistantConversationId, state:
 /// area's bottom margin (where the panel content rect clips) and the status bar.
 const COMPOSER_BOTTOM_PAD: f32 = 8.0;
 const ASSISTANT_SIDE_PAD: f32 = 8.0;
-pub(crate) const ASSISTANT_COMPOSER_HEIGHT: f32 = 58.0;
+/// Fixed two-row composer height. The text editor owns the full first row and
+/// the mode/model/actions own the second, so long input can never push the
+/// persistent Send/Stop controls outside the panel.
+pub(crate) const ASSISTANT_COMPOSER_HEIGHT: f32 = 92.0;
 // Must stay >= an icon button's natural width (glyph advance + 2 * button_padding.x,
 // ~29px at the current 8px padding). This is both the buttons' `min_size` width and
 // the per-button term in `reserved_width`; keeping it >= natural makes min_size win,
@@ -33,7 +36,9 @@ pub(crate) fn render_assistant_panel(
     let pal = crate::frontend::theme::palette(ui);
     ui.set_width(ui.available_width());
 
-    let provider = registry::active_provider(&state.config.assistant);
+    let selection = state.ui.agent.selection.clone();
+    let provider = registry::provider_spec(&selection.provider).unwrap_or(&registry::PROVIDERS[0]);
+    let model_selected = !selection.model.trim().is_empty();
     // Cached (the live check reads env + the key store); refreshed off the hot path.
     let key_present = state.ui.agent.key_available.unwrap_or(false);
     // Cloned so the cards can render without holding a borrow on `state`.
@@ -69,6 +74,7 @@ pub(crate) fn render_assistant_panel(
 
     let panel_rect = ui.available_rect_before_wrap();
     let content_rect = panel_rect.shrink2(egui::vec2(ASSISTANT_SIDE_PAD, 0.0));
+    let mut open_assistant_settings = false;
     ui.scope_builder(
         egui::UiBuilder::new()
             .max_rect(content_rect)
@@ -77,18 +83,11 @@ pub(crate) fn render_assistant_panel(
             ui.set_width(content_rect.width());
 
             let toolbar_height = 32.0;
-            let status_height = 28.0
-                + if state.ui.agent.last_usage.is_some() {
-                    24.0
-                } else {
-                    0.0
-                };
             let panel_width = ui.available_width();
             let approval_height = approval_block_height(&gated_calls, panel_width);
             let running_height = running_strip_height(&running_jobs);
             let queued_height = queued_strip_height(&queued);
-            let footer_height = status_height
-                + approval_height
+            let footer_height = approval_height
                 + running_height
                 + queued_height
                 + ASSISTANT_COMPOSER_HEIGHT
@@ -117,10 +116,12 @@ pub(crate) fn render_assistant_panel(
                         .show(ui, |ui| {
                             ui.set_width(transcript_content_width);
                             if state.ui.agent.transcript.is_empty() {
-                                render_assistant_empty_state(
+                                open_assistant_settings |= render_assistant_empty_state(
                                     ui,
                                     &pal,
+                                    state.config.assistant.enabled,
                                     key_present,
+                                    model_selected,
                                     provider,
                                     transcript_content_width,
                                 );
@@ -176,42 +177,7 @@ pub(crate) fn render_assistant_panel(
                 },
             );
 
-            weak_panel_hairline(ui, 14);
-            ui.add_space(3.0);
-
-            assistant_inset_row(ui, status_height.max(18.0), |ui| {
-                ui.spacing_mut().item_spacing.y = 2.0;
-                ui.add(
-                    egui::Label::new(
-                        RichText::new(format!(
-                            "{} | {}",
-                            provider.label, state.config.assistant.model
-                        ))
-                        .small()
-                        .color(pal.text_tertiary),
-                    )
-                    .wrap_mode(egui::TextWrapMode::Wrap),
-                );
-                if let Some(usage) = &state.ui.agent.last_usage {
-                    let session = &state.ui.agent.session_usage;
-                    ui.add(
-                        egui::Label::new(
-                            RichText::new(format!(
-                                "last in {} out {}; session in {} out {}",
-                                compact(usage.input_total()),
-                                compact(usage.output),
-                                compact(session.input_total()),
-                                compact(session.output),
-                            ))
-                            .small()
-                            .color(pal.text_tertiary),
-                        )
-                        .wrap_mode(egui::TextWrapMode::Wrap),
-                    );
-                }
-            });
-
-            ui.add_space(3.0);
+            ui.add_space(6.0);
 
             if !gated_calls.is_empty() {
                 assistant_inset_row(ui, approval_height, |ui| {
@@ -235,11 +201,18 @@ pub(crate) fn render_assistant_panel(
                 ui.add_space(4.0);
             }
 
-            render_assistant_composer(state, ui, actions, &pal, &running_jobs, &queued);
+            open_assistant_settings |=
+                render_assistant_composer(state, ui, actions, &pal, &running_jobs, &queued);
 
             ui.add_space(COMPOSER_BOTTOM_PAD);
         },
     );
+    if open_assistant_settings {
+        state.ui.settings.search_query.clear();
+        state.ui.settings.selected_category =
+            crate::frontend::ui::settings_registry::SettingCategory::Assistant;
+        state.ui.layout.settings_open = true;
+    }
     ui.advance_cursor_after_rect(panel_rect);
 }
 
@@ -271,8 +244,29 @@ fn assistant_toolbar(
                 ASSISTANT_TOOLBAR_BUTTON_WIDTH,
                 ASSISTANT_TOOLBAR_BUTTON_HEIGHT,
             );
+            let delete_confirm_id = ("del_conversation", active_id);
+            let confirming_delete = crate::frontend::ui::widgets::destructive_confirmation_is_armed(
+                ui,
+                delete_confirm_id,
+            );
 
-            if is_renaming {
+            if confirming_delete {
+                let is_last = conversations.len() <= 1;
+                let (prompt, confirm_word) = if is_last {
+                    ("Clear this conversation?", "Clear")
+                } else {
+                    ("Delete this conversation?", "Delete")
+                };
+                if crate::frontend::ui::widgets::confirm_destructive(
+                    ui,
+                    delete_confirm_id,
+                    prompt,
+                    confirm_word,
+                    |ui| ui.button(confirm_word),
+                ) {
+                    actions.push(AppAction::DeleteAssistantConversation(active_id));
+                }
+            } else if is_renaming {
                 let reserved_width =
                     2.0 * ASSISTANT_TOOLBAR_BUTTON_WIDTH + 2.0 * ASSISTANT_TOOLBAR_GAP;
                 let edit_width = (ui.available_width() - reserved_width).max(72.0);
@@ -281,15 +275,23 @@ fn assistant_toolbar(
                     egui::TextEdit::singleline(&mut state.ui.agent.rename_buffer)
                         .desired_width(edit_width),
                 );
+                if !response.has_focus() {
+                    response.request_focus();
+                }
                 let name_filled = !state.ui.agent.rename_buffer.trim().is_empty();
                 let submit = response.lost_focus()
                     && ui.input(|input| input.key_pressed(egui::Key::Enter))
                     && name_filled;
+                let cancel = ui.input(|input| input.key_pressed(egui::Key::Escape));
                 if submit {
                     actions.push(AppAction::RenameAssistantConversation {
                         id: active_id,
                         title: state.ui.agent.rename_buffer.clone(),
                     });
+                }
+                if cancel {
+                    state.ui.agent.renaming_conversation = None;
+                    state.ui.agent.rename_buffer.clear();
                 }
                 if ui
                     .add_enabled(
@@ -379,7 +381,7 @@ fn assistant_toolbar(
                 };
                 if crate::frontend::ui::widgets::confirm_destructive(
                     ui,
-                    ("del_conversation", active_id),
+                    delete_confirm_id,
                     prompt,
                     confirm_word,
                     |ui| {
@@ -565,15 +567,129 @@ pub(crate) fn assistant_inset_row<R>(
     )
 }
 
+pub(super) fn render_assistant_model_picker(
+    state: &AppState,
+    ui: &mut egui::Ui,
+    actions: &mut Vec<AppAction>,
+    provider: &crate::frontend::agent::registry::ProviderSpec,
+    current_model: &str,
+    width: f32,
+) -> bool {
+    use crate::frontend::agent::registry;
+
+    let can_switch = state.ui.agent.can_manage_conversations();
+    let selected_label = provider
+        .models
+        .iter()
+        .find(|model| model.id == current_model)
+        .map(|model| model.label)
+        .unwrap_or(current_model);
+    let selected_label = if selected_label.trim().is_empty() {
+        "Choose model…".to_string()
+    } else {
+        compact_model_label(selected_label, if width < 76.0 { 8 } else { 14 })
+    };
+    let mut open_settings = false;
+    let response = egui::ComboBox::from_id_salt("assistant.conversation_model")
+        .selected_text(assistant_text(selected_label))
+        .width(width.max(28.0))
+        .truncate()
+        .show_ui(ui, |ui| {
+            crate::frontend::theme::stabilize_selectable_rows(ui);
+            ui.set_min_width(220.0);
+            for spec in registry::PROVIDERS {
+                ui.label(RichText::new(spec.label).small().strong());
+                let available = registry::api_key_for(spec).is_some();
+                let fetched = state
+                    .ui
+                    .agent
+                    .fetched_models
+                    .get(spec.id)
+                    .map(Vec::as_slice)
+                    .unwrap_or_default();
+                let models = registry::merged_model_ids(spec, fetched);
+                if models.is_empty() {
+                    ui.label(
+                        RichText::new("Choose in Assistant settings")
+                            .small()
+                            .color(crate::frontend::theme::palette(ui).text_tertiary),
+                    );
+                }
+                for (model, label) in models {
+                    let selected = spec.id == provider.id && model == current_model;
+                    let response = ui.add_enabled(
+                        can_switch && available,
+                        egui::Button::selectable(selected, assistant_text(&label)),
+                    );
+                    let response = if available {
+                        response
+                    } else {
+                        response.on_hover_text("Add an API key for this provider first")
+                    };
+                    if response.clicked() && !selected {
+                        actions.push(AppAction::SwitchAssistantConversationModel {
+                            provider: spec.id.to_string(),
+                            model,
+                        });
+                        ui.close();
+                    }
+                }
+                if !available {
+                    ui.label(
+                        RichText::new("API key required")
+                            .small()
+                            .color(crate::frontend::theme::palette(ui).text_tertiary),
+                    );
+                }
+                ui.add_space(3.0);
+            }
+            ui.separator();
+            if ui.button("Manage providers and API keys…").clicked() {
+                open_settings = true;
+                ui.close();
+            }
+        });
+    let mut hover = format!("{} · {}", provider.label, current_model);
+    if let Some(usage) = &state.ui.agent.last_usage {
+        let session = &state.ui.agent.session_usage;
+        hover.push_str(&format!(
+            "\nLast: {} in / {} out\nSession: {} in / {} out",
+            compact(usage.input_total()),
+            compact(usage.output),
+            compact(session.input_total()),
+            compact(session.output),
+        ));
+    }
+    response.response.on_hover_text(hover);
+    open_settings
+}
+
+fn compact_model_label(label: &str, max_chars: usize) -> String {
+    let without_qualifier = label.split(" (").next().unwrap_or(label);
+    let short = ["Claude ", "Anthropic ", "OpenAI ", "Google "]
+        .iter()
+        .find_map(|prefix| without_qualifier.strip_prefix(prefix))
+        .unwrap_or(without_qualifier);
+    let count = short.chars().count();
+    if count <= max_chars {
+        return short.to_string();
+    }
+    let keep = max_chars.saturating_sub(1);
+    format!("{}…", short.chars().take(keep).collect::<String>())
+}
+
 /// First-run welcome shown when the transcript is empty: a centered prompt plus
 /// a missing-key callout when no credential is configured.
 fn render_assistant_empty_state(
     ui: &mut egui::Ui,
     pal: &crate::frontend::theme::Palette,
+    assistant_enabled: bool,
     key_present: bool,
+    model_selected: bool,
     provider: &crate::frontend::agent::registry::ProviderSpec,
     width: f32,
-) {
+) -> bool {
+    let mut open_settings = false;
     ui.set_width(width);
     ui.add_space(12.0);
     ui.vertical_centered(|ui| {
@@ -584,35 +700,80 @@ fn render_assistant_empty_state(
                 .color(pal.accent_soft()),
         );
         ui.add_space(6.0);
-        ui.label(
-            RichText::new("How can I help?")
-                .strong()
-                .color(pal.text_primary),
-        );
+        let title = if assistant_enabled && key_present && model_selected {
+            "How can I help?"
+        } else if assistant_enabled && key_present {
+            "Choose a model"
+        } else {
+            "Set up your Assistant"
+        };
+        ui.label(RichText::new(title).strong().color(pal.text_primary));
         ui.add_space(2.0);
-        ui.label(
-            RichText::new(
-                "Fetch a structure, restyle the view, or set up a calculation — try \
-                 \"fetch 1ubq and show it as cartoon\". I drive SilicoLab with the same \
-                 console commands you would type.",
-            )
-            .small()
-            .color(pal.text_tertiary),
-        );
+        let description = if assistant_enabled && key_present && model_selected {
+            "Fetch a structure, restyle the view, or set up a calculation — try \
+             “fetch 1ubq and show it as cartoon”. I drive SilicoLab with the same \
+             console commands you would type."
+        } else if assistant_enabled && key_present {
+            "Refresh models from your local server or enter its exact model id before your first message."
+        } else if !assistant_enabled && key_present {
+            "The Assistant is turned off. Enable it to start using the model already configured."
+        } else if !assistant_enabled {
+            "The Assistant is turned off. Enable it, choose a provider, and add its API key."
+        } else {
+            "Connect a model before your first message. It takes three quick steps:"
+        };
+        ui.label(RichText::new(description).small().color(pal.text_tertiary));
+        if !assistant_enabled || !key_present || !model_selected {
+            ui.add_space(8.0);
+            let steps = if assistant_enabled && key_present && !model_selected {
+                [
+                    "1  Start Ollama or a compatible server",
+                    "2  Refresh models or enter a model id",
+                    "3  Return here and start chatting",
+                ]
+            } else if !assistant_enabled && key_present {
+                [
+                    "1  Enable the Assistant",
+                    "2  Review the default model",
+                    "3  Return here and start chatting",
+                ]
+            } else {
+                [
+                    "1  Choose a provider",
+                    "2  Add its API key",
+                    "3  Return here and start chatting",
+                ]
+            };
+            for step in steps {
+                ui.label(RichText::new(step).small().color(pal.text_primary));
+            }
+            ui.add_space(10.0);
+            let label = if assistant_enabled && key_present && !model_selected {
+                "Choose model"
+            } else if assistant_enabled {
+                "Set up Assistant"
+            } else {
+                "Enable and set up Assistant"
+            };
+            if ui
+                .add(
+                    Button::new(RichText::new(label).color(Color32::WHITE))
+                        .fill(pal.accent)
+                        .corner_radius(CornerRadius::same(crate::frontend::theme::radius::CONTROL)),
+                )
+                .clicked()
+            {
+                open_settings = true;
+            }
+            ui.add_space(5.0);
+            ui.label(
+                RichText::new(format!("Current choice: {}", provider.label))
+                    .small()
+                    .color(pal.text_tertiary),
+            );
+        }
     });
-    if !key_present {
-        ui.add_space(10.0);
-        ui.label(
-            RichText::new(format!(
-                "{}  No API key found. Add one in Settings ▸ Assistant, set {} and restart, \
-                 or pick another provider there.",
-                egui_phosphor::regular::WARNING,
-                provider.key_env
-            ))
-            .small()
-            .color(pal.status_amber),
-        );
-    }
+    open_settings
 }
 
 /// Linear blend toward `b` (`t` = 0 → `a`, `t` = 1 → `b`), used for tinted

--- a/src/frontend/ui/panel_bodies/assistant_composer.rs
+++ b/src/frontend/ui/panel_bodies/assistant_composer.rs
@@ -49,10 +49,11 @@ pub(crate) fn render_assistant_composer(
     pal: &Palette,
     running_jobs: &[crate::frontend::jobs::LiveJobSnapshot],
     queued: &[String],
-) {
+) -> bool {
     let busy = state.ui.agent.is_busy();
     let assistant_enabled = state.config.assistant.enabled;
     let key_present = state.ui.agent.key_available.unwrap_or(false);
+    let model_selected = !state.ui.agent.selection.model.trim().is_empty();
     let running_height = running_strip_height(running_jobs);
     let queued_height = queued_strip_height(queued);
 
@@ -115,22 +116,25 @@ pub(crate) fn render_assistant_composer(
     // The user can submit whenever the assistant is enabled and keyed. If a
     // turn/computation is in flight (or a call awaits approval) the message is
     // queued rather than sent now — `send_agent_message` makes that call.
-    let can_submit = assistant_enabled && key_present;
+    let can_submit = assistant_enabled && key_present && model_selected;
     let will_queue = busy || state.ui.agent.pending_approval().is_some();
     let hint = if !assistant_enabled {
         "Assistant disabled"
     } else if !key_present {
-        "Set the API key env var"
+        "Set up API access above"
+    } else if !model_selected {
+        "Choose a model below"
     } else if busy {
         "Working… (Enter queues a follow-up)"
     } else {
         "Ask the assistant anything"
     };
 
-    let composer_radius = radius::CARD;
-    let inner_radius = radius::concentric(composer_radius, 4);
+    let composer_radius = radius::LARGE;
+    let inner_radius = radius::concentric(composer_radius, 5);
     let mut composer_focused = false;
     let mut send = false;
+    let mut open_assistant_settings = false;
     let mut composer_rect = egui::Rect::NOTHING;
     assistant_inset_row(ui, ASSISTANT_COMPOSER_HEIGHT, |ui| {
         let content_width = ui.available_width().max(96.0);
@@ -142,39 +146,43 @@ pub(crate) fn render_assistant_composer(
             .inner_margin(Margin::symmetric(8, 8))
             .show(ui, |ui| {
                 ui.set_width(frame_inner_width);
-                ui.horizontal(|ui| {
-                    ui.spacing_mut().item_spacing.x = 6.0;
-                    const BUTTON_SIZE: f32 = 26.0;
-                    // While busy the row carries both Stop and Send, so reserve
-                    // width for two buttons; otherwise just the Send button.
-                    let buttons_reserved = if busy {
-                        2.0 * BUTTON_SIZE + 6.0
-                    } else {
-                        BUTTON_SIZE
-                    };
-                    let text_width = (ui.available_width() - buttons_reserved - 6.0).max(48.0);
+                let response = ui.add_sized(
+                    [frame_inner_width, 42.0],
+                    egui::TextEdit::multiline(&mut state.ui.agent.input)
+                        .desired_width(frame_inner_width)
+                        .desired_rows(2)
+                        .font(assistant_body_font_id())
+                        .frame(Frame::NONE)
+                        .hint_text(hint),
+                );
+                composer_focused = response.has_focus();
+                if response.has_focus()
+                    && ui.input(|input| {
+                        input.key_pressed(egui::Key::Enter) && !input.modifiers.shift
+                    })
+                {
+                    send = true;
+                }
 
-                    let response = ui.add_sized(
-                        [text_width, 38.0],
-                        egui::TextEdit::multiline(&mut state.ui.agent.input)
-                            .desired_width(text_width)
-                            .desired_rows(2)
-                            .font(assistant_body_font_id())
-                            .frame(Frame::NONE)
-                            .hint_text(hint),
-                    );
-                    composer_focused = response.has_focus();
-                    if response.has_focus()
-                        && ui.input(|input| {
-                            input.key_pressed(egui::Key::Enter) && !input.modifiers.shift
-                        })
-                    {
-                        send = true;
-                    }
+                ui.add_space(6.0);
+                let (toolbar_rect, _) = ui
+                    .allocate_exact_size(egui::vec2(frame_inner_width, 28.0), egui::Sense::hover());
+                const BUTTON_SIZE: f32 = 28.0;
+                const CONTROL_GAP: f32 = 4.0;
+                const ACTION_GAP: f32 = 6.0;
 
-                    ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                        // Primary send/queue button (rightmost). Enabled whenever
-                        // the assistant is keyed; it queues if a turn is in flight.
+                // Give actions explicit right-anchored rectangles. The controls
+                // are clipped to the remaining rectangle and therefore cannot
+                // paint over or displace Send, even at the 240px sidebar minimum.
+                let send_rect = egui::Rect::from_min_size(
+                    egui::pos2(toolbar_rect.right() - BUTTON_SIZE, toolbar_rect.top()),
+                    egui::vec2(BUTTON_SIZE, BUTTON_SIZE),
+                );
+                ui.scope_builder(
+                    egui::UiBuilder::new()
+                        .max_rect(send_rect)
+                        .layout(Layout::centered_and_justified(egui::Direction::LeftToRight)),
+                    |ui| {
                         let (fill, ink) = if can_submit {
                             (pal.accent, Color32::WHITE)
                         } else {
@@ -189,25 +197,83 @@ pub(crate) fn render_assistant_composer(
                         let send_resp = if will_queue {
                             send_resp.on_hover_text("Queue a follow-up")
                         } else {
-                            send_resp
+                            send_resp.on_hover_text("Send")
                         };
                         if send_resp.clicked() {
                             send = true;
                         }
-                        // While a turn/computation runs, a Stop button to its left.
-                        if busy {
+                    },
+                );
+
+                let mut controls_right = send_rect.left() - ACTION_GAP;
+                if busy {
+                    let stop_rect = egui::Rect::from_min_size(
+                        egui::pos2(controls_right - BUTTON_SIZE, toolbar_rect.top()),
+                        egui::vec2(BUTTON_SIZE, BUTTON_SIZE),
+                    );
+                    ui.scope_builder(
+                        egui::UiBuilder::new()
+                            .max_rect(stop_rect)
+                            .layout(Layout::centered_and_justified(egui::Direction::LeftToRight)),
+                        |ui| {
                             let stop = Button::new(
-                                RichText::new(egui_phosphor::regular::X).color(pal.text_primary),
+                                RichText::new(egui_phosphor::regular::STOP).color(pal.text_primary),
                             )
                             .fill(pal.neutral_overlay(20))
                             .corner_radius(CornerRadius::same(inner_radius))
                             .min_size(egui::vec2(BUTTON_SIZE, BUTTON_SIZE));
-                            if ui.add(stop).on_hover_text("Stop").clicked() {
+                            if ui.add(stop).on_hover_text("Stop current task").clicked() {
                                 actions.push(AppAction::CancelAgent);
                             }
+                        },
+                    );
+                    controls_right = stop_rect.left() - ACTION_GAP;
+                }
+
+                let controls_rect = egui::Rect::from_min_max(
+                    toolbar_rect.left_top(),
+                    egui::pos2(
+                        controls_right.max(toolbar_rect.left()),
+                        toolbar_rect.bottom(),
+                    ),
+                );
+                ui.scope_builder(
+                    egui::UiBuilder::new()
+                        .max_rect(controls_rect)
+                        .layout(Layout::left_to_right(Align::Center)),
+                    |ui| {
+                        ui.set_clip_rect(controls_rect);
+                        ui.spacing_mut().item_spacing.x = CONTROL_GAP;
+                        ui.spacing_mut().interact_size.y = BUTTON_SIZE;
+                        let controls_width = controls_rect.width();
+                        if controls_width <= 1.0 {
+                            return;
                         }
-                    });
-                });
+                        let mode_width = if controls_width >= 150.0 {
+                            72.0
+                        } else if controls_width >= 96.0 {
+                            56.0
+                        } else {
+                            (controls_width * 0.42).max(28.0)
+                        };
+                        let model_width =
+                            (controls_width - mode_width - CONTROL_GAP).clamp(28.0, 132.0);
+                        render_approval_mode_picker(state, ui, actions, mode_width);
+
+                        let selection = state.ui.agent.selection.clone();
+                        let provider =
+                            crate::frontend::agent::registry::provider_spec(&selection.provider)
+                                .unwrap_or(&crate::frontend::agent::registry::PROVIDERS[0]);
+                        open_assistant_settings |= render_assistant_model_picker(
+                            state,
+                            ui,
+                            actions,
+                            provider,
+                            &selection.model,
+                            model_width,
+                        );
+                    },
+                );
             });
         composer_rect = response.response.rect;
     });
@@ -227,5 +293,57 @@ pub(crate) fn render_assistant_composer(
             actions.push(AppAction::SendAgentMessage(message));
             state.ui.agent.input.clear();
         }
+    }
+    open_assistant_settings
+}
+
+/// Compact, point-of-action permission control inspired by agent-first IDEs.
+/// The persisted approval policy remains the single source of truth; this is a
+/// second presentation of the same dispatcher action used in Settings.
+fn render_approval_mode_picker(
+    state: &AppState,
+    ui: &mut egui::Ui,
+    actions: &mut Vec<AppAction>,
+    width: f32,
+) {
+    use crate::backend::config::ApprovalMode;
+
+    let current = state.config.assistant.approval_mode;
+    let selected = compact_approval_label(current);
+    let can_switch = state.ui.agent.can_manage_conversations();
+    let response = ui
+        .add_enabled_ui(can_switch, |ui| {
+            egui::ComboBox::from_id_salt("assistant.composer_approval_mode")
+                .selected_text(assistant_text(selected))
+                .width(width.max(34.0))
+                .truncate()
+                .show_ui(ui, |ui| {
+                    crate::frontend::theme::stabilize_selectable_rows(ui);
+                    ui.set_min_width(250.0);
+                    for mode in ApprovalMode::all() {
+                        if ui
+                            .selectable_label(mode == current, assistant_text(mode.label()))
+                            .clicked()
+                            && mode != current
+                        {
+                            actions.push(AppAction::SetApprovalMode(mode));
+                            ui.close();
+                        }
+                    }
+                })
+        })
+        .inner;
+    response
+        .response
+        .on_hover_text(format!("Agent permissions\n{}", current.label()));
+}
+
+fn compact_approval_label(mode: crate::backend::config::ApprovalMode) -> &'static str {
+    use crate::backend::config::ApprovalMode;
+    match mode {
+        ApprovalMode::Manual => "Manual",
+        ApprovalMode::AutoSafe => "Safe",
+        ApprovalMode::Auto => "Auto",
+        ApprovalMode::Plan => "Plan",
     }
 }

--- a/src/frontend/ui/settings_registry/custom.rs
+++ b/src/frontend/ui/settings_registry/custom.rs
@@ -82,12 +82,21 @@ pub(crate) fn render_assistant_settings(
     );
     ui.add_space(6.0);
 
-    let provider = registry::active_provider(&state.config.assistant);
-    let current_model = state.config.assistant.model.clone();
+    let provider = registry::default_provider(&state.config.assistant);
+    let current_model = state.config.assistant.default_selection.model.clone();
+
+    ui.label(
+        RichText::new(
+            "These defaults are copied into new conversations. Switch the current conversation's model directly in Assistant.",
+        )
+        .size(CAPTION_SIZE)
+        .color(pal.text_tertiary),
+    );
+    ui.add_space(4.0);
 
     // Provider picker (data-driven).
     ui.horizontal(|ui| {
-        ui.label("Provider");
+        ui.label("Default provider");
         egui::ComboBox::from_id_salt("assistant.provider")
             .selected_text(provider.label)
             .show_ui(ui, |ui| {
@@ -98,11 +107,22 @@ pub(crate) fn render_assistant_settings(
                         .clicked()
                         && spec.id != provider.id
                     {
-                        // Switching provider resets to its first model.
+                        // Prefer a curated model, then a previously discovered
+                        // live model. Dynamic providers such as Local remain
+                        // intentionally blank until discovery or manual entry.
                         let model = spec
                             .models
                             .first()
                             .map(|model| model.id.to_string())
+                            .or_else(|| {
+                                state
+                                    .ui
+                                    .agent
+                                    .fetched_models
+                                    .get(spec.id)
+                                    .and_then(|models| models.first())
+                                    .cloned()
+                            })
                             .unwrap_or_default();
                         actions.push(AppAction::SwitchProviderModel {
                             provider: spec.id.to_string(),
@@ -129,13 +149,26 @@ pub(crate) fn render_assistant_settings(
         .iter()
         .find(|(id, _)| *id == current_model)
         .map(|(_, label)| label.clone())
-        .unwrap_or_else(|| current_model.clone());
+        .unwrap_or_else(|| {
+            if current_model.trim().is_empty() {
+                "Choose model…".to_string()
+            } else {
+                current_model.clone()
+            }
+        });
     ui.horizontal(|ui| {
-        ui.label("Model");
+        ui.label("Default model");
         egui::ComboBox::from_id_salt("assistant.model")
             .selected_text(selected_model_label)
             .show_ui(ui, |ui| {
                 crate::frontend::theme::stabilize_selectable_rows(ui);
+                if models.is_empty() {
+                    ui.label(
+                        RichText::new("No models detected")
+                            .small()
+                            .color(pal.text_tertiary),
+                    );
+                }
                 for (id, label) in &models {
                     if ui.selectable_label(*id == current_model, label).clicked()
                         && *id != current_model
@@ -175,8 +208,13 @@ pub(crate) fn render_assistant_settings(
         }
         _ => {}
     }
+    let model_help = if provider.models.is_empty() {
+        "Refresh from the local server or enter its exact model id below."
+    } else {
+        "Live list from the provider; offline keeps the built-in list."
+    };
     ui.label(
-        RichText::new("Live list from the provider; offline keeps the built-in list.")
+        RichText::new(model_help)
             .size(CAPTION_SIZE)
             .color(pal.text_tertiary),
     );
@@ -188,7 +226,11 @@ pub(crate) fn render_assistant_settings(
         "assistant.model_text",
         "Model id",
         &current_model,
-        "e.g. deepseek-reasoner",
+        if provider.id == "local" {
+            "e.g. llama3.1"
+        } else {
+            "e.g. deepseek-reasoner"
+        },
     ) && model != current_model
     {
         actions.push(AppAction::SwitchProviderModel {
@@ -216,7 +258,11 @@ pub(crate) fn render_assistant_settings(
     // Effort picker — only meaningful where the model accepts it. Caps fold in
     // the per-model override (see `registry::effective_caps`), so a custom
     // endpoint pointed at a reasoning model isn't greyed out.
-    let caps = registry::effective_caps(&state.config.assistant, provider);
+    let caps = registry::effective_caps(
+        &state.config.assistant,
+        &state.config.assistant.default_selection,
+        provider,
+    );
     let current_effort = state.config.assistant.effort;
     ui.horizontal(|ui| {
         ui.label("Effort");

--- a/src/frontend/ui/widgets.rs
+++ b/src/frontend/ui/widgets.rs
@@ -318,6 +318,19 @@ pub(crate) fn confirm_destructive(
     fired
 }
 
+/// Whether a [`confirm_destructive`] control with this salt is currently armed.
+/// Callers can use this to give the confirmation row more room than its resting
+/// trigger without owning a second copy of the transient state.
+pub(crate) fn destructive_confirmation_is_armed(
+    ui: &egui::Ui,
+    id_salt: impl std::hash::Hash,
+) -> bool {
+    let confirm_id = ui.id().with(id_salt);
+    let now = ui.ctx().cumulative_pass_nr();
+    let armed_at = ui.data(|data| data.get_temp::<u64>(confirm_id));
+    confirm_is_armed(armed_at, now)
+}
+
 /// Armed only if the flag was refreshed on the current or immediately preceding
 /// pass; a wider gap means the control was off-screen for a pass, which disarms.
 fn confirm_is_armed(armed_at: Option<u64>, now: u64) -> bool {
@@ -358,6 +371,19 @@ mod tests {
                 confirm_destructive(ui, "salt", "Delete it?", "Delete", |ui| ui.button("Delete"));
         });
         assert!(!fired, "resting frame with no click must not fire");
+    }
+
+    #[test]
+    fn destructive_confirmation_state_is_visible_to_layout_callers() {
+        let ctx = egui::Context::default();
+        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+            let salt = ("delete", 7_u64);
+            let id = ui.id().with(salt);
+            let now = ui.ctx().cumulative_pass_nr();
+            ui.data_mut(|data| data.insert_temp(id, now));
+
+            assert!(destructive_confirmation_is_armed(ui, salt));
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make provider and model selection conversation-specific
- add configurable defaults for newly created conversations
- persist each conversation's provider and model with project data
- redesign the assistant composer with model and approval-mode controls
- improve conversation management, setup guidance, and destructive-action confirmation
- support provider-specific base URLs and per-model reasoning capability overrides
- improve local-provider model discovery and manual model selection

## Validation

- `cargo pr-check`
- assistant conversation creation, switching, renaming, clearing, and deletion
- conversation provider/model switching
- project save and restore with multiple conversation selections
- narrow assistant-panel and composer layouts
- assistant setup states with missing keys or models

## Notes

SilicoLab has not released a version containing the previous assistant persistence format, so this change does not include migration logic for pre-redesign settings or project snapshots.
