### PR TITLE
feat: add external agent CLI providers (Codex, Claude)

### DIFF
--- a/compute-core/src/io/llm/anthropic/tests.rs
+++ b/compute-core/src/io/llm/anthropic/tests.rs
@@ -22,6 +22,7 @@ fn sonnet_45_disables_effort() {
 fn haiku_request_omits_thinking_and_effort() {
     let provider = AnthropicProvider::new("k".into(), "claude-haiku-4-5".into());
     let cfg = LlmConfig {
+        working_dir: None,
         model: "claude-haiku-4-5".into(),
         effort: Effort::High,
         max_output_tokens: 1000,
@@ -39,6 +40,7 @@ fn haiku_request_omits_thinking_and_effort() {
 fn opus_request_sends_adaptive_thinking_and_effort() {
     let provider = AnthropicProvider::new("k".into(), "claude-opus-4-8".into());
     let cfg = LlmConfig {
+        working_dir: None,
         model: "claude-opus-4-8".into(),
         effort: Effort::XHigh,
         max_output_tokens: 1000,
@@ -147,6 +149,7 @@ fn parse_sse_reconstructs_turn_and_streams_text() {
 fn streaming_request_sets_stream_flag() {
     let provider = AnthropicProvider::new("k".into(), "claude-sonnet-4-6".into());
     let cfg = LlmConfig {
+        working_dir: None,
         model: "claude-sonnet-4-6".into(),
         effort: Effort::High,
         max_output_tokens: 1000,

--- a/compute-core/src/io/llm/external.rs
+++ b/compute-core/src/io/llm/external.rs
@@ -1,0 +1,522 @@
+//! Adapters for locally installed, authenticated agent CLIs.
+
+use std::{
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use serde_json::{Value, json};
+
+use super::{
+    provider::{LlmProvider, ProviderCaps},
+    types::{
+        AssistantTurn, ChatMessage, ContentBlock, LlmConfig, LlmError, ReasoningBlob, Role,
+        StopReason, StreamEvent, ToolCall, ToolDef, Usage,
+    },
+};
+use crate::engines::process::{self, ProcessConfig};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExternalAgentKind {
+    Codex,
+    Claude,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExternalAgent {
+    kind: ExternalAgentKind,
+    executable: Option<PathBuf>,
+    access: ExternalAccess,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExternalAccess {
+    Controlled,
+    Unrestricted,
+}
+
+impl ExternalAgent {
+    pub fn new(
+        kind: ExternalAgentKind,
+        executable: Option<String>,
+        access: ExternalAccess,
+    ) -> Self {
+        Self {
+            kind,
+            executable: executable.map(PathBuf::from),
+            access,
+        }
+    }
+
+    fn executable(&self) -> Result<PathBuf, LlmError> {
+        if let Some(path) = &self.executable {
+            return Ok(prefer_windows_executable(path));
+        }
+        let names: &[&str] = match self.kind {
+            ExternalAgentKind::Codex => &["codex"],
+            ExternalAgentKind::Claude => &["claude"],
+        };
+        names
+            .iter()
+            .find_map(|name| process::find_on_path(name).map(|path| prefer_windows_executable(&path)))
+            .ok_or_else(|| {
+                LlmError::Network(format!(
+                    "{} CLI was not found. Install it separately and sign in with its own login flow.",
+                    self.label()
+                ))
+            })
+    }
+
+    fn label(&self) -> &'static str {
+        match self.kind {
+            ExternalAgentKind::Codex => "Codex",
+            ExternalAgentKind::Claude => "Claude",
+        }
+    }
+
+    fn args(&self, cfg: &LlmConfig, schema_path: &str) -> Vec<String> {
+        let mut args = match self.kind {
+            ExternalAgentKind::Codex => vec![
+                "exec".into(),
+                "--json".into(),
+                "--ephemeral".into(),
+                "--output-schema".into(),
+                schema_path.into(),
+                "-".into(),
+            ],
+            ExternalAgentKind::Claude => vec![
+                "-p".into(),
+                "--output-format".into(),
+                "stream-json".into(),
+                // stream-json output is rejected in print mode without --verbose.
+                "--verbose".into(),
+                "--include-partial-messages".into(),
+                "--no-session-persistence".into(),
+                "--json-schema".into(),
+                schema_path.into(),
+            ],
+        };
+        if !cfg.model.trim().is_empty() {
+            args.extend(["--model".into(), cfg.model.clone()]);
+        }
+        match (self.kind, self.access) {
+            (ExternalAgentKind::Codex, ExternalAccess::Controlled) => {
+                args.extend(["--sandbox".into(), "read-only".into()])
+            }
+            (ExternalAgentKind::Codex, ExternalAccess::Unrestricted) => {
+                args.push("--dangerously-bypass-approvals-and-sandbox".into())
+            }
+            (ExternalAgentKind::Claude, ExternalAccess::Controlled) => {
+                args.extend(["--permission-mode".into(), "plan".into()])
+            }
+            (ExternalAgentKind::Claude, ExternalAccess::Unrestricted) => {
+                args.push("--dangerously-skip-permissions".into())
+            }
+        }
+        args
+    }
+}
+
+impl LlmProvider for ExternalAgent {
+    fn complete(
+        &self,
+        cfg: &LlmConfig,
+        tools: &[ToolDef],
+        history: &[ChatMessage],
+        cancel: &Arc<AtomicBool>,
+        on_event: &mut dyn FnMut(StreamEvent),
+    ) -> Result<AssistantTurn, LlmError> {
+        let executable = self.executable()?;
+        let schema = external_schema(tools).to_string();
+        // Both CLIs take the output schema as a file path, not inline JSON.
+        let schema_file = std::env::temp_dir().join(format!(
+            "silicolab-agent-schema-{}-{}.json",
+            std::process::id(),
+            unique_suffix()
+        ));
+        std::fs::write(&schema_file, &schema).map_err(|e| {
+            LlmError::Network(format!(
+                "could not prepare {} output schema: {e}",
+                self.label()
+            ))
+        })?;
+        let schema_arg = schema_file.to_string_lossy().into_owned();
+        let work = cfg
+            .working_dir
+            .clone()
+            .or_else(|| std::env::current_dir().ok())
+            .ok_or_else(|| {
+                LlmError::Network("could not determine external agent working directory".into())
+            })?;
+        let stdin = render_prompt(cfg, history, tools).into_bytes();
+        // Share the turn's cancel flag with the child so a user cancel kills it
+        // promptly instead of waiting out the timeout.
+        let result = process::spawn_with_cancel(
+            ProcessConfig::new(executable, work)
+                .args(self.args(cfg, &schema_arg))
+                .stdin_bytes(stdin)
+                .timeout(Duration::from_secs(30 * 60)),
+            Arc::clone(cancel),
+        )
+        .and_then(process::ProcessHandle::join);
+        let _ = std::fs::remove_file(&schema_file);
+        let result = result.map_err(|e| LlmError::Network(e.to_string()))?;
+        if cancel.load(Ordering::Relaxed) || result.cancelled {
+            return Err(LlmError::Cancelled);
+        }
+        if result.timed_out {
+            return Err(LlmError::Network("external agent timed out".into()));
+        }
+        if result.exit_code != 0 {
+            return Err(classify_cli_error(
+                &result.stderr,
+                result.exit_code,
+                self.label(),
+            ));
+        }
+        parse_jsonl(&result.stdout, on_event)
+    }
+
+    fn encode_assistant_for_replay(&self, turn: &AssistantTurn) -> ChatMessage {
+        let mut content = Vec::new();
+        if !turn.text.is_empty() {
+            content.push(ContentBlock::Text(turn.text.clone()));
+        }
+        for call in &turn.tool_calls {
+            content.push(ContentBlock::ToolUse {
+                id: call.id.clone(),
+                name: call.name.clone(),
+                input: call.input.clone(),
+            });
+        }
+        ChatMessage {
+            role: Role::Assistant,
+            content,
+        }
+    }
+    fn id(&self) -> &str {
+        match self.kind {
+            ExternalAgentKind::Codex => "codex-cli",
+            ExternalAgentKind::Claude => "claude-cli",
+        }
+    }
+    fn caps(&self) -> ProviderCaps {
+        ProviderCaps {
+            supports_effort: false,
+            supports_thinking: false,
+            supports_prompt_cache: false,
+            supports_streaming: true,
+        }
+    }
+}
+
+fn external_schema(_tools: &[ToolDef]) -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "text": {"type": "string"},
+            "tool_calls": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "id": {"type": "string"},
+                        "name": {"type": "string"},
+                        "input": {"type": "string"}
+                    },
+                    "required": ["id", "name", "input"]
+                }
+            }
+        },
+        "required": ["text", "tool_calls"]
+    })
+}
+
+fn render_prompt(cfg: &LlmConfig, history: &[ChatMessage], tools: &[ToolDef]) -> String {
+    let messages: Vec<Value> = history.iter().map(|message| json!({"role": format_role(message.role), "content": message.content.iter().map(render_block).collect::<Vec<_>>() })).collect();
+    json!({"system": cfg.system, "messages": messages, "tools": tools.iter().map(|tool| json!({"name":tool.name,"description":tool.description,"input_schema":tool.input_schema})).collect::<Vec<_>>()}).to_string()
+}
+
+fn format_role(role: Role) -> &'static str {
+    match role {
+        Role::System => "system",
+        Role::User => "user",
+        Role::Assistant => "assistant",
+        Role::Tool => "tool",
+    }
+}
+fn render_block(block: &ContentBlock) -> Value {
+    match block {
+        ContentBlock::Text(text) => json!({"type":"text","text":text}),
+        ContentBlock::ToolUse { id, name, input } => {
+            json!({"type":"tool_use","id":id,"name":name,"input":input})
+        }
+        ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+        } => {
+            json!({"type":"tool_result","tool_use_id":tool_use_id,"content":content,"is_error":is_error})
+        }
+        ContentBlock::OpaqueReasoning(_) => json!({"type":"reasoning"}),
+    }
+}
+
+fn parse_jsonl(
+    stdout: &str,
+    on_event: &mut dyn FnMut(StreamEvent),
+) -> Result<AssistantTurn, LlmError> {
+    let mut text = String::new();
+    let mut calls = Vec::new();
+    let mut usage = Usage::default();
+    let mut final_value = None;
+    for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
+        let value: Value = serde_json::from_str(line)
+            .map_err(|e| LlmError::BadRequest(format!("invalid external agent JSONL: {e}")))?;
+        if let Some(message) = value
+            .get("message")
+            .and_then(Value::as_str)
+            .filter(|_| value.get("type").and_then(Value::as_str) == Some("error"))
+            .or_else(|| {
+                value
+                    .get("error")
+                    .and_then(|error| error.get("message"))
+                    .and_then(Value::as_str)
+                    .filter(|_| value.get("type").and_then(Value::as_str) == Some("turn.failed"))
+            })
+        {
+            return Err(LlmError::BadRequest(message.to_string()));
+        }
+        collect_usage(&value, &mut usage);
+        for delta in text_delta(&value) {
+            text.push_str(&delta);
+            on_event(StreamEvent::TextDelta(delta));
+        }
+        if let Some(value) = structured_value(&value) {
+            final_value = Some(value);
+        }
+        collect_tool(&value, &mut calls);
+    }
+    if let Some(value) = final_value {
+        apply_structured(&value, &mut text, &mut calls);
+    }
+    if text.is_empty() && calls.is_empty() {
+        return Err(LlmError::BadRequest(
+            "external agent exited without a final result".into(),
+        ));
+    }
+    let stop = if calls.is_empty() {
+        StopReason::EndTurn
+    } else {
+        StopReason::ToolUse
+    };
+    Ok(AssistantTurn {
+        text,
+        tool_calls: calls,
+        reasoning: ReasoningBlob::None,
+        stop,
+        usage,
+    })
+}
+
+fn text_delta(value: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(text) = value
+        .get("delta")
+        .and_then(|v| v.get("text"))
+        .and_then(Value::as_str)
+    {
+        out.push(text.into());
+    } else if value
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|t| matches!(t, "content_block_delta" | "text_delta"))
+        && let Some(text) = value.get("text").and_then(Value::as_str)
+    {
+        out.push(text.into());
+    } else if value.get("type").and_then(Value::as_str) == Some("item.completed")
+        && let Some(item) = value.get("item")
+        && item.get("type").and_then(Value::as_str) == Some("agent_message")
+        && let Some(text) = item.get("text").and_then(Value::as_str)
+        && serde_json::from_str::<Value>(text).is_err()
+    {
+        out.push(text.into());
+    }
+    out
+}
+fn structured_value(value: &Value) -> Option<Value> {
+    ["output", "result", "response", "structured_output"]
+        .iter()
+        .find_map(|key| value.get(*key).cloned().filter(Value::is_object))
+        .or_else(|| {
+            value
+                .get("item")
+                .filter(|item| item.get("type").and_then(Value::as_str) == Some("agent_message"))
+                .and_then(|item| item.get("text"))
+                .and_then(Value::as_str)
+                .and_then(|text| serde_json::from_str(text).ok())
+        })
+}
+fn apply_structured(value: &Value, text: &mut String, calls: &mut Vec<ToolCall>) {
+    if let Some(s) = value.get("text").and_then(Value::as_str)
+        && text.is_empty()
+    {
+        text.push_str(s);
+    }
+    collect_tool(value, calls);
+}
+fn collect_tool(value: &Value, calls: &mut Vec<ToolCall>) {
+    if let Some(items) = value.get("tool_calls").and_then(Value::as_array) {
+        for (index, item) in items.iter().enumerate() {
+            if let Some(name) = item.get("name").and_then(Value::as_str) {
+                let id = item
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .unwrap_or_else(|| format!("external-{index}"));
+                calls.push(ToolCall {
+                    id,
+                    name: name.into(),
+                    input: item
+                        .get("input")
+                        .and_then(|input| {
+                            input
+                                .as_str()
+                                .and_then(|input| serde_json::from_str(input).ok())
+                                .or_else(|| Some(input.clone()))
+                        })
+                        .unwrap_or_else(|| json!({})),
+                });
+            }
+        }
+    }
+}
+fn collect_usage(value: &Value, usage: &mut Usage) {
+    let u = value
+        .get("usage")
+        .or_else(|| value.get("result").and_then(|v| v.get("usage")));
+    if let Some(u) = u {
+        usage.input = usage.input.max(number(u, &["input_tokens", "input"]));
+        usage.output = usage.output.max(number(u, &["output_tokens", "output"]));
+        usage.cache_read = usage.cache_read.max(number(
+            u,
+            &[
+                "cache_read_input_tokens",
+                "cache_read",
+                "cached_input_tokens",
+            ],
+        ));
+        usage.cache_write = usage.cache_write.max(number(
+            u,
+            &[
+                "cache_creation_input_tokens",
+                "cache_write",
+                "cache_creation",
+            ],
+        ));
+    }
+}
+fn number(value: &Value, keys: &[&str]) -> u32 {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_u64))
+        .unwrap_or(0) as u32
+}
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0)
+}
+fn classify_cli_error(stderr: &str, code: i32, label: &str) -> LlmError {
+    let detail = stderr.trim();
+    let lower = detail.to_ascii_lowercase();
+    if lower.contains("login") || lower.contains("auth") || lower.contains("unauthorized") {
+        LlmError::Auth
+    } else {
+        LlmError::BadRequest(if detail.is_empty() {
+            format!("{label} CLI exited with status {code}")
+        } else {
+            detail.to_string()
+        })
+    }
+}
+
+fn prefer_windows_executable(path: &std::path::Path) -> PathBuf {
+    if !cfg!(windows) || path.extension().is_some() {
+        return path.to_path_buf();
+    }
+    for extension in ["exe", "cmd", "bat", "com"] {
+        let candidate = path.with_extension(extension);
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    path.to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn parses_structured_output_and_usage() {
+        let mut events = Vec::new();
+        let turn = parse_jsonl(
+            r#"{"type":"text_delta","text":"hi"}
+{"usage":{"input_tokens":4,"output_tokens":2}}
+{"result":{"text":"ignored","tool_calls":[{"id":"1","name":"inspect","input":{}}]}}"#,
+            &mut |event| events.push(event),
+        )
+        .unwrap();
+        assert_eq!(turn.text, "hi");
+        assert_eq!(turn.tool_calls[0].name, "inspect");
+        assert_eq!(turn.usage.input, 4);
+        assert_eq!(events.len(), 1);
+    }
+    #[test]
+    fn captures_cache_tokens_from_usage() {
+        let turn = parse_jsonl(
+            r#"{"type":"result","usage":{"input_tokens":10,"output_tokens":3,"cache_read_input_tokens":900,"cache_creation_input_tokens":40}}
+{"result":{"text":"done","tool_calls":[]}}"#,
+            &mut |_| {},
+        )
+        .unwrap();
+        assert_eq!(turn.usage.input, 10);
+        assert_eq!(turn.usage.cache_read, 900);
+        assert_eq!(turn.usage.cache_write, 40);
+        // Fresh input is a fraction of what actually got billed — the rest is cache.
+        assert_eq!(turn.usage.input_total(), 950);
+    }
+    #[test]
+    fn unknown_events_are_ignored() {
+        let turn = parse_jsonl(
+            r#"{"type":"future_event"}
+{"result":{"text":"done","tool_calls":[]}}"#,
+            &mut |_| {},
+        )
+        .unwrap();
+        assert_eq!(turn.text, "done");
+    }
+
+    #[test]
+    fn parses_codex_completed_agent_message() {
+        let turn = parse_jsonl(
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"hello"}}"#,
+            &mut |_| {},
+        )
+        .unwrap();
+        assert_eq!(turn.text, "hello");
+    }
+    #[test]
+    fn corrupt_json_is_an_error() {
+        assert!(matches!(
+            parse_jsonl("{", &mut |_| {}),
+            Err(LlmError::BadRequest(_))
+        ));
+    }
+}

--- a/compute-core/src/io/llm/mod.rs
+++ b/compute-core/src/io/llm/mod.rs
@@ -6,6 +6,7 @@
 //! vendor JSON entirely behind that boundary.
 
 pub mod anthropic;
+pub mod external;
 pub mod openai_compat;
 pub mod provider;
 pub mod retry;

--- a/compute-core/src/io/llm/openai_compat.rs
+++ b/compute-core/src/io/llm/openai_compat.rs
@@ -525,6 +525,7 @@ mod tests {
             "openai",
         );
         let cfg = LlmConfig {
+            working_dir: None,
             model: "o4".into(),
             effort: Effort::Medium,
             max_output_tokens: 1000,
@@ -555,6 +556,7 @@ mod tests {
             "local",
         );
         let cfg = LlmConfig {
+            working_dir: None,
             model: "m".into(),
             effort: Effort::High,
             max_output_tokens: 100,
@@ -591,6 +593,7 @@ mod tests {
             ],
         }];
         let cfg = LlmConfig {
+            working_dir: None,
             model: "m".into(),
             effort: Effort::Low,
             max_output_tokens: 100,

--- a/compute-core/src/io/llm/types.rs
+++ b/compute-core/src/io/llm/types.rs
@@ -129,6 +129,7 @@ pub struct LlmConfig {
     pub stream: bool,
     /// Persona + `.sls` catalog. Static across a session, so it caches.
     pub system: String,
+    pub working_dir: Option<std::path::PathBuf>,
 }
 
 /// A tool invocation the model emitted this turn.

--- a/src/backend/assistant_config.rs
+++ b/src/backend/assistant_config.rs
@@ -9,6 +9,41 @@ pub struct AssistantModelSelection {
     pub model: String,
 }
 
+/// Sandbox posture handed to an external agent CLI. `Controlled` maps to the
+/// CLI's read-only/plan mode; `Unrestricted` opts into its approval- and
+/// sandbox-bypass flags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum ExternalAgentAccess {
+    #[default]
+    Controlled,
+    Unrestricted,
+}
+
+impl ExternalAgentAccess {
+    pub fn all() -> [ExternalAgentAccess; 2] {
+        [
+            ExternalAgentAccess::Controlled,
+            ExternalAgentAccess::Unrestricted,
+        ]
+    }
+
+    /// Full description for a menu row.
+    pub fn label(self) -> &'static str {
+        match self {
+            ExternalAgentAccess::Controlled => "Controlled — read-only / plan sandbox",
+            ExternalAgentAccess::Unrestricted => "Unrestricted — bypass CLI approvals & sandbox",
+        }
+    }
+
+    /// Compact label for the collapsed picker.
+    pub fn short_label(self) -> &'static str {
+        match self {
+            ExternalAgentAccess::Controlled => "Controlled",
+            ExternalAgentAccess::Unrestricted => "Unrestricted",
+        }
+    }
+}
+
 impl Default for AssistantModelSelection {
     fn default() -> Self {
         Self {
@@ -94,6 +129,10 @@ pub struct AssistantConfig {
     /// an older `settings.json` parses to the default (AutoSafe).
     #[serde(default)]
     pub approval_mode: ApprovalMode,
+    #[serde(default)]
+    pub external_agent_access: ExternalAgentAccess,
+    #[serde(default)]
+    pub external_agent_executables: std::collections::BTreeMap<String, String>,
 }
 
 impl Default for AssistantConfig {
@@ -105,6 +144,8 @@ impl Default for AssistantConfig {
             base_urls: Default::default(),
             model_effort_overrides: Default::default(),
             approval_mode: ApprovalMode::default(),
+            external_agent_access: ExternalAgentAccess::default(),
+            external_agent_executables: Default::default(),
         }
     }
 }

--- a/src/backend/config.rs
+++ b/src/backend/config.rs
@@ -22,7 +22,7 @@ pub use persist::{
 };
 
 pub use crate::backend::assistant_config::{
-    ApprovalMode, AssistantConfig, AssistantModelSelection,
+    ApprovalMode, AssistantConfig, AssistantModelSelection, ExternalAgentAccess,
 };
 
 /// How the interface picks its light/dark appearance.

--- a/src/backend/storage/assistant.rs
+++ b/src/backend/storage/assistant.rs
@@ -53,6 +53,8 @@ pub struct PersistedAssistantConversation {
     pub provider: String,
     pub model: String,
     #[serde(default)]
+    pub external_access: crate::backend::assistant_config::ExternalAgentAccess,
+    #[serde(default)]
     pub history: Vec<PersistedChatMessage>,
     #[serde(default)]
     pub transcript: Vec<PersistedTranscriptEntry>,

--- a/src/backend/storage/tests.rs
+++ b/src/backend/storage/tests.rs
@@ -519,6 +519,7 @@ fn assistant_history_survives_save_and_load() {
         next_conversation_id: 3,
         next_conversation_number: 3,
         conversations: vec![PersistedAssistantConversation {
+            external_access: Default::default(),
             id: 2,
             title: "Protein setup".to_string(),
             provider: "openai".to_string(),
@@ -622,6 +623,7 @@ fn corrupt_assistant_state_warns_but_project_loads() {
             history: History::default(),
             assistant: ProjectAssistantSnapshot {
                 conversations: vec![PersistedAssistantConversation {
+                    external_access: Default::default(),
                     id: 1,
                     title: "Chat".to_string(),
                     provider: "anthropic".to_string(),

--- a/src/frontend/actions.rs
+++ b/src/frontend/actions.rs
@@ -375,6 +375,10 @@ pub enum AppAction {
     /// Set (blank clears) the base-URL override for an OpenAI-compatible
     /// assistant provider and persist.
     SetAssistantBaseUrl(String),
+    /// Set (blank clears) the installed external CLI executable override.
+    SetAssistantExecutable(String),
+    /// Set the active conversation's external-agent sandbox posture.
+    SetAssistantExternalAccess(crate::backend::config::ExternalAgentAccess),
     /// Store the entered API key for the active provider in the app key store.
     SetAssistantApiKey(String),
     /// Remove the stored key for the provider with this id (active "Clear" button

--- a/src/frontend/agent/loop_driver/settings.rs
+++ b/src/frontend/agent/loop_driver/settings.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use eframe::egui;
 
-use crate::backend::config::ApprovalMode;
+use crate::backend::config::{ApprovalMode, ExternalAgentAccess};
 use crate::frontend::agent::registry;
 use crate::frontend::agent::session::{AssistantConversationId, ModelFetchStatus};
 use crate::frontend::jobs::spawn_model_fetch;
@@ -137,6 +137,31 @@ pub fn set_assistant_base_url(state: &mut AppState, base_url: &str) {
     persist(state);
 }
 
+pub fn set_assistant_executable(state: &mut AppState, path: &str) {
+    let provider = state.config.assistant.default_selection.provider.clone();
+    let path = path.trim();
+    if path.is_empty() {
+        state
+            .config
+            .assistant
+            .external_agent_executables
+            .remove(&provider);
+    } else {
+        state
+            .config
+            .assistant
+            .external_agent_executables
+            .insert(provider, path.to_string());
+    }
+    persist(state);
+}
+
+/// Set the active conversation's external-agent sandbox posture and persist.
+pub fn set_assistant_external_access(state: &mut AppState, access: ExternalAgentAccess) {
+    state.ui.agent.external_access = access;
+    persist(state);
+}
+
 /// Store the default provider's API key in the app key store (never in config).
 pub fn set_assistant_api_key(state: &mut AppState, key: &str) {
     let provider = registry::default_provider(&state.config.assistant);
@@ -185,6 +210,13 @@ pub fn fetch_models(state: &mut AppState, ctx: &egui::Context) {
         return;
     }
     let spec = registry::default_provider(&state.config.assistant);
+    if matches!(spec.kind, registry::ProviderKind::ExternalAgent(_)) {
+        state.ui.agent.model_fetch = ModelFetchStatus::Error(
+            "CLI agents use their own model selection; model enumeration is not requested.".into(),
+        );
+        ctx.request_repaint();
+        return;
+    }
     let Some(key) = registry::api_key_for(spec) else {
         state.ui.agent.model_fetch = ModelFetchStatus::Error(format!(
             "Add a key for {} first to list its models.",

--- a/src/frontend/agent/loop_driver/turn.rs
+++ b/src/frontend/agent/loop_driver/turn.rs
@@ -81,7 +81,9 @@ pub fn spawn_next_turn(state: &mut AppState, ctx: &egui::Context) {
     }
 
     let selection = state.ui.agent.selection.clone();
-    let provider = match registry::build_provider(&state.config.assistant, &selection) {
+    let mut assistant_config = state.config.assistant.clone();
+    assistant_config.external_agent_access = state.ui.agent.external_access;
+    let provider = match registry::build_provider(&assistant_config, &selection) {
         Ok(provider) => provider,
         Err(reason) => {
             notice(state, &reason);
@@ -103,13 +105,14 @@ pub fn spawn_next_turn(state: &mut AppState, ctx: &egui::Context) {
         .workspace
         .project()
         .map(|project| project.root.clone());
-    state.ui.agent.ensure_skills_loaded(project_root);
+    state.ui.agent.ensure_skills_loaded(project_root.clone());
     let cfg = LlmConfig {
         model: selection.model,
         effort: state.config.assistant.effort,
         max_output_tokens: MAX_OUTPUT_TOKENS,
         stream,
         system: system_prompt(&state.ui.agent.skills),
+        working_dir: project_root,
     };
     let tools = tools::tool_defs();
     let history = state.ui.agent.history.clone();

--- a/src/frontend/agent/mock.rs
+++ b/src/frontend/agent/mock.rs
@@ -84,6 +84,7 @@ mod tests {
 
     fn cfg() -> LlmConfig {
         LlmConfig {
+            working_dir: None,
             model: "mock".to_string(),
             effort: Effort::High,
             max_output_tokens: 1000,

--- a/src/frontend/agent/mod.rs
+++ b/src/frontend/agent/mod.rs
@@ -19,6 +19,7 @@ pub use loop_driver::{
     refresh_key_status, reject_tool_call, remove_queued_agent_input, rename_assistant_conversation,
     send_agent_message, set_approval_mode, set_assistant_api_key, set_assistant_base_url,
     set_assistant_effort, set_assistant_effort_supported, set_assistant_enabled,
-    switch_assistant_conversation, switch_assistant_conversation_model, switch_provider_model,
+    set_assistant_executable, set_assistant_external_access, switch_assistant_conversation,
+    switch_assistant_conversation_model, switch_provider_model,
 };
 pub use session::{AgentSession, AssistantConversationId, ModelFetchStatus, TranscriptEntry};

--- a/src/frontend/agent/registry.rs
+++ b/src/frontend/agent/registry.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::config::{AssistantConfig, AssistantModelSelection};
 use crate::io::llm::anthropic::{AnthropicProvider, caps_for_model};
+use crate::io::llm::external::{ExternalAccess, ExternalAgent, ExternalAgentKind};
 use crate::io::llm::openai_compat::OpenAiCompatProvider;
 use crate::io::llm::provider::{LlmProvider, ProviderCaps};
 
@@ -13,6 +14,7 @@ use crate::io::llm::provider::{LlmProvider, ProviderCaps};
 pub enum ProviderKind {
     Native,
     OpenAiCompat,
+    ExternalAgent(ExternalAgentKind),
 }
 
 /// One selectable model within a provider.
@@ -74,6 +76,12 @@ impl ProviderSpec {
                     supports_streaming: false,
                 }
             }
+            ProviderKind::ExternalAgent(_) => ProviderCaps {
+                supports_effort: false,
+                supports_thinking: false,
+                supports_prompt_cache: false,
+                supports_streaming: true,
+            },
         }
     }
 }
@@ -82,6 +90,24 @@ impl ProviderSpec {
 /// adapter (base-URL swap). Model ids drift — they are editable as free text in
 /// the Assistant settings, and `base_url` is overridable per install.
 pub const PROVIDERS: &[ProviderSpec] = &[
+    ProviderSpec {
+        id: "codex_cli",
+        label: "Codex CLI",
+        kind: ProviderKind::ExternalAgent(ExternalAgentKind::Codex),
+        base_url: "",
+        key_env: "",
+        reasoning_replay: false,
+        models: &[],
+    },
+    ProviderSpec {
+        id: "claude_cli",
+        label: "Claude CLI",
+        kind: ProviderKind::ExternalAgent(ExternalAgentKind::Claude),
+        base_url: "",
+        key_env: "",
+        reasoning_replay: false,
+        models: &[],
+    },
     ProviderSpec {
         id: "anthropic",
         label: "Anthropic (Claude)",
@@ -399,11 +425,30 @@ pub fn build_provider(
 ) -> Result<Box<dyn LlmProvider>, String> {
     let spec = provider_spec(&selection.provider)
         .ok_or_else(|| format!("Unknown assistant provider `{}`.", selection.provider))?;
-    if selection.model.trim().is_empty() {
+    if selection.model.trim().is_empty() && !matches!(spec.kind, ProviderKind::ExternalAgent(_)) {
         return Err(format!(
             "Choose a model for {} before sending a message.",
             spec.label
         ));
+    }
+    if let ProviderKind::ExternalAgent(kind) = spec.kind {
+        let executable = config
+            .external_agent_executables
+            .get(spec.id)
+            .filter(|path| !path.trim().is_empty())
+            .cloned();
+        return Ok(Box::new(ExternalAgent::new(
+            kind,
+            executable,
+            match config.external_agent_access {
+                crate::backend::config::ExternalAgentAccess::Controlled => {
+                    ExternalAccess::Controlled
+                }
+                crate::backend::config::ExternalAgentAccess::Unrestricted => {
+                    ExternalAccess::Unrestricted
+                }
+            },
+        )));
     }
     let key = api_key_for(spec).ok_or_else(|| {
         format!(
@@ -425,6 +470,7 @@ pub fn build_provider(
             spec.reasoning_replay,
             spec.id,
         ))),
+        ProviderKind::ExternalAgent(_) => unreachable!("external agents returned above"),
     }
 }
 

--- a/src/frontend/agent/session.rs
+++ b/src/frontend/agent/session.rs
@@ -6,7 +6,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::ops::{Deref, DerefMut};
 
-use crate::backend::config::AssistantModelSelection;
+use crate::backend::config::{AssistantModelSelection, ExternalAgentAccess};
 use crate::frontend::console::RiskLevel;
 use crate::io::llm::types::{ChatMessage, ContentBlock, ToolCall, Usage};
 
@@ -109,6 +109,7 @@ pub struct AssistantConversation {
     pub id: AssistantConversationId,
     pub title: String,
     pub selection: AssistantModelSelection,
+    pub external_access: ExternalAgentAccess,
     /// Neutral conversation history replayed to the provider each turn (includes
     /// prior assistant turns with their opaque reasoning blobs). The system
     /// prompt is *not* stored here — it is rebuilt per turn into `LlmConfig`.
@@ -164,6 +165,7 @@ impl AssistantConversation {
             id,
             title,
             selection,
+            external_access: ExternalAgentAccess::Controlled,
             history: Vec::new(),
             transcript: Vec::new(),
             input: String::new(),

--- a/src/frontend/agent/session/persistence.rs
+++ b/src/frontend/agent/session/persistence.rs
@@ -100,6 +100,7 @@ fn persist_conversation(conversation: &AssistantConversation) -> PersistedAssist
         title: conversation.title.clone(),
         provider: conversation.selection.provider.clone(),
         model: conversation.selection.model.clone(),
+        external_access: conversation.external_access,
         history: resumable.history.iter().map(persist_message).collect(),
         transcript,
         input: conversation.input.clone(),
@@ -117,6 +118,7 @@ fn restore_conversation(payload: PersistedAssistantConversation) -> AssistantCon
     };
     let mut conversation = AssistantConversation::new(id, title, selection);
     conversation.history = payload.history.into_iter().map(restore_message).collect();
+    conversation.external_access = payload.external_access;
     conversation.transcript = payload
         .transcript
         .into_iter()

--- a/src/frontend/dispatcher/mod.rs
+++ b/src/frontend/dispatcher/mod.rs
@@ -404,6 +404,12 @@ pub fn dispatch(state: &mut AppState, action: AppAction, ctx: &egui::Context) {
         AppAction::SetAssistantBaseUrl(url) => {
             crate::frontend::agent::set_assistant_base_url(state, &url)
         }
+        AppAction::SetAssistantExecutable(path) => {
+            crate::frontend::agent::set_assistant_executable(state, &path)
+        }
+        AppAction::SetAssistantExternalAccess(access) => {
+            crate::frontend::agent::set_assistant_external_access(state, access)
+        }
         AppAction::SetAssistantApiKey(key) => {
             crate::frontend::agent::set_assistant_api_key(state, &key)
         }

--- a/src/frontend/jobs/update.rs
+++ b/src/frontend/jobs/update.rs
@@ -116,6 +116,9 @@ fn fetch_model_ids(
             .header("x-api-key", api_key)
             .header("anthropic-version", "2023-06-01")
             .call(),
+        ProviderKind::ExternalAgent(_) => {
+            return Err("CLI agents do not expose an API model list; choose CLI default or enter a model id.".into());
+        }
     };
 
     let mut response = response.map_err(|error| error.to_string())?;

--- a/src/frontend/ui/panel_bodies.rs
+++ b/src/frontend/ui/panel_bodies.rs
@@ -4,6 +4,7 @@ use crate::frontend::app::{ASSISTANT_CJK_FONT, CONSOLE_CJK_MONO_FONT};
 
 mod assistant;
 mod assistant_composer;
+mod assistant_model_picker;
 mod assistant_transcript;
 mod console;
 mod monitor;
@@ -13,6 +14,7 @@ mod task_monitor;
 
 pub(crate) use assistant::*;
 pub(crate) use assistant_composer::*;
+pub(crate) use assistant_model_picker::render_assistant_model_picker;
 use assistant_transcript::*;
 pub(crate) use console::*;
 pub(crate) use monitor::*;

--- a/src/frontend/ui/panel_bodies/assistant.rs
+++ b/src/frontend/ui/panel_bodies/assistant.rs
@@ -38,7 +38,8 @@ pub(crate) fn render_assistant_panel(
 
     let selection = state.ui.agent.selection.clone();
     let provider = registry::provider_spec(&selection.provider).unwrap_or(&registry::PROVIDERS[0]);
-    let model_selected = !selection.model.trim().is_empty();
+    let model_selected = !selection.model.trim().is_empty()
+        || matches!(provider.kind, registry::ProviderKind::ExternalAgent(_));
     // Cached (the live check reads env + the key store); refreshed off the hot path.
     let key_present = state.ui.agent.key_available.unwrap_or(false);
     // Cloned so the cards can render without holding a borrow on `state`.
@@ -567,117 +568,6 @@ pub(crate) fn assistant_inset_row<R>(
     )
 }
 
-pub(super) fn render_assistant_model_picker(
-    state: &AppState,
-    ui: &mut egui::Ui,
-    actions: &mut Vec<AppAction>,
-    provider: &crate::frontend::agent::registry::ProviderSpec,
-    current_model: &str,
-    width: f32,
-) -> bool {
-    use crate::frontend::agent::registry;
-
-    let can_switch = state.ui.agent.can_manage_conversations();
-    let selected_label = provider
-        .models
-        .iter()
-        .find(|model| model.id == current_model)
-        .map(|model| model.label)
-        .unwrap_or(current_model);
-    let selected_label = if selected_label.trim().is_empty() {
-        "Choose model…".to_string()
-    } else {
-        compact_model_label(selected_label, if width < 76.0 { 8 } else { 14 })
-    };
-    let mut open_settings = false;
-    let response = egui::ComboBox::from_id_salt("assistant.conversation_model")
-        .selected_text(assistant_text(selected_label))
-        .width(width.max(28.0))
-        .truncate()
-        .show_ui(ui, |ui| {
-            crate::frontend::theme::stabilize_selectable_rows(ui);
-            ui.set_min_width(220.0);
-            for spec in registry::PROVIDERS {
-                ui.label(RichText::new(spec.label).small().strong());
-                let available = registry::api_key_for(spec).is_some();
-                let fetched = state
-                    .ui
-                    .agent
-                    .fetched_models
-                    .get(spec.id)
-                    .map(Vec::as_slice)
-                    .unwrap_or_default();
-                let models = registry::merged_model_ids(spec, fetched);
-                if models.is_empty() {
-                    ui.label(
-                        RichText::new("Choose in Assistant settings")
-                            .small()
-                            .color(crate::frontend::theme::palette(ui).text_tertiary),
-                    );
-                }
-                for (model, label) in models {
-                    let selected = spec.id == provider.id && model == current_model;
-                    let response = ui.add_enabled(
-                        can_switch && available,
-                        egui::Button::selectable(selected, assistant_text(&label)),
-                    );
-                    let response = if available {
-                        response
-                    } else {
-                        response.on_hover_text("Add an API key for this provider first")
-                    };
-                    if response.clicked() && !selected {
-                        actions.push(AppAction::SwitchAssistantConversationModel {
-                            provider: spec.id.to_string(),
-                            model,
-                        });
-                        ui.close();
-                    }
-                }
-                if !available {
-                    ui.label(
-                        RichText::new("API key required")
-                            .small()
-                            .color(crate::frontend::theme::palette(ui).text_tertiary),
-                    );
-                }
-                ui.add_space(3.0);
-            }
-            ui.separator();
-            if ui.button("Manage providers and API keys…").clicked() {
-                open_settings = true;
-                ui.close();
-            }
-        });
-    let mut hover = format!("{} · {}", provider.label, current_model);
-    if let Some(usage) = &state.ui.agent.last_usage {
-        let session = &state.ui.agent.session_usage;
-        hover.push_str(&format!(
-            "\nLast: {} in / {} out\nSession: {} in / {} out",
-            compact(usage.input_total()),
-            compact(usage.output),
-            compact(session.input_total()),
-            compact(session.output),
-        ));
-    }
-    response.response.on_hover_text(hover);
-    open_settings
-}
-
-fn compact_model_label(label: &str, max_chars: usize) -> String {
-    let without_qualifier = label.split(" (").next().unwrap_or(label);
-    let short = ["Claude ", "Anthropic ", "OpenAI ", "Google "]
-        .iter()
-        .find_map(|prefix| without_qualifier.strip_prefix(prefix))
-        .unwrap_or(without_qualifier);
-    let count = short.chars().count();
-    if count <= max_chars {
-        return short.to_string();
-    }
-    let keep = max_chars.saturating_sub(1);
-    format!("{}…", short.chars().take(keep).collect::<String>())
-}
-
 /// First-run welcome shown when the transcript is empty: a centered prompt plus
 /// a missing-key callout when no credential is configured.
 fn render_assistant_empty_state(
@@ -780,13 +670,4 @@ fn render_assistant_empty_state(
 /// callout fills that stay readable on either theme.
 fn blend(a: Color32, b: Color32, t: f32) -> Color32 {
     crate::frontend::theme::mix(a, b, t)
-}
-
-/// Compact token count, e.g. `1234` → `1.2k`.
-fn compact(value: u32) -> String {
-    if value < 1000 {
-        value.to_string()
-    } else {
-        format!("{:.1}k", value as f32 / 1000.0)
-    }
 }

--- a/src/frontend/ui/panel_bodies/assistant_composer.rs
+++ b/src/frontend/ui/panel_bodies/assistant_composer.rs
@@ -53,7 +53,15 @@ pub(crate) fn render_assistant_composer(
     let busy = state.ui.agent.is_busy();
     let assistant_enabled = state.config.assistant.enabled;
     let key_present = state.ui.agent.key_available.unwrap_or(false);
-    let model_selected = !state.ui.agent.selection.model.trim().is_empty();
+    let provider =
+        crate::frontend::agent::registry::provider_spec(&state.ui.agent.selection.provider);
+    let model_selected = !state.ui.agent.selection.model.trim().is_empty()
+        || provider.is_some_and(|provider| {
+            matches!(
+                provider.kind,
+                crate::frontend::agent::registry::ProviderKind::ExternalAgent(_)
+            )
+        });
     let running_height = running_strip_height(running_jobs);
     let queued_height = queued_strip_height(queued);
 
@@ -258,12 +266,22 @@ pub(crate) fn render_assistant_composer(
                         };
                         let model_width =
                             (controls_width - mode_width - CONTROL_GAP).clamp(28.0, 132.0);
-                        render_approval_mode_picker(state, ui, actions, mode_width);
 
                         let selection = state.ui.agent.selection.clone();
                         let provider =
                             crate::frontend::agent::registry::provider_spec(&selection.provider)
                                 .unwrap_or(&crate::frontend::agent::registry::PROVIDERS[0]);
+                        // External CLIs ignore SilicoLab's approval policy; their
+                        // own sandbox posture is the relevant control instead.
+                        if matches!(
+                            provider.kind,
+                            crate::frontend::agent::registry::ProviderKind::ExternalAgent(_)
+                        ) {
+                            render_external_access_picker(state, ui, actions, mode_width);
+                        } else {
+                            render_approval_mode_picker(state, ui, actions, mode_width);
+                        }
+
                         open_assistant_settings |= render_assistant_model_picker(
                             state,
                             ui,
@@ -336,6 +354,46 @@ fn render_approval_mode_picker(
     response
         .response
         .on_hover_text(format!("Agent permissions\n{}", current.label()));
+}
+
+/// Per-conversation sandbox posture for external CLI agents, shown in place of
+/// the approval picker (which those agents ignore). Persisted on the active
+/// conversation via the same dispatcher action used nowhere else.
+fn render_external_access_picker(
+    state: &AppState,
+    ui: &mut egui::Ui,
+    actions: &mut Vec<AppAction>,
+    width: f32,
+) {
+    use crate::backend::config::ExternalAgentAccess;
+
+    let current = state.ui.agent.external_access;
+    let can_switch = state.ui.agent.can_manage_conversations();
+    let response = ui
+        .add_enabled_ui(can_switch, |ui| {
+            egui::ComboBox::from_id_salt("assistant.composer_external_access")
+                .selected_text(assistant_text(current.short_label()))
+                .width(width.max(34.0))
+                .truncate()
+                .show_ui(ui, |ui| {
+                    crate::frontend::theme::stabilize_selectable_rows(ui);
+                    ui.set_min_width(250.0);
+                    for access in ExternalAgentAccess::all() {
+                        if ui
+                            .selectable_label(access == current, assistant_text(access.label()))
+                            .clicked()
+                            && access != current
+                        {
+                            actions.push(AppAction::SetAssistantExternalAccess(access));
+                            ui.close();
+                        }
+                    }
+                })
+        })
+        .inner;
+    response
+        .response
+        .on_hover_text(format!("External agent access\n{}", current.label()));
 }
 
 fn compact_approval_label(mode: crate::backend::config::ApprovalMode) -> &'static str {

--- a/src/frontend/ui/panel_bodies/assistant_model_picker.rs
+++ b/src/frontend/ui/panel_bodies/assistant_model_picker.rs
@@ -1,0 +1,158 @@
+use super::*;
+
+use eframe::egui::{self, RichText};
+
+use crate::frontend::{actions::AppAction, state::AppState};
+
+pub(crate) fn render_assistant_model_picker(
+    state: &AppState,
+    ui: &mut egui::Ui,
+    actions: &mut Vec<AppAction>,
+    provider: &crate::frontend::agent::registry::ProviderSpec,
+    current_model: &str,
+    width: f32,
+) -> bool {
+    use crate::frontend::agent::registry;
+
+    let can_switch = state.ui.agent.can_manage_conversations();
+    let selected_label = provider
+        .models
+        .iter()
+        .find(|model| model.id == current_model)
+        .map(|model| model.label)
+        .unwrap_or(current_model);
+    let selected_label = if selected_label.trim().is_empty() {
+        if matches!(provider.kind, registry::ProviderKind::ExternalAgent(_)) {
+            "CLI default".to_string()
+        } else {
+            "Choose model…".to_string()
+        }
+    } else {
+        compact_model_label(selected_label, if width < 76.0 { 8 } else { 14 })
+    };
+    let mut open_settings = false;
+    let response = egui::ComboBox::from_id_salt("assistant.conversation_model")
+        .selected_text(assistant_text(selected_label))
+        .width(width.max(28.0))
+        .truncate()
+        .show_ui(ui, |ui| {
+            crate::frontend::theme::stabilize_selectable_rows(ui);
+            ui.set_min_width(220.0);
+            for spec in registry::PROVIDERS {
+                ui.label(RichText::new(spec.label).small().strong());
+                let available = registry::api_key_for(spec).is_some();
+                let fetched = state
+                    .ui
+                    .agent
+                    .fetched_models
+                    .get(spec.id)
+                    .map(Vec::as_slice)
+                    .unwrap_or_default();
+                let models = registry::merged_model_ids(spec, fetched);
+                if matches!(spec.kind, registry::ProviderKind::ExternalAgent(_)) {
+                    let selected = spec.id == provider.id && current_model.trim().is_empty();
+                    if ui
+                        .add_enabled(
+                            can_switch,
+                            egui::Button::selectable(selected, "CLI default"),
+                        )
+                        .clicked()
+                        && !selected
+                    {
+                        actions.push(AppAction::SwitchAssistantConversationModel {
+                            provider: spec.id.to_string(),
+                            model: String::new(),
+                        });
+                        ui.close();
+                    }
+                }
+                if models.is_empty() {
+                    ui.label(
+                        RichText::new("Choose in Assistant settings")
+                            .small()
+                            .color(crate::frontend::theme::palette(ui).text_tertiary),
+                    );
+                }
+                for (model, label) in models {
+                    let selected = spec.id == provider.id && model == current_model;
+                    let response = ui.add_enabled(
+                        can_switch && available,
+                        egui::Button::selectable(selected, assistant_text(&label)),
+                    );
+                    let response = if available {
+                        response
+                    } else {
+                        response.on_hover_text("Add an API key for this provider first")
+                    };
+                    if response.clicked() && !selected {
+                        actions.push(AppAction::SwitchAssistantConversationModel {
+                            provider: spec.id.to_string(),
+                            model,
+                        });
+                        ui.close();
+                    }
+                }
+                if !available {
+                    ui.label(
+                        RichText::new("API key required")
+                            .small()
+                            .color(crate::frontend::theme::palette(ui).text_tertiary),
+                    );
+                }
+                ui.add_space(3.0);
+            }
+            ui.separator();
+            if ui.button("Manage providers and API keys…").clicked() {
+                open_settings = true;
+                ui.close();
+            }
+        });
+    let model_label = if current_model.trim().is_empty()
+        && matches!(provider.kind, registry::ProviderKind::ExternalAgent(_))
+    {
+        "CLI default"
+    } else {
+        current_model
+    };
+    let mut hover = format!("{} · {}", provider.label, model_label);
+    if let Some(usage) = &state.ui.agent.last_usage {
+        let session = &state.ui.agent.session_usage;
+        hover.push_str(&format!(
+            "\nLast: {} in / {} out\nSession: {} in / {} out",
+            compact_tokens(usage.input_total()),
+            compact_tokens(usage.output),
+            compact_tokens(session.input_total()),
+            compact_tokens(session.output)
+        ));
+    }
+    response.response.on_hover_text(hover);
+    open_settings
+}
+
+fn compact_tokens(value: u32) -> String {
+    if value < 1_000 {
+        return value.to_string();
+    }
+    if value < 1_000_000 {
+        return format!("{:.1}k", value as f32 / 1_000.0);
+    }
+    format!("{:.1}m", value as f32 / 1_000_000.0)
+}
+
+fn compact_model_label(label: &str, max_chars: usize) -> String {
+    let without_qualifier = label.split(" (").next().unwrap_or(label);
+    let short = ["Claude ", "Anthropic ", "OpenAI ", "Google "]
+        .iter()
+        .find_map(|prefix| without_qualifier.strip_prefix(prefix))
+        .unwrap_or(without_qualifier);
+    if short.chars().count() <= max_chars {
+        return short.to_string();
+    }
+    format!(
+        "{}…",
+        short
+            .chars()
+            .take(max_chars.saturating_sub(1))
+            .collect::<String>()
+    )
+}

--- a/src/frontend/ui/settings_registry/custom.rs
+++ b/src/frontend/ui/settings_registry/custom.rs
@@ -151,7 +151,11 @@ pub(crate) fn render_assistant_settings(
         .map(|(_, label)| label.clone())
         .unwrap_or_else(|| {
             if current_model.trim().is_empty() {
-                "Choose model…".to_string()
+                if matches!(provider.kind, registry::ProviderKind::ExternalAgent(_)) {
+                    "CLI default".to_string()
+                } else {
+                    "Choose model…".to_string()
+                }
             } else {
                 current_model.clone()
             }
@@ -218,6 +222,27 @@ pub(crate) fn render_assistant_settings(
             .size(CAPTION_SIZE)
             .color(pal.text_tertiary),
     );
+
+    if matches!(provider.kind, registry::ProviderKind::ExternalAgent(_)) {
+        let executable = state
+            .config
+            .assistant
+            .external_agent_executables
+            .get(provider.id)
+            .cloned()
+            .unwrap_or_default();
+        if let Some(path) = committed_text_field(
+            ui,
+            "assistant.external_executable",
+            "Executable override",
+            &executable,
+            "auto-detect from PATH",
+        ) && path != executable
+        {
+            actions.push(AppAction::SetAssistantExecutable(path));
+        }
+        ui.label(RichText::new("Uses the installed CLI's own login and subscription. SilicoLab never stores an API key or installs it.").size(CAPTION_SIZE).color(pal.text_tertiary));
+    }
 
     // Free-text model id — model ids drift, and OpenRouter/local take arbitrary
     // ids, so let the user type one directly. Committed on Enter / focus loss.


### PR DESCRIPTION
## What

Adds **Codex CLI** and **Claude CLI** as assistant providers. Instead of
calling a vendor API with a stored key, these shell out to the locally
installed, separately-authenticated CLI — it uses its own login and
subscription, and SilicoLab never stores or installs a key for them.

## Why

Lets users drive the assistant through a CLI agent they already have
installed and signed in, without re-entering credentials or paying a
second time through an API key.

## How

- **`compute-core/src/io/llm/external.rs`** — new `ExternalAgent`
  `LlmProvider`:
  - Resolves the executable via PATH (with Windows `.exe/.cmd/.bat`
    preference) or a per-provider override.
  - Renders neutral history to the CLI's stdin JSON contract; parses the
    JSONL / `stream-json` output (deltas, structured result, usage,
    tool calls) back into an `AssistantTurn`.
  - Shares the turn's cancel flag with the child process and caps runs at
    a 30-minute timeout; classifies auth failures from stderr.
- **`LlmConfig` gains `working_dir`** so the CLI runs in the project root.
- **Registry** — `ProviderKind::ExternalAgent(Codex | Claude)` with empty
  model lists ("CLI default"); `build_provider` routes external providers
  ahead of the API-key path.
- **Per-conversation `ExternalAgentAccess`** (`Controlled` → read-only /
  plan sandbox, `Unrestricted` → bypass sandbox & approvals), persisted
  with the conversation. The composer swaps the approval-mode picker for
  an access picker when the provider is a CLI, since external agents
  ignore SilicoLab's approval policy.
- **Settings** — optional executable-override field per external provider.
- **Refactor** — extract the conversation model picker out of
  `assistant.rs` into `assistant_model_picker.rs`.

## Testing

- `cargo pr-check` passes (fmt, clippy, rustdoc, worker builds, file-size,
  tests, deploy tests).
- Unit tests in `external.rs` cover JSONL parsing, cache-token capture,
  Codex `item.completed` messages, unknown-event tolerance, and corrupt
  JSON.

## Notes

- **Security posture:** `Unrestricted` maps to each CLI's
  bypass-sandbox/approvals flag (`--dangerously-bypass-approvals-and-sandbox`
  for Codex, `--dangerously-skip-permissions` for Claude). It's opt-in
  per conversation and defaults to `Controlled`.
